### PR TITLE
Removed all occurence of searchable attributes

### DIFF
--- a/advanced_guides/search_parameters.md
+++ b/advanced_guides/search_parameters.md
@@ -8,7 +8,6 @@ Search parameters let the user customize his search request.
 | **[offset](/advanced_guides/search_parameters.md#offset)**                | number of documents to skip                        | 0             |
 | **[limit](/advanced_guides/search_parameters.md#limit)**                 | number of documents returned                       | 20            |
 | **[attributesToRetrieve](/advanced_guides/search_parameters.md#attributes-to-retrieve)**  | document attributes to show                        | *             |
-| **[attributesToSearchIn](/advanced_guides/search_parameters.md#attributes-to-search-in)**  | which attributes are used to match documents       | *             |
 | **[attributesToCrop](/advanced_guides/search_parameters.md#attributes-to-crop)**      | which attributes to crop                           | none          |
 | **[cropLength](/advanced_guides/search_parameters.md#crop-length)**            | limit length at which to crop specified attributes | 200           |
 | **[attributesToHighlight](/advanced_guides/search_parameters.md#attributes-to-highlight)** | which attributes to highlight                      | none          |
@@ -44,11 +43,6 @@ X number of documents in the search query response. This is helpful for **pagina
 
 Attributes that will appear in the returned documents.
 
-## Attributes to search in
-
-`attributesToSearchIn=<Attribute>,<Attribute>,...`.
-
-Attributes used to match document in the search engine.
 
 ## Attributes to crop
 

--- a/advanced_guides/search_parameters.md
+++ b/advanced_guides/search_parameters.md
@@ -43,7 +43,6 @@ X number of documents in the search query response. This is helpful for **pagina
 
 Attributes that will appear in the returned documents.
 
-
 ## Attributes to crop
 
 `attributesToCrop=<Attribute>,<Attribute>,...`

--- a/main_concepts/search.md
+++ b/main_concepts/search.md
@@ -42,12 +42,6 @@ A lot of configuration can be made at *query-time*. Here is some usage examples
 curl -X GET 'http://localhost:7700/indexes/4eb345y7/search?q=batman&limit=5&offset=10'
 ```
 
-- _Search only in specific attributes_ - Search can be configured at query time, for example, you can search in only selected attributes
-
-```bash
-curl -X GET 'https://localhost:7700/indexes/4eb345y7/search?q=moliere&attributesToSearchIn=title'
-```
-
 - _Filters_ - You can build a faceted search using the query param `filter`. It will only returned the specific filtered documents.
 
 ```bash

--- a/references/search.md
+++ b/references/search.md
@@ -21,7 +21,6 @@ Search for documents matching a specific query in the given index.
 | **offset**                | number of documents to skip                        | 0             |
 | **limit**                 | number of documents to take                        | 20            |
 | **attributesToRetrieve**  | document attributes to show                        | *             |
-| **attributesToSearchIn**  | which attributes are used to match documents       | *             |
 | **attributesToCrop**      | which attributes to crop                           | none          |
 | **cropLength**            | limit length at which to crop specified attributes | 200           |
 | **attributesToHighlight** | which attributes to highlight                      | none          |


### PR DESCRIPTION
Removed all occurrences of searchableAttributes or how it was previously called: attributes to search in.
fixes: meilisearch/MeiliSearch#429
