### PR TITLE
REFACTO: Create middle-man component to make glossary Client Only

### DIFF
--- a/.vuepress/components/ClientGlossary.vue
+++ b/.vuepress/components/ClientGlossary.vue
@@ -1,0 +1,14 @@
+<template>
+    <ClientOnly><glossary :word="word"/></ClientOnly>
+</template>
+
+<script>
+export default {
+    name: "clientGlossary",
+    props: {
+        'word': {
+            type: String
+        }
+    },
+}
+</script>

--- a/guides/introduction/quick_start_guide.md
+++ b/guides/introduction/quick_start_guide.md
@@ -110,7 +110,7 @@ This is done through a [RESTFul API](/references/README.md) or one of our [SDKs]
 ## Create your Index
 
 In MeiliSearch, the information is subdivided into indexes. Each [index](/guides/main_concepts/indexes.md) contains a data structure and the associated documents.
-The indexes can be imagined as SQL tables. But you won't need to define the table because MeiliSearch is <ClientOnly><glossary word="schemaless"/></ClientOnly>.
+The indexes can be imagined as SQL tables. But you won't need to define the table because MeiliSearch is <clientGlossary word="schemaless"/>.
 In order to be able to store our documents in an index, we have to create one first.
 
 :::: tabs
@@ -166,9 +166,9 @@ Once the index has been created, it needs to be filled with [documents](/guides/
 
 Documents are sent to MeiliSearch in JSON format.
 
-To be processed by MeiliSearch, all documents need one common <ClientOnly><glossary word="field" /></ClientOnly> which will serve as [primary key](/guides/main_concepts/documents.md#primary-key) for the document. The value in this field must be **unique**.
+To be processed by MeiliSearch, all documents need one common <clientGlossary word="field" /> which will serve as [primary key](/guides/main_concepts/documents.md#primary-key) for the document. The value in this field must be **unique**.
 
-There are [several ways to let MeiliSearch know what the primary key](/guides/main_concepts/documents.md#primary-key) is, the easiest way is to have an <ClientOnly><glossary word="attribute" /></ClientOnly> that contains the string `id` case-insensitively.
+There are [several ways to let MeiliSearch know what the primary key](/guides/main_concepts/documents.md#primary-key) is, the easiest way is to have an <clientGlossary word="attribute" /> that contains the string `id` case-insensitively.
 
 
 Let's use an example [movies.json dataset](https://github.com/meilisearch/MeiliSearch/blob/master/datasets/movies/movies.json) to showcase how to add documents.

--- a/guides/main_concepts/documents.md
+++ b/guides/main_concepts/documents.md
@@ -37,14 +37,14 @@ A **document must contain** [the primary key field](/guides/main_concepts/docume
 
 ## Fields
 
-All fields present in a document are automatically <ClientOnly><glossary word="searchable" /></ClientOnly> and <ClientOnly><glossary word="displayed" /></ClientOnly>.
+All fields present in a document are automatically <clientGlossary word="searchable" /> and <clientGlossary word="displayed" />.
 The way MeiliSearch handles a field is customizable in the settings <Badge text="soon" type="warn"/>. You can make a field only searchable, or only displayed, or none, in this case, MeiliSearch will completely ignore the field when it is sent on document addition.
 
-You can also add <ClientOnly><glossary word="ranking rules" /></ClientOnly> on a field, to, for example, add a rule that makes recent movies more relevant than older ones.
+You can also add <clientGlossary word="ranking rules" /> on a field, to, for example, add a rule that makes recent movies more relevant than older ones.
 
 ## Primary key
 
-A primary key is an <ClientOnly><glossary word="attribute" /></ClientOnly> with a unique value found in each document of a given index. It is used to store the document in the index.
+A primary key is an <clientGlossary word="attribute" /> with a unique value found in each document of a given index. It is used to store the document in the index.
 
 Each index recognizes **only one** primary key attribute. Once the [primary key is set on the index](/guides/main_concepts/documents.md#setting-the-primary-key), it **cannot be changed**.
 

--- a/guides/main_concepts/indexes.md
+++ b/guides/main_concepts/indexes.md
@@ -5,7 +5,7 @@ An index is the collection of a certain type of data.
 It is, as a table in SQL, or a collection in MongoDB, an entity that collects a set of documents.
 
 An index is defined by an `uid` and contains the following information:
-- One <glossary word="primary key"/>
+- One <clientGlossary word="primary key"/>
 - A set of relevancy rules (based on presets and customization)
 - A list of synonyms and stop-words
 - Rules for each field of a document
@@ -37,13 +37,13 @@ The `uid` cannot be changed.
 
 ## Primary key
 
-The primary key is a <ClientOnly><glossary word="field"/></ClientOnly> present in all documents. This field is composed of a primary key <ClientOnly><glossary word="attribute"/></ClientOnly> name and it's unique value. All documents in a given index have the same primary key attribute, with each a unique value. The primary key's attribute name **must** be known by the index. There are [multiple ways to set your primary key](/guides/main_concepts/documents.md#setting-the-primary-key).
+The primary key is a <clientGlossary word="field"/> present in all documents. This field is composed of a primary key <clientGlossary word="attribute"/> name and it's unique value. All documents in a given index have the same primary key attribute, with each a unique value. The primary key's attribute name **must** be known by the index. There are [multiple ways to set your primary key](/guides/main_concepts/documents.md#setting-the-primary-key).
 
 [More information about the document primary key](/guides/main_concepts/documents.md#primary-key)
 
 ## Relevancy rules
 
-Each index has its own relevancy rules. By default, all indexes come with the same <ClientOnly><glossary word="ranking rules"/></ClientOnly> applied in the same order. Once you add your first document, from the order of the keys in this document, the index will be able to record which key is more important than another.
+Each index has its own relevancy rules. By default, all indexes come with the same <clientGlossary word="ranking rules"/> applied in the same order. Once you add your first document, from the order of the keys in this document, the index will be able to record which key is more important than another.
 
 For example, if your first document has the following keys in this order: `id, title, description, release_date`. A document containing the matching query in the `title` will be considered more relevant than a document where it is in `description`.
 

--- a/references/indexes.md
+++ b/references/indexes.md
@@ -79,7 +79,7 @@ This route takes as parameter an unique `uid` and **optionally** the [primary ke
 | Variable  | Description           |
 |-----------|-----------------------|
 | **index_uid** | The index unique identifier (*mandatory*)|
-| **primaryKey** | The <ClientOnly><glossary word="primary key" /></ClientOnly> of the documents  |
+| **primaryKey** | The <clientGlossary word="primary key" /> of the documents  |
 
 ```json
 {
@@ -129,7 +129,7 @@ Update an index.
 
 | Variable          | Description           |
 |-------------------|-----------------------|
-| **primaryKey** | The <ClientOnly><glossary word="primary key" /></ClientOnly> of the documents  |
+| **primaryKey** | The <clientGlossary word="primary key" /> of the documents  |
 
 The `uid` of an index cannot be changed.<br>
 The `primaryKey` can be added if it does not already exist (to know if it has been set, use [the get index route](/references/indexes.md#get-one-index)).


### PR DESCRIPTION
Because I could not add ClientOnly in the glossary component since the dom element `this.$el` became empty in the mounted() method, I created a middle-man component that wrapped the glossary. 