### PR TITLE
Change advanced guides navbar order

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -43,17 +43,17 @@ module.exports = {
           collapsable: false,
           children: [
             "/guides/advanced_guides/installation",
-            "/guides/advanced_guides/typotolerance",
-            "/guides/advanced_guides/concat",
-            "/guides/advanced_guides/synonyms",
-            "/guides/advanced_guides/stop_words",
             "/guides/advanced_guides/search_parameters",
             "/guides/advanced_guides/keys",
-            "/guides/advanced_guides/prefix",
-            "/guides/advanced_guides/distinct",
             "/guides/advanced_guides/asynchronous_updates",
-            "/guides/advanced_guides/bucket_sort",
-            "/guides/advanced_guides/web_interface"
+            "/guides/advanced_guides/web_interface",
+            "/guides/advanced_guides/synonyms",
+            "/guides/advanced_guides/stop_words",
+            "/guides/advanced_guides/prefix",
+            "/guides/advanced_guides/typotolerance",
+            "/guides/advanced_guides/concat",
+            "/guides/advanced_guides/distinct",
+            "/guides/advanced_guides/bucket_sort"
           ]
         }
       ],

--- a/guides/advanced_guides/README.md
+++ b/guides/advanced_guides/README.md
@@ -2,16 +2,17 @@
 
 In the advanced guides you will find how to tune your search API and customize it:
 - [How to install MeiliSearch](installation.md)
-- [Stop words](stop_words.md)
 - [Search parameters](search_parameters.md)
-- [Synonyms](synonyms.md)
-- [Distinct](distinct.md)
 - [Keys](keys.md)
+- [Synonyms](synonyms.md)
+- [Stop words](stop_words.md)
+- [Distinct](distinct.md)
 
 You can also read the following articles to understand how MeiliSearch works under the hood and better understand the algorithms used:
 
+- [Asynchronous updates](asynchronous_updates.md)
 - [Prefix search](prefix.md)
+- [Web interface](web_interface.md)
 - [Typo Tolerance](typotolerance.md)
 - [Concatenate and split queries](concat.md)
 - [Bucket sort](bucket_sort.md)
-- [Asynchronous updates](asynchronous_updates.md)


### PR DESCRIPTION
Change the order of the guides in `advanced guides` category.

In the navbar they are ordered by what I considered to be the most important guides to grasp the knowledge of MeiliSearch.

In the README file they are ordered by importance and by type (API customization or General knowledge)
