### PR TITLE
Add heroku quickstart

### DIFF
--- a/advanced_guides/binary.md
+++ b/advanced_guides/binary.md
@@ -48,6 +48,20 @@ $ docker run -it --rm -p 7700:7700 getmeili/meilisearch:latest
 Server is listening on: http://0.0.0.0:7700
 ```
 
+## Running on Heroku
+
+You can deploy the latest stable build of MeiliSearch straight on Heroku.
+
+<p align="center">
+  <a href="https://heroku.com/deploy?template=https://github.com/meilisearch/MeiliSearch">
+    <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
+  </a>
+</p>
+
+::: note
+The deploy can take up to 20 minutes because it will compile the whole project from the GitHub repository.
+:::
+
 ## Usage
 
 ```bash

--- a/getting_started/download.md
+++ b/getting_started/download.md
@@ -38,6 +38,20 @@ Server is listening on: http://127.0.0.1:7700
 ```
 :::
 
+::: tab Heroku
+You can deploy the latest stable build of MeiliSearch straight on Heroku.
+
+<p align="center">
+  <a href="https://heroku.com/deploy?template=https://github.com/meilisearch/MeiliSearch">
+    <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
+  </a>
+</p>
+
+::: note
+The deploy can take up to 20 minutes because it will compile the whole project from the GitHub repository.
+:::
+
+
 ::::
 
 More [ways to run MeiliSearch](/advanced_guides/binary.md) and more information about the [environment variables](/advanced_guides/binary.md#environment-variables).

--- a/getting_started/quickstart.md
+++ b/getting_started/quickstart.md
@@ -45,6 +45,19 @@ Server is listening on: http://127.0.0.1:7700
 ```
 :::
 
+::: tab Heroku
+You can deploy the latest stable build of MeiliSearch straight on Heroku.
+
+<p align="center">
+  <a href="https://heroku.com/deploy?template=https://github.com/meilisearch/MeiliSearch">
+    <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
+  </a>
+</p>
+
+::: note
+The deploy can take up to 20 minutes because it will compile the whole project from the GitHub repository.
+:::
+
 ::::
 
 ### Create an Index and Upload Some Documents


### PR DESCRIPTION
Documentation for [meilisearch/Meilisearch#401](https://github.com/meilisearch/MeiliSearch/pull/401).

We should merge this only when the PR is merged in MeiliSearch repo.