### PR TITLE
Fix typo in search_parameters.md

### DIFF
--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -32,7 +32,7 @@ X first documents to skip. This is helpful for **pagination**
 
 ## Limit
 
-`offset=<Integer>`.
+`limit=<Integer>`.
 
 X number of documents in the search query response. This is helpful for **pagination**
 


### PR DESCRIPTION
I know this feels kind of drive-by, but I'm currently in the process of writing a simple Go client for Meili and noticed this was off.