### PR TITLE
Rename action into update

### DIFF
--- a/advanced_guides/asynchronous_updates.md
+++ b/advanced_guides/asynchronous_updates.md
@@ -2,11 +2,11 @@
 
 MeiliSearch is an **asynchronous API**. It means that the API does not behave as you would typically expect when handling the request's responses.
 
-Some actions are put in a queue and will be executed in turn (asynchronously). In this case, the server response contains the identifier to track the execution of the action.
+Some updates are put in a queue and will be executed in turn (asynchronously). In this case, the server response contains the identifier to track the execution of the update.
 
 ### Async flow
 
-- When making a write request (*create/update/delete*) against the search engine, it stores the writing action received in a queue and returns an `updateId`. With this id, the specific action execution is trackable.
+- When making a write request (*create/update/delete*) against the search engine, it stores the writing udpate received in a queue and returns an `updateId`. With this id, the specific update execution is trackable.
 - Each update received is treated following the order it has been received.
 - You can get the update status on the [`/updates`](/references/updates.md) route.
 
@@ -25,9 +25,9 @@ sequenceDiagram
   M->>-Q: dequeue update 2
 </mermaid>
 
-### Which actions are async?
+### Which updates are async?
 
-Every action which could be compute-expensive is asynchronous. These include:
+Every update which could be compute-expensive is asynchronous. These include:
 - Create/update a schema
 - Update index settings
 - Add/update/delete documents
@@ -35,11 +35,11 @@ Every action which could be compute-expensive is asynchronous. These include:
 ### Understanding updates
 
 Updates returns the following information:
-* **status**: State of the action (enqueued, processed)
+* **status**: State of the update (enqueued, processed)
 * **updateId**: Id of the update
-* **type**: Information about the action type
-* **enqueuedAt**: Date at which the action has been added to the queue
-* **processedAt**: Date ate which the action has done processing.
+* **type**: Information about the update type
+* **enqueuedAt**: Date at which the update has been added to the queue
+* **processedAt**: Date ate which the update has done processing.
 
 ### Examples
 

--- a/getting_started/features.md
+++ b/getting_started/features.md
@@ -18,5 +18,5 @@ Our feature list with extended explanations and links to the documentation.
     - [Custom ranking](/advanced_guides/ranking.md#custom-ranking-rules): Create your own ranking rules on indexation.
     - [Schema customization](/main_concepts/indexes.md#index-uid-and-name): Customize schema  to suit your needs perfectly.
 * **RESTfull API**
-* **Asynchronous write actions**: Actions will be added to a queue for **low response time** and **guaranteed consistency**.
+* **Asynchronous write updates**: Updates will be added to a queue for **low response time** and **guaranteed consistency**.
 * [Bucket sort](/advanced_guides/bucket_sort.md) with [6 default ranking rules](/advanced_guides/ranking.md#ranking-rules) that [can be re-ordered](/advanced_guides/ranking.md#ranking-order) to suit your needs.

--- a/references/documents.md
+++ b/references/documents.md
@@ -147,7 +147,7 @@ curl \
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Add or update documents
 
@@ -202,7 +202,7 @@ curl \
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete all documents
 
@@ -233,7 +233,7 @@ curl \
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete one document
 
@@ -264,7 +264,7 @@ The `updateId` returned by this route can be sent to the [update status route](/
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 
 
@@ -313,4 +313,4 @@ The body must be a **Json Array** with the unique identifiers of the documents t
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/indexes.md
+++ b/references/indexes.md
@@ -143,7 +143,7 @@ If schema has been given:
   "updatedAt": "2019-11-20T09:40:33.711476Z"
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Update an index
 
@@ -373,4 +373,4 @@ curl \
   "updateId": 1,
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/settings.md
+++ b/references/settings.md
@@ -135,4 +135,4 @@ Setting the fields to `[]`, `{}` or `""` will erase **all rules**, even the Meil
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/stop_words.md
+++ b/references/stop_words.md
@@ -65,7 +65,7 @@ curl \
   "updateId": 1,
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete stop-words
 
@@ -101,4 +101,4 @@ curl \
   "updateId": 1,
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/synonyms.md
+++ b/references/synonyms.md
@@ -110,7 +110,7 @@ An object with either multi-way string associations or one-way string associatio
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Update a synonym
 
@@ -148,7 +148,7 @@ This will **override** the previous synonyms of the given sequence. Don't forget
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete a synonym
 
@@ -178,7 +178,7 @@ Delete a synonym.
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Batch write synonyms
 
@@ -224,7 +224,7 @@ An object with either multi-way string associations or one-way string associatio
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Clear synonyms
 
@@ -253,4 +253,4 @@ Delete all synonyms
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current action](/references/updates.md).
+This `updateId` allows you to [track the current update](/references/updates.md).


### PR DESCRIPTION
I changed the word `action` only in API references, but the term `action` is widely used in [asynchronous explanation](https://github.com/meilisearch/documentation/blob/master/advanced_guides/asynchronous_updates.md).
Can you tell me if I have to change this part as well?