### PR TITLE
Web interface mention and changed to search guide

### DIFF
--- a/guides/getting_started/quick_start_guide.md
+++ b/guides/getting_started/quick_start_guide.md
@@ -241,6 +241,8 @@ The search engine is now aware of our documents and can serve those via our HTTP
 $ curl 'http://127.0.0.1:7700/indexes/12345678/search?q=botman'
 ```
 
+MeiliSearch also offers an out-of-the-box [web interface](/guides/advanced_guides/web_interface.md) on which you can try the search. Simply go to your MeiliSearch address using a browser. In our case that would be: `http://127.0.0.1:7700`
+
 :::: tabs
 
 ::: tab Curl

--- a/guides/getting_started/quick_start_guide.md
+++ b/guides/getting_started/quick_start_guide.md
@@ -241,7 +241,7 @@ The search engine is now aware of our documents and can serve those via our HTTP
 $ curl 'http://127.0.0.1:7700/indexes/12345678/search?q=botman'
 ```
 
-MeiliSearch also offers an out-of-the-box [web interface](/guides/advanced_guides/web_interface.md) on which you can try the search. Simply go to your MeiliSearch address using a browser. In our case that would be: `http://127.0.0.1:7700`
+MeiliSearch also offers an out-of-the-box [web interface](/guides/advanced_guides/web_interface.md) on which you can try the search. Go to your MeiliSearch address using a browser. In our case that would be: `http://127.0.0.1:7700`
 
 :::: tabs
 

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -24,7 +24,7 @@ Here is the ordered list of the default ranking rules used in MeiliSearch:
 - _Position_ - A document containing the query words at the start of an attribute is considered better than a document that contains them at the end.
 - _Exact_ - A document containing the query words in their exact form, not only a prefix of them, is considered better.
 
-You can change the order of these rules, but you should know that these work well for a majority of use-cases. You can also add your own rule for domains specific needs. For example, you could add a date sorting criterion when searching into documents where the date of publication is essential. [Read more about ranking](/guides/main_concepts/relevancy.md) to see how to add custom rules.
+You can change the order of these rules, but you should know that these work well for a majority of use-cases. You can also add your own rules for domains specific needs. For example, you could add a date sorting criterion when searching into documents where the date of publication is essential. [Read more about ranking](/guides/main_concepts/relevancy.md) to see how to add custom rules.
 
 ## Search options
 

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -22,7 +22,7 @@ Here is the ordered list of the default ranking rules used in MeiliSearch:
 - _Words Proximity_ - The closer the query words are in the document, the better is the document.
 - _Attribute_ - A document containing the query words in a more important attribute than another document is considered better.
 - _Position_ - A document containing the query words at the start of an attribute is considered better than a document that contains them at the end.
-- _Exact_ - A document containing the query words in their exact form, not only a prefix of them, is considered better.
+- _Exactness_ - A document containing the query words in their exact form, not only a prefix of them, is considered better.
 
 You can change the order of these rules, but you should know that these work well for a majority of use-cases. You can also add your own rules for domains specific needs. For example, you could add a date sorting criterion when searching into documents where the date of publication is essential. [Read more about ranking](/guides/main_concepts/relevancy.md) to see how to add custom rules.
 

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -5,7 +5,7 @@
 When the query input is received, MeiliSearch is building a more complex query taking into account *typos*, n-grams, and *synonyms* if configured.
 
 - _Typos_ - For example, if the query string is `botman`, MeiliSearch will return documents containing `batman`. [Read more about the typo rules](/guides/advanced_guides/typotolerance.md).
