### PR TITLE
Update rules of identifier

### DIFF
--- a/main_concepts/documents.md
+++ b/main_concepts/documents.md
@@ -32,9 +32,9 @@ When using the [route to add new documents](/references/documents.md#add-or-upda
 
 To be indexed by MeiliSearch, a document must have an **identifier**. A document without an identifier will be ignored when added to MeiliSearch.
 
-The identifier attribute name can be anything (unless the [schema is inferred when adding documents](/main_concepts/indexes.md#inferred-schema)).
+The identifier **attribute** can be anything, unless the [schema is inferred when adding documents](/main_concepts/indexes.md#inferred-schema).
 
-The identifier value must contain only `A-Z a-z 0-0` and `-_`.
+The identifier **value** must contain only `A-Z a-z 0-0` and `-_` characters.
 #### Examples
 Good :
 ```

--- a/main_concepts/documents.md
+++ b/main_concepts/documents.md
@@ -34,7 +34,6 @@ To be indexed by MeiliSearch, a document must have an **identifier**. A document
 
 The identifier attribute name can be anything (unless the [schema is inferred when adding documents](/main_concepts/indexes.md#inferred-schema)).
 
-
 The identifier value must contain only `A-Z a-z 0-0` and `-_`.
 #### Examples
 Good :

--- a/main_concepts/documents.md
+++ b/main_concepts/documents.md
@@ -3,7 +3,6 @@
 `Documents` are objects composed of fields containing any data.</br>
 A `field` is composed of an `attribute` and its associated data.
 
-
 ```json
 {
   "id": 3205,

--- a/main_concepts/documents.md
+++ b/main_concepts/documents.md
@@ -19,7 +19,7 @@ The **fields** are the combination of attributes and data (i.e., `"title": "Inte
 ## Documents structure
 
 A document is added to MeiliSearch in `JSON format`.<br/>
-Each field in a document should correspond to a field defined in the [schema](/main_concepts/indexes.html#schema-definition) to be taken into account.
+Each field in a document should correspond to a field defined in the [schema](/main_concepts/indexes.md#schema-definition) to be taken into account.
 
 A **document must contain** [one identifier field](/main_concepts/documents.md#documents-identifiers) to be indexed in meiliSearch.
 
@@ -33,7 +33,7 @@ When using the [route to add new documents](/references/documents.md#add-or-upda
 
 To be indexed by MeiliSearch, a document must have an **identifier**. A document without an identifier will be ignored when added to MeiliSearch.
 
-The identifier attribute name can be anything (unless the [schema is inferred when adding documents](/main_concepts/indexes.html#inferred-schema)).
+The identifier attribute name can be anything (unless the [schema is inferred when adding documents](/main_concepts/indexes.md#inferred-schema)).
 
 
 The identifier value must contain only `A-Z a-z 0-0` and `-_`.

--- a/main_concepts/documents.md
+++ b/main_concepts/documents.md
@@ -3,6 +3,7 @@
 `Documents` are objects composed of fields containing any data.</br>
 A `field` is composed of an `attribute` and its associated data.
 
+
 ```json
 {
   "id": 3205,
@@ -13,15 +14,35 @@ A `field` is composed of an `attribute` and its associated data.
 ```
 
 In this document, **attributes** are `"id"`, `"title"`, `"description"` and `"type"`.</br>
-The **fields** are the combination of attributes and data (i.e. `"title": "Interstellar"`).
+The **fields** are the combination of attributes and data (i.e., `"title": "Interstellar"`).
 
 ## Documents structure
 
 A document is added to MeiliSearch in `JSON format`.<br/>
-Each documents fields should correspond to an attribute in the schema to be taken into account.
+Each field in a document should correspond to a field defined in the [schema](/main_concepts/indexes.html#schema-definition) to be taken into account.
+
+A **document must contain** [one identifier field](/main_concepts/documents.md#documents-identifiers) to be indexed in meiliSearch.
 
 ::: danger
-Documents fields that do not correspond to the schema fields are ignored.
+Documents fields that do not exist in the schema are ignored.
 :::
 
-When using the [route to add new documents](/references/documents.md#add-or-update-documents) all documents should be sent in an array. And this, even if there is only one document.
+When using the [route to add new documents](/references/documents.md#add-or-update-documents), all documents should be sent in an array. And this, even if there is only one document.
+
+## Documents identifiers
+
+To be indexed by MeiliSearch, a document must have an **identifier**. A document without an identifier will be ignored when added to MeiliSearch.
+
+The identifier attribute name can be anything (unless the [schema is inferred when adding documents](/main_concepts/indexes.html#inferred-schema)).
+
+
+The identifier value must contain only `A-Z a-z 0-0` and `-_`.
+#### Examples
+Good :
+```
+"id" : "_Aabc012_"
+```
+Bad :
+```
+"id" : "@BI+* ^5h2%"
+```

--- a/main_concepts/documents.md
+++ b/main_concepts/documents.md
@@ -20,7 +20,7 @@ The **fields** are the combination of attributes and data (i.e., `"title": "Inte
 A document is added to MeiliSearch in `JSON format`.<br/>
 Each field in a document should correspond to a field defined in the [schema](/main_concepts/indexes.md#schema-definition) to be taken into account.
 
-A **document must contain** [one identifier field](/main_concepts/documents.md#documents-identifiers) to be indexed in meiliSearch.
+A **document must contain** [one identifier field](/main_concepts/documents.md#documents-identifiers) to be indexed in MeiliSearch.
 
 ::: danger
 Documents fields that do not exist in the schema are ignored.

--- a/main_concepts/indexes.md
+++ b/main_concepts/indexes.md
@@ -105,7 +105,6 @@ If a document is added when there is already a document with the same ID in Meil
 **The identifier is mandatory**, and must [follow formatting rules](/main_concepts/documents.md#documents-identifiers).
 :::
 
-
 ::: tip
 Documents identifiers are always converted into strings. Only strings and integers are valid identifiers.
 It means that it is, for example, forbidden to use arrays or objects as an identifier.

--- a/main_concepts/indexes.md
+++ b/main_concepts/indexes.md
@@ -27,7 +27,7 @@ It helps you track your different indexes with a human-readable name.
 
 In the schema definition, each attribute has one or multiple of the following properties :
 
-* **identifier**: The unique identifier of a document (e.g `id`)
+* **identifier**: The unique [identifier of a document](/main_concepts/documents.md#documents-identifiers) (e.g `id`)
 * **indexed**: the search engine will search inside those fields.
 * **displayed**: Fields that will appear in the returned documents.
 * **ranked**: Ranked fields are used to create ranking rules.
@@ -101,10 +101,17 @@ If two documents added at the same time have the same ID, MeiliSearch will only 
 
 If a document is added when there is already a document with the same ID in MeiliSearch, it will be updated.
 
+::: warning
+**The identifier is mandatory**, and must [follow formatting rules](/main_concepts/documents.md#documents-identifiers).
+:::
+
+
 ::: tip
 Documents identifiers are always converted into strings. Only strings and integers are valid identifiers.
 It means that it is, for example, forbidden to use arrays or objects as an identifier.
 :::
+
+
 
 ## Indexed
 

--- a/main_concepts/indexes.md
+++ b/main_concepts/indexes.md
@@ -110,7 +110,6 @@ Documents identifiers are always converted into strings. Only strings and intege
 It means that it is, for example, forbidden to use arrays or objects as an identifier.
 :::
 
-
 ## Indexed
 
 It defines the fields that will be used to find the documents.

--- a/main_concepts/indexes.md
+++ b/main_concepts/indexes.md
@@ -111,7 +111,6 @@ It means that it is, for example, forbidden to use arrays or objects as an ident
 :::
 
 
-
 ## Indexed
 
 It defines the fields that will be used to find the documents.


### PR DESCRIPTION
Fixes: meilisearch/MeiliSearch#416 :

* The document id must contain only A-Z a-z 0-0 and -_. This is to avoid encoding in the url path in the case of a multi-word id.