### PR TITLE
Fix on new doc

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -85,10 +85,12 @@ module.exports = {
         },
         {
           title: '🍳 Cookbooks',
+          sidebarDepth: 0,
           path: '/tutorials/cookbooks/'
         },
         {
           title: '🧷 How to\'s',
+          sidebarDepth: 0,
           path: '/tutorials/howtos/'
         }
       ],

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 MeiliSearch is a **RESTfull search API** that is the **ready-to-go solution** for everyone wanting a **powerful, fast, and relevant search experience** for their end-users ⚡️🔎
 
+<linkButton method="GET" text="🚀  GETTING STARTED" url="/guides/#getting-started"/>
+
+
 Efficient search engines are often only accessible to companies with the financial means and resources necessary to develop a search solution adapted to their needs. The majority of other companies that do not have the means or do not realize that the lack of relevance of a search greatly impacts the pleasure of navigation on their application,
 end up with poor solutions that are more frustrating than effective, for both the developer and the user.
 
@@ -11,7 +14,7 @@ That's why we created MeiliSearch, an open-source solution accessible to everyon
 
 Our solution is **instant**; it **accepts typos**; it understands **filters**, **custom rankings**, and a lot of other [features](/getting_started/features.md).
 
-<linkButton method="GET" text="🚀  QUICKSTART" url="/tutorials"/>
+
 
 
 ## Open-source