-- _N-grams_ - MeiliSearch is set to merge multi-words query into a single word. Ex: Searching for `bat mobile` will returns documents containing `batmobile`. Each word of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`. [Read more about Concatenate and Split Queries](/guides/advanced_guides/concat.md)
+- _N-grams_ - MeiliSearch is set to merge multi-words queries into a single word when searching for matching documents. Ex: Searching for `bat mobile` will return documents containing `batmobile`. Each word of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`. [Read more about Concatenate and Split Queries](/guides/advanced_guides/concat.md)
 - _Synonyms_ - MeiliSearch will return documents containing `batman` when searching for `the dark knight`. Synonyms are not set by default because they are domain-specific. [Read more about synonyms](/guides/advanced_guides/synonyms.md).
 
 ## Sorting documents

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -43,4 +43,5 @@ $ curl -X GET 'https://localhost:7700/indexes/4eb345y7/search?q=batman&filters=d
 ```
 
 ### Try out
+
 Once you have added your data to Meilisearch, **try out the search** experience using the available [web interface](/guides/advanced_guides/web_interface.md) at your MeiliSearch address in any browser.

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -1,21 +1,21 @@
 # Search
 
-### Finding documents
+## Finding documents
 
 When the query input is received, MeiliSearch is building a more complex query taking into account *typos*, n-grams, and *synonyms* if configured.
 
 - _Typos_ - For example, if the query string is `botman`, MeiliSearch will return documents containing `batman`. [Read more about the typo rules](/guides/advanced_guides/typotolerance.md).
-- _N-grams_ - MeiliSearch is set to merge multi-words query into a single word. Ex: Searching for `bat mobile` will returns documents containing `batmobile`. Each words of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`.
+- _N-grams_ - MeiliSearch is set to merge multi-words query into a single word. Ex: Searching for `bat mobile` will returns documents containing `batmobile`. Each words of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`. [Read more about Concatenate and Split Queries](/guides/advanced_guides/concat.md)
 - _Synonyms_ - MeiliSearch will return documents containing `batman` when searching for `the dark knight`. Synonyms are not set by default because they are domain-specific. [Read more about synonyms](/guides/advanced_guides/synonyms.md).
 
-### Sorting documents
+## Sorting documents
 
 > It would not be a search engine if there was not a notion of relevancy in the results returned.
 
-When all documents corresponding to the request have been collected, *MeiliSearch sorts the documents* using a bucket sort.
+When all documents corresponding to the request have been collected, *MeiliSearch sorts the documents* using a bucket sort and a list of built-in rules.
 
-A bucket sort can be described as an ordered set of sorting criteria. All the documents are sorted within the first criterion, then documents that can not be distinguished will be sorted using the second criterion, and so on. Thus, every document is not sorted for every criterion, which induces a reduced compute time.
-Here is the ordered list of the default criteria used in MeiliSearch:
+A bucket sort can be described as an ordered set of sorting rules. All the documents are sorted within the first rule, then documents that can not be distinguished will be sorted using the second rule, and so on. Thus, every document is not sorted for every rule, which induces a reduced compute time.
+Here is the ordered list of the default ranking rules used in MeiliSearch:
 
 - _Number of Typos_ - The fewer typos there are between the query words and the document words, the better is the document.
 - _Number of Words_ - A document containing more of the query words will be more important than one that contains less.
@@ -24,11 +24,11 @@ Here is the ordered list of the default criteria used in MeiliSearch:
 - _Position_ - A document containing the query words at the start of an attribute is considered better than a document that contains them at the end.
 - _Exact_ - A document containing the query words in their exact form, not only a prefix of them, is considered better.
 
-You can change the order of these criteria, but you should know that these work well for a majority of use-cases. You can also add your own criteria for domains specific needs. For example, you could add a date sorting criterion when searching into documents where the date of publication is essential. [Read more about ranking](/guides/main_concepts/relevancy.md) to see how to add custom criteria.
+You can change the order of these rules, but you should know that these work well for a majority of use-cases. You can also add your own rule for domains specific needs. For example, you could add a date sorting criterion when searching into documents where the date of publication is essential. [Read more about ranking](/guides/main_concepts/relevancy.md) to see how to add custom rules.
 
-### Search options
+## Search options
 
-A lot of configuration can be made at *query-time*. Here are some usage examples:
+A lot of configuration can be made at *query-time* using the [search paramaters](/guides/advanced_guides/search_parameters.md). Here are some usage examples:
 
 - _Pagination_ - Results can be paginated using the query params `limit` and `offset`
 
@@ -41,3 +41,6 @@ $ curl -X GET 'http://localhost:7700/indexes/4eb345y7/search?q=batman&limit=5&of
 ```bash
 $ curl -X GET 'https://localhost:7700/indexes/4eb345y7/search?q=batman&filters=director:Christopher%20Nolan'
 ```
+
+### Try out
+Once you have added your data to Meilisearch, simply **try out the search** experience using the available [web interface](/guides/advanced_guides/web_interface.md) at your MeiliSearch address in any browser.

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -12,7 +12,7 @@ When the query input is received, MeiliSearch is building a more complex query t
 
 > It would not be a search engine if there was not a notion of relevancy in the results returned.
 
-When all documents corresponding to the request have been collected, *MeiliSearch sorts the documents* using a bucket sort and a list of built-in rules.
+When all documents corresponding to the request have been collected, *MeiliSearch sorts the documents* using a [bucket sort](/guides/advanced_guides/bucket_sort.md) and a list of built-in [ranking rules](/guides/main_concepts/relevancy.md#ranking-rules).
 
 A bucket sort can be described as an ordered set of sorting rules. All the documents are sorted within the first rule, then documents that can not be distinguished will be sorted using the second rule, and so on. Thus, every document is not sorted for every rule, which induces a reduced compute time.
 Here is the ordered list of the default ranking rules used in MeiliSearch:
@@ -43,4 +43,4 @@ $ curl -X GET 'https://localhost:7700/indexes/4eb345y7/search?q=batman&filters=d
 ```
 
 ### Try out
-Once you have added your data to Meilisearch, simply **try out the search** experience using the available [web interface](/guides/advanced_guides/web_interface.md) at your MeiliSearch address in any browser.
+Once you have added your data to Meilisearch, **try out the search** experience using the available [web interface](/guides/advanced_guides/web_interface.md) at your MeiliSearch address in any browser.

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -5,7 +5,7 @@
 When the query input is received, MeiliSearch is building a more complex query taking into account *typos*, n-grams, and *synonyms* if configured.
 
 - _Typos_ - For example, if the query string is `botman`, MeiliSearch will return documents containing `batman`. [Read more about the typo rules](/guides/advanced_guides/typotolerance.md).
-- _N-grams_ - MeiliSearch is set to merge multi-words query into a single word. Ex: Searching for `bat mobile` will returns documents containing `batmobile`. Each words of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`. [Read more about Concatenate and Split Queries](/guides/advanced_guides/concat.md)
+- _N-grams_ - MeiliSearch is set to merge multi-words query into a single word. Ex: Searching for `bat mobile` will returns documents containing `batmobile`. Each word of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`. [Read more about Concatenate and Split Queries](/guides/advanced_guides/concat.md)
 - _Synonyms_ - MeiliSearch will return documents containing `batman` when searching for `the dark knight`. Synonyms are not set by default because they are domain-specific. [Read more about synonyms](/guides/advanced_guides/synonyms.md).
 
 ## Sorting documents


### PR DESCRIPTION
On basis of this comment 

> Some points:
> 
> talking about the web interface in the getting started is mandatory for me :) And it should be mentioned in guides/main_concept/search, or at least put a link to the advanced guide part talking about the web interface.
> there is an empty file web in guides/advanced_guides

from @curquiza 

And also on wording changes and overall update of the search guide.