### PR TITLE
Changes in installation guide

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -42,7 +42,7 @@ module.exports = {
           collapsable: false,
           children: [
             "/guides/advanced_guides/relevancy",
-            "/guides/advanced_guides/binary",
+            "/guides/advanced_guides/installation",
             "/guides/advanced_guides/typotolerance",
             "/guides/advanced_guides/concat",
             "/guides/advanced_guides/synonyms",

--- a/guides/advanced_guides/README.md
+++ b/guides/advanced_guides/README.md
@@ -1,7 +1,7 @@
 # Advanced guides
 
 In the advanced guides you will find how to tune your search API and customize it:
-- [MeiliSearch Binary](binary.md)
+- [Installation](installation.md)
 - [Stop words](stop_words.md)
 - [Search parameters](search_parameters.md)
 - [Synonyms](synonyms.md)

--- a/guides/advanced_guides/README.md
+++ b/guides/advanced_guides/README.md
@@ -1,7 +1,7 @@
 # Advanced guides
 
 In the advanced guides you will find how to tune your search API and customize it:
-- [Installation](installation.md)
+- [How to install MeiliSearch](installation.md)
 - [Stop words](stop_words.md)
 - [Search parameters](search_parameters.md)
 - [Synonyms](synonyms.md)

--- a/guides/advanced_guides/installation.md
+++ b/guides/advanced_guides/installation.md
@@ -72,7 +72,7 @@ The [Heroku filesystem is ephemeral](https://help.heroku.com/K1PPS2WM/why-are-my
 
 MeiliSearch is made in `Rust`. Therefore the Rust toolchain must [be installed](https://www.rust-lang.org/tools/install) to compile the project.
 
-If you have the Rust toolchain already installed, you need to clone the repository and go to the cloned directory.
+If you have the Rust toolchain installed, you can clone the repository and compile it this way:
 
 ```bash
 $ git clone https://github.com/meilisearch/MeiliSearch

--- a/guides/advanced_guides/installation.md
+++ b/guides/advanced_guides/installation.md
@@ -133,7 +133,7 @@ $ ./meilisearch --db-path ./meilifiles --http-addr 127.0.0.1:7700
 Server is listening on: http://127.0.0.1:7700
 ```
 
-Here is the list of **all Environment variables and Flags** (CLI options).
+Here is the list of **all Environment variables and Flags** (CLI options).
 
 | Environment Variable | CLI option     | Description                                                                                                                                                            | Default value      |
 |----------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|

--- a/guides/advanced_guides/installation.md
+++ b/guides/advanced_guides/installation.md
@@ -85,16 +85,7 @@ Inside the folder, compile MeiliSearch.
 # Production version
 $ cargo build --release
 
-# Debug version
-$ cargo build
-```
-
-Compiling in release mode takes more time than in debug mode but the binary process time will be significantly faster. You **must** run a release binary when using MeiliSearch in production.
-
-You can find the compiled binary in `target/debug` or `target/release`.
-
-```bash
-# Excuting the server binary
+# Executing the server binary
 $ ./target/release/meilisearch
 ```
 
@@ -107,7 +98,7 @@ $ ./target/release/meilisearch
 
 ## Usage
 
-```bash
+```
 $ ./meilisearch --help
 meilisearch-http 0.9.0
 
@@ -137,7 +128,7 @@ OPTIONS:
 
 Flags can be added on launch.
 
-```bash
+```
 $ ./meilisearch --db-path ./meilifiles --http-addr 127.0.0.1:7700
 Server is listening on: http://127.0.0.1:7700
 ```
@@ -150,3 +141,11 @@ Here is the list of **all Environment variables and Flags** (CLI options).
 | MEILI_HTTP_ADDR      | --http-addr    | Address and port to listen to                                                                                                                                          | "127.0.0.1:7700"   |
 | MEILI_MASTER_KEY     | --master-key   | Default admin API key                                                                                                                                                  |                    |
 | MEILI_NO_ANALYTICS   | --no-analytics | Deactivate analytics. Analytics help us to know how much users are using our project, knowing which versions and which platforms are used. It is completely anonymous. |                    |
+| MEILI_ENV   | --env | Defines the environment in which MeiliSearch is running. Can be `production` or `development` |  development  |
+
+### Environments
+
+By default, MeiliSearch runs in `development` mode.
+
+- `Production`: the [master key](/guides/advanced_guides/keys.md) is **mandatory**.
+- `Development`: the [master key](/guides/advanced_guides/keys.md) is **optional** and logs are output in "info" mode (*console output*).

--- a/guides/advanced_guides/installation.md
+++ b/guides/advanced_guides/installation.md
@@ -141,7 +141,7 @@ Here is the list of **all Environment variables and Flags** (CLI options).
 | MEILI_HTTP_ADDR      | --http-addr    | Address and port to listen to                                                                                                                                          | "127.0.0.1:7700"   |
 | MEILI_MASTER_KEY     | --master-key   | Default admin API key                                                                                                                                                  |                    |
 | MEILI_NO_ANALYTICS   | --no-analytics | Deactivate analytics. Analytics help us to know how much users are using our project, knowing which versions and which platforms are used. It is completely anonymous. |                    |
-| MEILI_ENV   | --env | Defines the environment in which MeiliSearch is running. Can be `production` or `development` |  development  |
+| MEILI_ENV   | --env | Defines the environment in which MeiliSearch is running. Can be `production` or `development` |  "development"  |
 
 ### Environments
 

--- a/guides/getting_started/quick_start_guide.md
+++ b/guides/getting_started/quick_start_guide.md
@@ -6,7 +6,7 @@ This quick tour will help you get started with MeiliSearch in only a few steps.
 
 First of all, you must have access to a running instance of MeiliSearch.
 
-There are [several download possibilities](/guides/advanced_guides/binary.md#download-and-launch).
+There are [several download possibilities](/guides/advanced_guides/installation.md#download-and-launch).
 
 :::: tabs
 ::: tab cURL
@@ -107,7 +107,7 @@ $ ./target/release/meilisearch
 
 ::::
 
-[Environment variables and flags](/guides/advanced_guides/binary.md#environment-variables-and-flags) can be set before and on launch. With them you can among other things  add the **master key** or set the **port**.
+[Environment variables and flags](/guides/advanced_guides/installation.md#environment-variables-and-flags) can be set before and on launch. With them you can among other things  add the **master key** or set the **port**.
 
 ### Communicate with MeiliSearch
 

--- a/guides/getting_started/quick_start_guide.md
+++ b/guides/getting_started/quick_start_guide.md
@@ -107,7 +107,7 @@ $ ./target/release/meilisearch
 
 ::::
 
-[Environment variables and flags](/guides/advanced_guides/installation.md#environment-variables-and-flags) can be set before and on launch. With them you can among other things  add the **master key** or set the **port**.
+[Environment variables and flags](/guides/advanced_guides/installation.md#environment-variables-and-flags) can be set before and on launch. With them, you can among other things add the **master key** or set the **port**.
 
 ### Communicate with MeiliSearch
 


### PR DESCRIPTION
- Removed debug cargo build
- Changed `binary` file name to `installation`.
- Changed links from Binary to Installation
- Added Env and CLI variable MEILI_ENV
- Added environments explanation at the end of the installation guide