--- a/getting_started/download.md
+++ b/getting_started/download.md
@@ -67,4 +67,4 @@ The [Heroku filesystem is ephemeral](https://help.heroku.com/K1PPS2WM/why-are-my
 
 ::::
 
-More [ways to run MeiliSearch](/guides/advanced_guides/binary.md) and more information about the [environment variables](/guides/advanced_guides/binary.md#environment-variables).
+More [ways to run MeiliSearch](/guides/advanced_guides/binary.md) and more information about the [environment variables and the flags](/guides/advanced_guides/binary.md#environment-variables-and-flags).

--- a/guides/README.md
+++ b/guides/README.md
@@ -127,7 +127,7 @@ $ ./target/release/meilisearch
 
 Now that our meilisearch server is up and running, we will be able to communicate with it.
 
-This is done through a [RESTFul API](/references/readme.md) or one of our [SDK's](/resources/sdks.md).
+This is done through a [RESTFul API](/references/README.md) or one of our [SDK's](/resources/sdks.md).
 
 For this getting started, communication will be done with the RESTful API using cURL.
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -351,7 +351,7 @@ In MeiliSearch we have three concepts on which we build our search engine. If yo
 - [Search](/guides/main_concepts/search.md)
 
 Finally, you can find the API references here :
-- [API References](/references/)
+- [API References](/references)
 
 And the SDK's links here :
 - [Ressources](/resources/sdks.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -19,14 +19,109 @@ First of all, you must have access to a running instance of MeiliSearch.
 
 There are [several download possibilities](/guides/advanced_guides/binary.md#download-and-launch).
 
-Once you have downloaded MeiliSearch, we need to start an instance. The port, as well as the master key, can be defined at launch. There are other [options available](/guides/advanced_guides/binary.md#usage).
+:::: tabs
 
-One way of installing MeiliSearch is curl :
+::: tab cURL
+Download the **latest stable release** of MeiliSearch with **curl**.
+
+Launch the MeiliSearch package to start MeiliSearch's server.
 ```bash
 $ curl -L https://install.meilisearch.com | sh
-$ ./meilisearch --http-addr 127.0.0.1:7700 --api-key 'MasterKey'
+$ ./meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+:::
+
+::: tab Brew
+Download the **latest stable release** of MeiliSearch with **Homebrew**.
+
+Launch the MeiliSearch package to start MeiliSearch's server.
+```bash
+$ brew update && brew install meilisearch
+$ meilisearch
+Server is listening on: http://127.0.0.1:7700
+```
+:::
+
+::: tab Docker
+Using **Docker** you can choose to run [any available tags](https://hub.docker.com/r/getmeili/meilisearch/tags).
+
+This command starts the **latest stable release** of MeiliSearch.
+```bash
+$ docker run -it --rm -p 7700:7700 -v $(pwd)/data.ms:/data.ms getmeili/meilisearch
+Server is listening on: http://0.0.0.0:7700
+```
+
+::: warning
+Docker is not persistent. You should share a volume to make your container filesystem persistent. MeiliSearch write its data at `/data.ms`
+:::
+
+::: tab APT
+
+Download the **latest stable release** of MeiliSearch with **APT**.
+
+Launch the MeiliSearch package to start MeiliSearch's server.
+```bash
+$ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
+$ apt update && apt install meilisearch-http
+$ meilisearch
+Server is listening on: http://127.0.0.1:7700
+```
+:::
+
+::: tab Heroku
+
+You can deploy the latest stable build of MeiliSearch straight on Heroku.
+
+<p align="center">
+  <a href="https://heroku.com/deploy?template=https://github.com/meilisearch/MeiliSearch">
+    <img src="https://www.herokucdn.com/deploy/button.svg" alt="Deploy">
+  </a>
+</p>
+
+
+The deploy can take up to 20 minutes because it will compile the whole project from the GitHub repository.
+
+::: warning
+The [Heroku filesystem is ephemeral](https://help.heroku.com/K1PPS2WM/why-are-my-file-uploads-missing-deleted), which means you may lose your data on any restart of the Heroku instance. **The Heroku deploy is okay for testing purposes, but it won't work for production.**
+:::
+
+
+::: tab Source
+
+MeiliSearch is made in `Rust`. Therefore the Rust toolchain must [be installed](https://www.rust-lang.org/tools/install) to compile the project.
+
+If you have the Rust toolchain already installed, you need to clone the repository and go to the cloned directory.
+
+```bash
+git clone https://github.com/meilisearch/MeiliSearch
+cd MeiliSearch
+```
+
+Inside the folder, compile MeiliSearch.
+
+```bash
+# Production version
+cargo build --release
+
+# Debug version
+cargo build
+```
+
+Compiling in release mode takes more time than in debug mode but the binary process time will be significantly faster. You **must** run a release binary when using MeiliSearch in production.
+
+You can find the compiled binary in `target/debug` or `target/release`.
+
+```bash
+# Excuting the server binary
+$ ./target/release/meilisearch
+```
+
+:::
+
+::::
+
+[Environnements variables and flags](/guides/advanced_guides/binary.md#environment-variables-and-flags) can be set before and on launch. With them you can among other things  add the **master key** or set the **port**.
 
 ### Communicate with MeiliSearch
 

--- a/guides/README.md
+++ b/guides/README.md
@@ -351,7 +351,7 @@ In MeiliSearch we have three concepts on which we build our search engine. If yo
 - [Search](/guides/main_concepts/search.md)
 
 Finally, you can find the API references here :
-- [API References](/references)
+- [API References](/references/README.md)
 
 And the SDK's links here :
 - [Ressources](/resources/sdks.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -1,30 +1,25 @@
 # Foreword
 
-Welcome to the beta version of the MeiliSearch API documentation 🐣
+This guide is made to give you a fast overview of MeiliSearch. Every bit of information is linked to its advanced documentation.
 
-This is our first draft guide in the limbo of the HTTP MeiliSearch routes.
-You can navigate into the documentation using the sidebar or by using the search bar above.
-
-If you spot any typo or any error in the documentation like a miss-documented response body for example,
-please contact us [by email](mailto:bonjour@meilisearch.com) or using the little chat box at the bottom right of this page.
-
-Thank you for your interest and have fun with your HTTP client 🌍
+If you want an even quicker overview we suggest [you look into our quickstart](/tutorials).
 ## Getting Started
 
-MeiliSearch has been developed to provide an easily integrated search solution. Each step of the implementation process has been designed to be as simple as possible. This guide will help you get started with MeiliSearch.
+MeiliSearch has been developed to provide an easily integrated search solution. Each step of the implementation process has been designed to be **as simple as possible**. This guide will help you get started with MeiliSearch.
 
 Contents :
-- Launching an instance of MeiliSearch
-- Create your index and add documents
-- Integrate search
-- Doing Research
+- [Launching an instance of MeiliSearch](/guides/#download-and-launch)
+- [Create your index](/guides/#create-your-index)
+- [Add documents](/guides/#add-documents)
+- [Search !](/guides/#searches)
+
+### Download and launch
 
 First of all, you must have access to a running instance of MeiliSearch.
 
-### Download and launch
 There are [several download possibilities](/guides/advanced_guides/binary.md#download-and-launch).
 
-Once it is downloaded, we need to start our instance of MeiliSearch. The port, as well as the master key, can be defined at launch. There are other [options available](/guides/advanced_guides/binary.md#usage).
+Once you have downloaded MeiliSearch, we need to start an instance. The port, as well as the master key, can be defined at launch. There are other [options available](/guides/advanced_guides/binary.md#usage).
 
 One way of installing MeiliSearch is curl :
 ```bash
@@ -37,7 +32,9 @@ Server is listening on: http://127.0.0.1:7700
 
 Now that our meilisearch server is up and running, we will be able to communicate with it.
 
-This is done through a [RESTFull API](/references/readme.md) or one of our [SDK's](/resources/sdks.md).
+This is done through a [RESTFul API](/references/readme.md) or one of our [SDK's](/resources/sdks.md).
+
+For this getting started, communication will be done with the RESTful API using cURL.
 
 ### Create your Index
 
@@ -105,25 +102,6 @@ The documents must have at least one field in common. This field contains the id
 Lets use an example [movies.json dataset](https://github.com/meilisearch/MeiliSearch/blob/master/datasets/movies/movies.json) to showcase how to add documents.
 
 
-```
-[{
-        "id": 287947,
-        "title": "Shazam",
-        "poster": "https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg",
-        "overview": "A boy is given the ability to become an adult superhero in times of need with a single magic word.",
-        "release_date": 1546473600
-      },{
-        "id": "522681",
-        "title": "Escape Room",
-        "poster": "https://image.tmdb.org/t/p/w1280/8yZAx7tlKRZIg7pJfaPhl00yHIQ.jpg",
-        "overview": "Six strangers find themselves in circumstances beyond their control, and must use their wits to survive.",
-        "release_date": 1546473600
-      },
-      ...
-]
-```
-
-
 :::: tabs
 
 ::: tab Curl
@@ -180,7 +158,7 @@ In MeiliSearch most actions are asynchronous. This lets you stack actions. They 
 You can [track the state of each action](/guides/advanced_guides/asynchronous_updates.md).
 
 
-### Doing Searches
+### Searches
 
 Now that our documents have been added to MeiliSearch we are be able to [search](/guides/main_concepts/search.md) in it.
 
@@ -269,6 +247,20 @@ Meilisearch **response** :
 ```
 
 
+### Afterword
 
 
-<!-- recognize that the guy is on windows or mac or linux -->
+In MeiliSearch we have three concepts on which we build our search engine. If you did not go to those pages, they give an essential insight.
+- [Indexes](/guides/main_concepts/indexes.md)
+- [Documents](/guides/main_concepts/documents.md)
+- [Search](/guides/main_concepts/search.md)
+
+Finally, you can find the API references here :
+- [API References](/references/)
+
+And the SDK's links here :
+- [Ressources](/resources/sdks.md)
+
+Tutorials and Cookbooks are being made. They will be available soon.
+
+

--- a/guides/README.md
+++ b/guides/README.md
@@ -345,7 +345,7 @@ Meilisearch **response** :
 ### Afterword
 
 
-In MeiliSearch we have three concepts on which we build our search engine. If you did not go to those pages, they give an essential insight.
+In MeiliSearch we have three concepts on which we build our search engine. If you haven't read these pages yet, do not hesitate, they give an essential insight.
 - [Indexes](/guides/main_concepts/indexes.md)
 - [Documents](/guides/main_concepts/documents.md)
 - [Search](/guides/main_concepts/search.md)

--- a/guides/README.md
+++ b/guides/README.md
@@ -23,7 +23,7 @@ There are [several download possibilities](/guides/advanced_guides/binary.md#dow
 ::: tab cURL
 Download the **latest stable release** of MeiliSearch with **curl**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
@@ -34,7 +34,7 @@ Server is listening on: http://127.0.0.1:7700
 ::: tab Brew
 Download the **latest stable release** of MeiliSearch with **Homebrew**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ brew update && brew install meilisearch
 $ meilisearch
@@ -59,7 +59,7 @@ Docker is not persistent. You should share a volume to make your container files
 
 Download the **latest stable release** of MeiliSearch with **APT**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 $ apt update && apt install meilisearch-http

--- a/guides/advanced_guides/binary.md
+++ b/guides/advanced_guides/binary.md
@@ -104,13 +104,8 @@ $ ./target/release/meilisearch
 ::::
 
 
-## Flags
-[Flags](/guides/advanced_guides/binary.md#environment-variables) can be added on launch.
 
-```bash
-$ ./meilisearch --db-path ./meilifiles --http-addr 127.0.0.1:7700
-Server is listening on: http://127.0.0.1:7700
-```
+
 
 ## Usage
 
@@ -133,7 +128,16 @@ OPTIONS:
         --no-analytics <no-analytics>    Do not send analytics to Meili. [env: MEILI_NO_ANALYTICS=]
 ```
 
-# Environment variables
+## Environment variables and Flags
+
+[Flags](/guides/advanced_guides/binary.md#environment-variables) can be added on launch.
+
+```bash
+$ ./meilisearch --db-path ./meilifiles --http-addr 127.0.0.1:7700
+Server is listening on: http://127.0.0.1:7700
+```
+
+Here is the list of **all Environment variables and Flags** (CLI options).
 
 | Environment Variable | CLI option     | Description                                                                                                                                                            | Default value      |
 |----------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|

--- a/guides/advanced_guides/binary.md
+++ b/guides/advanced_guides/binary.md
@@ -130,7 +130,7 @@ OPTIONS:
 
 ## Environment variables and Flags
 
-[Flags](/guides/advanced_guides/binary.md#environment-variables) can be added on launch.
+Flags can be added on launch.
 
 ```bash
 $ ./meilisearch --db-path ./meilifiles --http-addr 127.0.0.1:7700

--- a/guides/advanced_guides/binary.md
+++ b/guides/advanced_guides/binary.md
@@ -6,7 +6,7 @@
 ::: tab cURL
 Download the **latest stable release** of MeiliSearch with **curl**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
@@ -17,7 +17,7 @@ Server is listening on: http://127.0.0.1:7700
 ::: tab Brew
 Download the **latest stable release** of MeiliSearch with **Homebrew**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ brew update && brew install meilisearch
 $ meilisearch
@@ -42,7 +42,7 @@ Docker is not persistent. You should share a volume to make your container files
 
 Download the **latest stable release** of MeiliSearch with **APT**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server..
 ```bash
 $ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 $ apt update && apt install meilisearch-http

--- a/references/README.md
+++ b/references/README.md
@@ -13,7 +13,7 @@ Thank you for your interest and have fun with your HTTP client 🌍
 ::: warning
 The documentation is written for the latest stable release: [v0.8.4](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.8.4).
 
-v0.9.0 is on its way and will bring significant changes in the settings API!
+v0.9.0 is on its way and will bring significant changes in the settings API.
 :::
 
 # Headers

--- a/references/readme.md
+++ b/references/readme.md
@@ -13,7 +13,7 @@ Thank you for your interest and have fun with your HTTP client 🌍
 ::: warning
 The documentation is written for the latest stable release: [v0.8.4](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.8.4).
 
-v0.9.0 is on its way and will bring significant changes in the settings API.
+v0.9.0 is on its way and will bring significant changes in the settings API!
 :::
 
 # Headers

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -12,7 +12,7 @@ You can deploy the server on your own machine. It will listen to HTTP requests o
 ::: tab cURL
 Download the **latest stable release** of MeiliSearch with **curl**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
@@ -23,7 +23,7 @@ Server is listening on: http://127.0.0.1:7700
 ::: tab Brew
 Download the **latest stable release** of MeiliSearch with **Homebrew**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ brew update && brew install meilisearch
 $ meilisearch
@@ -48,7 +48,7 @@ Docker is not persistent. You should share a volume to make your container files
 
 Download the **latest stable release** of MeiliSearch with **APT**.
 
-Launch the MeiliSearch package to start MeiliSearch's server.
+Launch MeiliSearch to start the server.
 ```bash
 $ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 $ apt update && apt install meilisearch-http

--- a/tutorials/cookbooks/README.md
+++ b/tutorials/cookbooks/README.md
@@ -1,0 +1,3 @@
+## Comming soon
+
+Cookbooks are being made and will soon overflow this section.

--- a/tutorials/cookbooks/readme.md
+++ b/tutorials/cookbooks/readme.md
@@ -1,3 +1,0 @@
-## Comming soon
-
-Cookbooks are being made and will soon overflow this section. 🚗

--- a/tutorials/cookbooks/readme.md
+++ b/tutorials/cookbooks/readme.md
@@ -1,3 +1,3 @@
 ## Comming soon
 
-Cookbooks are being made and will soon overflow this section.
+Cookbooks are being made and will soon overflow this section. 🚗

--- a/tutorials/cookbooks/readme.md
+++ b/tutorials/cookbooks/readme.md
@@ -1,0 +1,3 @@
+## Comming soon
+
+Cookbooks are being made and will soon overflow this section.

--- a/tutorials/howtos/README.md
+++ b/tutorials/howtos/README.md
@@ -1,0 +1,3 @@
+## Comming soon
+
+How to's are being made and will soon overflow this section.

--- a/tutorials/howtos/readme.md
+++ b/tutorials/howtos/readme.md
@@ -1,0 +1,3 @@
+## Comming soon
+
+How to's are being made and will soon overflow this section.

--- a/tutorials/howtos/readme.md
+++ b/tutorials/howtos/readme.md
@@ -1,3 +1,3 @@
 ## Comming soon
 
-How to's are being made and will soon overflow this section.
+How to's are being made and will soon overflow this section. 🚗

--- a/tutorials/howtos/readme.md
+++ b/tutorials/howtos/readme.md
@@ -1,3 +1,0 @@
-## Comming soon
-
-How to's are being made and will soon overflow this section. 🚗


### PR DESCRIPTION
```
I really LOVE the new structure!! (The new Home page, the separated part between Guide/Api Reference/Tutorial...)
Some points:

The search bar in the middle of the navbar chocks me a lot. Is it possible to put it at the right?
At the end of the QuickStart, the user is not redirected to another part of our documentation. Maybe the Guide part is a good idea...?
In Guide -> Getting started -> Download and launch :
1) there is a dead link on option available and the tests didn't see it.
2) I think it could be better to put all the possibilities of download like in Advanced Guide -> Installation (but we should find a way to link both tables)
```
@curquiza 
The searchbar position will be changed when I change the searchbar.
The user is now redirected to the getting started which in turn redirects to all parts of the documentation.
No dead links have been found in the getting started.
I have put all the possibilities of download in the getting started.


