### PR TITLE
Update the installation script URL in the binary.md

### DIFF
--- a/advanced_guides/binary.md
+++ b/advanced_guides/binary.md
@@ -4,7 +4,7 @@
 
 This script will download the **latest stable release** of MeiliSearch.
 ```bash
-$ curl https://raw.githubusercontent.com/meilisearch/MeiliSearch/master/download-latest.sh | sh
+$ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```


### PR DESCRIPTION
We should use the `<Content/>` thing you talked about in https://github.com/meilisearch/documentation/issues/62 when stable, and avoid these little inconsistencies :)