### PR TITLE
Adding linter and prettier fixes and tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,14 +9,6 @@ charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-[**.js]
-indent_style = space
-indent_size = 2
-
-[**.{css,scss}]
-indent_style = space
-indent_size = 2
-
-[**.html]
+[**.{js,vue,css,scss,html}]
 indent_style = space
 indent_size = 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+!.vuepress
+.vuepress/dist/
+.vuepress/theme/components/Navbar.vue
+.vuepress/theme/components/MeiliSearchBox.vue

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,37 @@
+module.exports = {
+    "env": {
+        "browser": true,
+        "es6": true,
+        "node": true
+    },
+    "extends": [
+      "standard",
+      'plugin:vue/recommended',
+      "plugin:prettier/recommended"
+    ],
+    "globals": {
+        "Atomics": "readonly",
+        "SharedArrayBuffer": "readonly"
+    },
+    "parserOptions": {
+        "parser": "babel-eslint",
+        "allowImportExportEverywhere": true,
+        "ecmaVersion": 2018,
+        "sourceType": "module"
+    },
+    "plugins": [
+        "vue",
+        "prettier"
+    ],
+    "rules": {
+      "vue/no-v-html":"off", //used in cases where HTML is needed
+      "prettier/prettier": "error",
+      'vue/max-attributes-per-line': [2, {
+        'singleline': 20,
+        'multiline': {
+           'max': 1,
+           'allowFirstLine': false
+         }
+      }]
+    }
+};

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -1,0 +1,25 @@
+---
+name: Check styling
+on: [pull_request]
+jobs:
+  build-deploy:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '12.x'
+
+    - name: Cache dependencies
+      uses: actions/cache@v1
+      with:
+        path: ~/.npm
+        key: ${{ runner.os }}-node-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-node-
+
+    - run: yarn install
+
+    - run: yarn check-style

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+node_modules/
+.yarn/
+.github/
+public/

--- a/.vuepress/components/ClientGlossary.vue
+++ b/.vuepress/components/ClientGlossary.vue
@@ -1,14 +1,15 @@
 <template>
-    <ClientOnly><glossary :word="word"/></ClientOnly>
+  <ClientOnly><glossary :word="word" /></ClientOnly>
 </template>
 
 <script>
 export default {
-    name: "clientGlossary",
-    props: {
-        'word': {
-            type: String
-        }
+  name: "ClientGlossary",
+  props: {
+    word: {
+      type: String,
+      default: "",
     },
-}
+  },
+};
 </script>

--- a/.vuepress/components/RouteHighlighter.vue
+++ b/.vuepress/components/RouteHighlighter.vue
@@ -1,12 +1,21 @@
 <template>
   <div class="route">
     <div>
-      <div class="method get" v-if="method.toLowerCase() === 'get'">GET</div>
-      <div class="method post" v-else-if="method.toLowerCase() === 'post'">POST</div>
-      <div class="method put" v-else-if="method.toLowerCase() === 'put'">PUT</div>
-      <div class="method delete" v-else-if="method.toLowerCase() === 'delete'">DELETE</div>
-      <div class="method" v-else>{{ method }}</div>
-
+      <div v-if="method.toLowerCase() === 'get'" class="method get">
+        GET
+      </div>
+      <div v-else-if="method.toLowerCase() === 'post'" class="method post">
+        POST
+      </div>
+      <div v-else-if="method.toLowerCase() === 'put'" class="method put">
+        PUT
+      </div>
+      <div v-else-if="method.toLowerCase() === 'delete'" class="method delete">
+        DELETE
+      </div>
+      <div v-else class="method">
+        {{ method }}
+      </div>
       <pre><code>{{ route }}</code></pre>
     </div>
   </div>
@@ -14,18 +23,26 @@
 
 <script>
 export default {
-  name: 'RouteHighlighter',
-  props: ['method', 'route'],
-  data () {
-    return {
-
-    }
-  }
-}
+  name: "RouteHighlighter",
+  props: {
+    method: {
+      type: String,
+      default: "",
+      validator: function (x) {
+        return ["get", "post", "put", "patch", "delete"].includes(
+          x.toLowerCase()
+        );
+      },
+      route: {
+        type: String,
+        default: "my/route",
+      },
+    },
+  },
+};
 </script>
 
 <style lang="css" scoped>
-
 div.route {
   display: inline-block;
   width: 100%;
@@ -70,5 +87,4 @@ div.route {
 .route > div > pre {
   border-radius: 0px 6px 6px 0px;
 }
-
 </style>

--- a/.vuepress/components/glossary.vue
+++ b/.vuepress/components/glossary.vue
@@ -1,102 +1,119 @@
 <template>
-    <span>
-        <span
-            class="tooltip-text"
-            v-on:mouseover="showTooltip"
-            v-on:mouseleave="hideTooltip"
-        >{{ word }}</span>
-        <div class="tooltip-content" v-html="content"></div>
+  <span>
+    <span
+      class="tooltip-text"
+      @mouseover="showTooltip"
+      @mouseleave="hideTooltip"
+    >
+      {{ word }}
     </span>
+    <div class="tooltip-content" v-html="content" />
+  </span>
 </template>
 
 <script>
-import { createPopper } from '@popperjs/core';
+import { createPopper } from "@popperjs/core";
 
 const glossary = {
-    'field': "A field is composed of an <b>attribute</b> and its associated data. <br><br> Ex: <code>attribute: 'data'</code>",
-    'attribute': "The key associated to some data in a field. <br><br> Ex:  <code>title: 'batman'</code> <br> title is the attribute in this example.",
-    'ranking rules': "Rules that are used by MeiliSearch to determine the relevancy of a document. <br><br> For example, the number of typos or the number of times the matching query is found in a document.",
-    'primary key': 'The attribute in a document of its unique identifier field. <br><br> Used by MeiliSearch to store the document. <br><br> Example: `movie_id` is the primary key of a movie document.',
-    'schemaless': 'This means you don\'t need to define or describe the structure of your data before adding data to an index. <br><br> For example, SQL\'s tables need schemas but mongodb\'s collections does not require it.',
-    'searchable': 'The data is used to determine the relevancy of a document when doing a search query.',
-    'displayed': 'The field is present in the document returned upon search.'
-}
+  field:
+    "A field is composed of an <b>attribute</b> and its associated data. <br><br> Ex: <code>attribute: 'data'</code>",
+  attribute:
+    "The key associated to some data in a field. <br><br> Ex:  <code>title: 'batman'</code> <br> title is the attribute in this example.",
+  "ranking rules":
+    "Rules that are used by MeiliSearch to determine the relevancy of a document. <br><br> For example, the number of typos or the number of times the matching query is found in a document.",
+  "primary key":
+    "The attribute in a document of its unique identifier field. <br><br> Used by MeiliSearch to store the document. <br><br> Example: <code>movie_id</code> is the primary key of a movie document.",
+  schemaless:
+    "This means you don't need to define or describe the structure of your data before adding data to an index. <br><br> For example, SQL's tables need schemas but mongodb's collections does not require it.",
+  searchable:
+    "The data is used to determine the relevancy of a document when doing a search query.",
+  displayed: "The field is present in the document returned upon search.",
+};
 
 export default {
-    props: {
-        'word': {
-            type: String,
-            validator: function (x) {
-                return glossary[x];
-            }
-        }
+  props: {
+    word: {
+      type: String,
+      default: "field",
+      validator: function (x) {
+        return glossary[x];
+      },
     },
-    data: () => {
-        return {
-            glossary,
-            content: ""
-        }
-    },
-    created () {
-        this.content = glossary[this.word] + "<div id='arrow' data-popper-arrow></div>";
-    },
-    methods: {
-        showTooltip() {
-            this.$el.querySelector('.tooltip-content').classList.remove("tooltip-hide");
+  },
+  data: () => {
+    return {
+      glossary,
+      content: "",
+    };
+  },
+  created() {
+    this.content =
+      glossary[this.word] + "<div id='arrow' data-popper-arrow></div>";
+  },
+  mounted() {
+    const text = this.$el.querySelector(".tooltip-text");
+    const tooltip = this.$el.querySelector(".tooltip-content");
+    createPopper(text, tooltip, {
+      placement: "top",
+      modifiers: [
+        {
+          name: "offset",
+          options: {
+            offset: [0, 8],
+          },
         },
-        hideTooltip() {
-            this.$el.querySelector('.tooltip-content').classList.add("tooltip-hide");
-        }
+      ],
+    });
+    this.hideTooltip();
+  },
+  methods: {
+    showTooltip() {
+      this.$el
+        .querySelector(".tooltip-content")
+        .classList.remove("tooltip-hide");
     },
-    mounted() {
-        const text = this.$el.querySelector('.tooltip-text');
-        const tooltip = this.$el.querySelector('.tooltip-content');
-        createPopper(text, tooltip, {
-            placement: 'top',
-            modifiers: [
-                {
-                    name: 'offset',
-                    options: {
-                        offset: [0, 8],
-                    },
-                },
-            ],
-        });
-        this.hideTooltip();
-    }
-}
+    hideTooltip() {
+      this.$el.querySelector(".tooltip-content").classList.add("tooltip-hide");
+    },
+  },
+};
 </script>
 
 <style>
-    .tooltip-hide {
-        visibility: hidden;
-    }
-    #arrow,
-    #arrow::before {
-        position: absolute;
-        width: 8px;
-        height: 8px;
-        z-index: -1;
-    }
-    #arrow::before {
-        content: '';
-        transform: rotate(45deg);
-        background: #333;
-    }
-    .tooltip-text {
-        font-style: italic;
-        border-bottom: 1px dotted grey;
-        position: relative;
-    }
-    .tooltip-content {
-        display: inline-block;
-        font-family: inherit !important;
-        background: rgba(0, 0, 0, 0.8);
-        color: white;
-        padding: 15px;
-        font-size: 13px;
-        border-radius: 4px;
-        z-index: 100;
-        max-width: 500px;
-    }
+.tooltip-hide {
+  visibility: hidden;
+}
+#arrow,
+#arrow::before {
+  position: absolute;
+  width: 8px;
+  height: 8px;
+  z-index: -1;
+}
+#arrow::before {
+  content: "";
+  transform: rotate(45deg);
+  background: #333;
+}
+.tooltip-text {
+  font-style: italic;
+  border-bottom: 1px dotted grey;
+  position: relative;
+}
+.tooltip-content {
+  display: inline-block;
+  font-family: inherit !important;
+  background: rgba(0, 0, 0, 0.8);
+  color: white;
+  padding: 15px;
+  font-size: 0.9rem;
+  border-radius: 4px;
+  z-index: 100;
+  max-width: 500px;
+}
+.tooltip-content code {
+  font-size: 0.9rem;
+  color: #7ec699;
+  background-color: rgba(18, 0, 0, 0.5);
+}
 </style>

--- a/.vuepress/components/linkButton.vue
+++ b/.vuepress/components/linkButton.vue
@@ -1,18 +1,22 @@
 <template>
   <div class="route">
-      <div>{{ text }}</div>
+    <div>{{ text }}</div>
   </div>
 </template>
 
 <script>
 export default {
-  name: 'linkButton',
-  props: ['text']
-}
+  name: "LinkButton",
+  props: {
+    text: {
+      type: String,
+      default: "",
+    },
+  },
+};
 </script>
 
 <style lang="css" scoped>
-
 div.route {
   display: block;
   text-align: center;
@@ -31,7 +35,5 @@ div.route {
   font-weight: bold;
   margin-left: auto;
   margin-right: auto;
-  width: 200px;
 }
-
 </style>

--- a/.vuepress/components/mermaid.vue
+++ b/.vuepress/components/mermaid.vue
@@ -1,18 +1,18 @@
 <template>
   <div class="mermaid">
-    <slot></slot>
+    <slot />
   </div>
 </template>
 
 <script>
 export default {
   beforeMount() {
-    import("mermaid/dist/mermaid").then(m => {
+    import("mermaid/dist/mermaid").then((m) => {
       m.initialize({
-        startOnLoad: true
+        startOnLoad: true,
       });
       m.init();
     });
-  }
+  },
 };
 </script>

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -122,9 +122,9 @@ module.exports = {
             "/resources/sdks",
             "/resources/comparison_to_alternatives",
             "/resources/faq",
-          ]
-        }
-      ]
+          ],
+        },
+      ],
     },
     meilisearch: {
       hostUrl: "https://e10b17e6.getmeili.com",

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,4 +1,4 @@
-let ogprefix = 'og: http://ogp.me/ns#'
+const ogprefix = "og: http://ogp.me/ns#";
 module.exports = {
   title: "MeiliSearch Documentation v0.9",
   description: "Open source Instant Search Engine",
@@ -11,21 +11,21 @@ module.exports = {
     sidebarDepth: 1,
     smoothScroll: true,
     nav: [
-      { text: 'Guides', link: '/guides/' },
-      { text: 'API References', link: '/references/' },
-      { text: 'Tutorials', link: '/tutorials/' },
-      { text: 'Resources', link: '/resources/' }
+      { text: "Guides", link: "/guides/" },
+      { text: "API References", link: "/references/" },
+      { text: "Tutorials", link: "/tutorials/" },
+      { text: "Resources", link: "/resources/" },
     ],
     sidebar: {
-      '/guides/': [
+      "/guides/": [
         {
           title: "🚀 Introduction",
-          path: '/guides/introduction/',
+          path: "/guides/introduction/",
           collapsable: false,
           children: [
             "/guides/introduction/quick_start_guide",
-            "/guides/introduction/whats_next"
-          ]
+            "/guides/introduction/whats_next",
+          ],
         },
         {
           title: "💡 Main concepts",
@@ -35,8 +35,8 @@ module.exports = {
             "/guides/main_concepts/indexes",
             "/guides/main_concepts/documents",
             "/guides/main_concepts/search",
-            "/guides/main_concepts/relevancy"
-          ]
+            "/guides/main_concepts/relevancy",
+          ],
         },
         {
           title: "📚 Advanced Guides",
@@ -54,20 +54,20 @@ module.exports = {
             "/guides/advanced_guides/typotolerance",
             "/guides/advanced_guides/concat",
             "/guides/advanced_guides/distinct",
-            "/guides/advanced_guides/bucket_sort"
-          ]
-        }
+            "/guides/advanced_guides/bucket_sort",
+          ],
+        },
       ],
-      '/download/': [
+      "/download/": [
         {
           title: "Download",
-          path:'/download/'
-        }
+          path: "/download/",
+        },
       ],
-      '/references/': [
+      "/references/": [
         {
-          title: '📒 API References',
-          path: '/references/',
+          title: "📒 API References",
+          path: "/references/",
           collapsable: false,
           children: [
             "/references/indexes",
@@ -76,13 +76,13 @@ module.exports = {
             "/references/updates",
             "/references/keys",
             {
-              title: 'Settings',
-              path: '/references/settings',
+              title: "Settings",
+              path: "/references/settings",
               collapsable: false,
               children: [
                 {
-                  title: 'All Settings',
-                  path: '/references/settings'
+                  title: "All Settings",
+                  path: "/references/settings",
                 },
                 "/references/synonyms",
                 "/references/stop_words",
@@ -91,34 +91,32 @@ module.exports = {
                 "/references/searchable_attributes",
                 "/references/displayed_attributes",
                 "/references/accept_new_fields",
-              ]
+              ],
             },
             "/references/stats",
             "/references/health",
             "/references/version",
-            "/references/sys-info"
-          ]
-        }
+            "/references/sys-info",
+          ],
+        },
       ],
-      '/tutorials/': [
+      "/tutorials/": [
         {
-          title: '🍳 Cookbooks',
-          path: '/tutorials/cookbooks/',
-          collapsable: false
+          title: "🍳 Cookbooks",
+          path: "/tutorials/cookbooks/",
+          collapsable: false,
         },
         {
-          title: '🧷 How to\'s',
-          path: '/tutorials/howtos/',
+          title: "🧷 How to's",
+          path: "/tutorials/howtos/",
           collapsable: false,
-          children: [
-            "/tutorials/howtos/quickstart"
-          ]
-        }
+          children: ["/tutorials/howtos/quickstart"],
+        },
       ],
-      '/resources/': [
+      "/resources/": [
         {
           title: "📦 Resources",
-          path: '/resources/',
+          path: "/resources/",
           collapsable: false,
           children: [
             "/resources/sdks",
@@ -129,65 +127,118 @@ module.exports = {
       ]
     },
     meilisearch: {
-      hostUrl: 'https://e10b17e6.getmeili.com',
-      indexUid: '9tz3lqoi',
-      apiKey: 'R62XWZPJG794YB5VFOADHTNQEKLCISM01U38',
+      hostUrl: "https://e10b17e6.getmeili.com",
+      indexUid: "9tz3lqoi",
+      apiKey: "R62XWZPJG794YB5VFOADHTNQEKLCISM01U38",
     },
-    searchPlaceholder: 'Search as you type...'
+    searchPlaceholder: "Search as you type...",
   },
   plugins: [
     ["check-md", { pattern: "**/*.md" }],
     ["sitemap", { hostname: "https://docs.meilisearch.com" }],
     ["seo", {}],
     "vuepress-plugin-element-tabs",
-    ['vuepress-plugin-container', { type: 'note' }]
+    ["vuepress-plugin-container", { type: "note" }],
   ],
   head: [
     ["meta", { charset: "utf-8" }],
-    ["meta", { name: "viewport", content: "width=device-width, initial-scale=1" }],
-    ["meta", {
-      property: "google-site-verification",
-      content: "u0OYrst4u5F16t0Vh4-EkO_sWE38Pp9aT7idfr0Ar9c"
-    }],
-    ["meta", { prefix: ogprefix, property: "og:title", content: "MeiliSearch Documentation" }],
+    [
+      "meta",
+      { name: "viewport", content: "width=device-width, initial-scale=1" },
+    ],
+    [
+      "meta",
+      {
+        property: "google-site-verification",
+        content: "u0OYrst4u5F16t0Vh4-EkO_sWE38Pp9aT7idfr0Ar9c",
+      },
+    ],
+    [
+      "meta",
+      {
+        prefix: ogprefix,
+        property: "og:title",
+        content: "MeiliSearch Documentation",
+      },
+    ],
     ["meta", { prefix: ogprefix, property: "og:type", content: "website" }],
-    ["meta", { prefix: ogprefix, property: "og:url", content: "http://docs.meilisearch.com" }],
-    ["meta", {
-      prefix: ogprefix, property: "og:image",
-      content:
-        "https://res.cloudinary.com/meilisearch/image/upload/v1582134509/og-image_dlbsnb.png"
-    }],
-    ["meta", {
-      prefix: ogprefix, property: "og:image-secure-url",
-      content:
-        "https://res.cloudinary.com/meilisearch/image/upload/v1582134509/og-image_dlbsnb.png"
-    }],
-    ["meta", {
-      prefix: ogprefix, property: "og:image-image-type",
-      content: "image/png"
-    }],
+    [
+      "meta",
+      {
+        prefix: ogprefix,
+        property: "og:url",
+        content: "http://docs.meilisearch.com",
+      },
+    ],
+    [
+      "meta",
+      {
+        prefix: ogprefix,
+        property: "og:image",
+        content:
+          "https://res.cloudinary.com/meilisearch/image/upload/v1582134509/og-image_dlbsnb.png",
+      },
+    ],
+    [
+      "meta",
+      {
+        prefix: ogprefix,
+        property: "og:image-secure-url",
+        content:
+          "https://res.cloudinary.com/meilisearch/image/upload/v1582134509/og-image_dlbsnb.png",
+      },
+    ],
+    [
+      "meta",
+      {
+        prefix: ogprefix,
+        property: "og:image-image-type",
+        content: "image/png",
+      },
+    ],
     ["meta", { prefix: ogprefix, property: "og:image-height", content: "630" }],
     ["meta", { prefix: ogprefix, property: "og:locale", content: "en_GB" }],
-    ["meta", { prefix: ogprefix, property: "og:site-name", content: "MeiliSearch Documentation" }],
-    ["meta", { property: "twitter:title", content: "MeiliSearch Documentation" }],
-    ["meta", {
-      property: "twitter:description",
-      content:
-        "The official documentation of MeiliSearch"
-    }],
-    ["meta", {
-      property: "twitter:image",
-      content:
-        "https://res.cloudinary.com/meilisearch/image/upload/v1582134509/og-image_dlbsnb.png"
-    }],
-    ["meta", {
-      property: "twitter:card",
-      content: "summary_large_image"
-    }],
-    ["meta", {
-      property: "twitter:image:alt",
-      content: "Next generation search API"
-    }],
+    [
+      "meta",
+      {
+        prefix: ogprefix,
+        property: "og:site-name",
+        content: "MeiliSearch Documentation",
+      },
+    ],
+    [
+      "meta",
+      { property: "twitter:title", content: "MeiliSearch Documentation" },
+    ],
+    [
+      "meta",
+      {
+        property: "twitter:description",
+        content: "The official documentation of MeiliSearch",
+      },
+    ],
+    [
+      "meta",
+      {
+        property: "twitter:image",
+        content:
+          "https://res.cloudinary.com/meilisearch/image/upload/v1582134509/og-image_dlbsnb.png",
+      },
+    ],
+    [
+      "meta",
+      {
+        property: "twitter:card",
+        content: "summary_large_image",
+      },
+    ],
+    [
+      "meta",
+      {
+        property: "twitter:image:alt",
+        content: "Next generation search API",
+      },
+    ],
     ["meta", { property: "twitter:site", content: "@meilisearch" }],
     [
       "script",
@@ -202,7 +253,7 @@ module.exports = {
           s.async=1;
           d.getElementsByTagName("head")[0].appendChild(s);
       })();
-    `
+    `,
     ],
     [
       "script",
@@ -219,7 +270,7 @@ module.exports = {
     })(document, window, '//analytics.meilisearch.com/tracker.js', 'fathom');
     fathom('set', 'siteId', 'XQNHD');
     fathom('trackPageview');
-    `
-    ]
-  ]
+    `,
+    ],
+  ],
 };

--- a/.vuepress/theme/components/MeiliSearchBox.vue
+++ b/.vuepress/theme/components/MeiliSearchBox.vue
@@ -15,21 +15,22 @@
 <script>
 export default {
   name: 'MeiliSearchBox',
-
-  props: ['options'],
-
+  props: {
+    options: {
+      type: Object,
+      default: () => ({})
+    }
+  },
   data () {
     return {
       placeholder: undefined
     }
   },
-
   watch: {
     options (newValue) {
       this.update(newValue)
     }
   },
-
   mounted () {
     this.initialize(this.options)
     this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
@@ -54,8 +55,8 @@ export default {
               this.$router.push(`${routepath}${hash}`)
             }
           }
-        );
-        docsSearchBar(input);
+        )
+        docsSearchBar(input)
       })
     },
 

--- a/.vuepress/theme/components/Navbar.vue
+++ b/.vuepress/theme/components/Navbar.vue
@@ -54,7 +54,7 @@ export default {
   computed: {
     meilisearchOptions () {
       return this.$themeLocaleConfig.meilisearch || this.$site.themeConfig.meilisearch || {}
-    },
+    }
 
   },
 
@@ -65,8 +65,8 @@ export default {
       if (document.documentElement.clientWidth < MOBILE_DESKTOP_BREAKPOINT) {
         this.linksWrapMaxWidth = null
       } else {
-        this.linksWrapMaxWidth = this.$el.offsetWidth - NAVBAR_VERTICAL_PADDING
-          - (this.$refs.siteName && this.$refs.siteName.offsetWidth || 0)
+        this.linksWrapMaxWidth = this.$el.offsetWidth - NAVBAR_VERTICAL_PADDING -
+          (this.$refs.siteName && this.$refs.siteName.offsetWidth || 0)
       }
     }
     handleLinksWrapWidth()

--- a/.vuepress/theme/index.js
+++ b/.vuepress/theme/index.js
@@ -1,5 +1,3 @@
-const path = require('path');
-
 module.exports = {
-  extend: '@vuepress/theme-default',
+  extend: "@vuepress/theme-default",
 };

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains the documentation for [MeiliSearch](https://github.com/
 
 Want to contribute to the documentation of MeiliSearch? You can do so by cloning this repository, making your change and submitting your pull request.
 
+Thank you for considering helping out!
+
 ### Install & Run
 
 ```bash
@@ -17,11 +19,38 @@ $ yarn install
 $ yarn dev
 ```
 
+### Testing
+
+A complete test can be done using this command:
+
+```
+$ yarn test
+```
+
+This will also trigger on `yarn build` and on any pull request to master.
+
 #### Check dead links
 
-It can be tough to make changes to the documentation without creating any dead links. You can check the dead links before making any pull request
+It can be tough to make changes to the documentation without creating any dead links. You can check the dead links before making any pull request.
+
 ```bash
 $ yarn check-links
+```
+
+#### Check Styling
+
+The documentation follows styling rules. All the following files will be checked: `*.vue`, `*.js`, and `*.md`.
+
+You can check out and fix the styling errors.
+
+```bash
+$ yarn style:fix
+```
+
+You can test if the code is well-formatted without fixing.
+
+```bash
+$ yarn check-style
 ```
 
 ### Deployment

--- a/guides/README.md
+++ b/guides/README.md
@@ -5,6 +5,7 @@ This guide is made to give you an overview of MeiliSearch. Every bit of informat
 If you want an even quicker overview we suggest [you look into our quickstart](/tutorials/howtos/quickstart).
 
 Content:
+
 - [🚀 Introduction](/guides/introduction/): Starting with MeiliSearch!
 - [💡 Main Concepts](/guides/main_concepts/): to understand the basics like indexes, documents and searches.
 - [📚 Advanced Guides](/guides/advanced_guides/): to deep dive into the advanced but accessible concepts of MeiliSearch.

--- a/guides/advanced_guides/README.md
+++ b/guides/advanced_guides/README.md
@@ -1,6 +1,7 @@
 # Advanced guides
 
 In the advanced guides you will find how to tune your search API and customize it:
+
 - [How to install MeiliSearch](installation.md)
 - [Search parameters](search_parameters.md)
 - [Keys](keys.md)

--- a/guides/advanced_guides/asynchronous_updates.md
+++ b/guides/advanced_guides/asynchronous_updates.md
@@ -6,7 +6,7 @@ Some operations are put in a queue and will be executed in turn (asynchronously)
 
 ### Async flow
 
-- When making a write request (*create/update/delete*) against the search engine, it stores the operation received in a queue and returns an `updateId`. With this id, the operation update is trackable.
+- When making a write request (_create/update/delete_) against the search engine, it stores the operation received in a queue and returns an `updateId`. With this id, the operation update is trackable.
 - Each update received is treated following the order it has been received.
 - You can get the update status on the [`/updates`](/references/updates.md) route.
 
@@ -28,21 +28,24 @@ sequenceDiagram
 ### Which operations are async?
 
 Every operation which could be compute-expensive is asynchronous. These include:
+
 - Update index settings
 - Add/update/delete documents
 
 ### Understanding updates
 
 Updates returns the following information:
-* **status**: The state of the operation (enqueued, processed, or failed).
-* **updateId**: The id of the update.
-* **type**: The type of the operation.
-* **enqueuedAt**: The date at which the operation has been added to the queue.
-* **processedAt**: The date at which the operation has been processed.
+
+- **status**: The state of the operation (enqueued, processed, or failed).
+- **updateId**: The id of the update.
+- **type**: The type of the operation.
+- **enqueuedAt**: The date at which the operation has been added to the queue.
+- **processedAt**: The date at which the operation has been processed.
 
 ### Examples
 
 Adding documents:
+
 ```json
 {
   "status": "processed",
@@ -58,6 +61,7 @@ Adding documents:
 ```
 
 Failing to upload document:
+
 ```json
 {
   "status": "failed",

--- a/guides/advanced_guides/concat.md
+++ b/guides/advanced_guides/concat.md
@@ -9,6 +9,7 @@ When searching for multiple words, a search is also done on the concatenation of
 #### Example
 
 A search on `The news paper` will also search for the following concatenated queries:
+
 - `Thenews paper`
 - `the newspaper`
 - `Thenewspaper`
@@ -19,7 +20,7 @@ This concatenation is done on a **maximum of 3 words**.
 
 ## Split Queries
 
-When you do a search, it **applies the splitting algorithm to every word** (*string separated by a space*).
+When you do a search, it **applies the splitting algorithm to every word** (_string separated by a space_).
 
 This consists of finding the most interesting place to separate the words and to create a parallel search query with this proposition.
 

--- a/guides/advanced_guides/distinct.md
+++ b/guides/advanced_guides/distinct.md
@@ -7,6 +7,7 @@ When a field is `distinct`, there will **never be two, or more, occurrence of th
 ### Example
 
 Let's use the sample of the following documents with 3 jackets of **different `colors`** but **same `skuid`**:
+
 ```json
 [
   {
@@ -26,7 +27,7 @@ Let's use the sample of the following documents with 3 jackets of **different `c
     "skuid": "abcdef",
     "name": "Really nice Jacket",
     "color": "green"
-  },
+  }
 ]
 ```
 

--- a/guides/advanced_guides/installation.md
+++ b/guides/advanced_guides/installation.md
@@ -8,28 +8,33 @@
 Download the **latest stable release** of MeiliSearch with **curl**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Brew
 Download the **latest stable release** of MeiliSearch with **Homebrew**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ brew update && brew install meilisearch
 $ meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Docker
 Using **Docker** you can choose to run [any available tags](https://hub.docker.com/r/getmeili/meilisearch/tags).
 
 This command starts the **latest stable release** of MeiliSearch.
+
 ```bash
 $ docker run -it --rm -p 7700:7700 -v $(pwd)/data.ms:/data.ms getmeili/meilisearch
 Server is listening on: http://0.0.0.0:7700
@@ -44,12 +49,14 @@ Docker is not persistent. You should share a volume to make your container files
 Download the **latest stable release** of MeiliSearch with **APT**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 $ apt update && apt install meilisearch-http
 $ meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Heroku
@@ -96,9 +103,6 @@ $ ./target/release/meilisearch
 
 ::::
 
-
-
-
 ## Usage
 
 ```
@@ -138,17 +142,17 @@ Server is listening on: http://127.0.0.1:7700
 
 Here is the list of **all Environment variables and Flags** (CLI options).
 
-| Environment Variable | CLI option     | Description                                                                                                                                                            | Default value      |
-|----------------------|----------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------|
-| MEILI_DB_PATH        | --db-path      | Define the location for the database files                                                                                                                                         | "./data.ms" |
-| MEILI_HTTP_ADDR      | --http-addr    | Address and port to listen to                                                                                                                                          | "127.0.0.1:7700"   |
-| MEILI_MASTER_KEY     | --master-key   | Default admin API key                                                                                                                                                  |                    |
-| MEILI_NO_ANALYTICS   | --no-analytics | Deactivate analytics. Analytics help us to know how many users are using our project, knowing which versions and which platforms are used. It is entirely anonymous. |                    |
-| MEILI_ENV   | --env | Defines the environment in which MeiliSearch is running. Can be `production` or `development` |  "development"  |
+| Environment Variable | CLI option     | Description                                                                                                                                                          | Default value    |
+| -------------------- | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
+| MEILI_DB_PATH        | --db-path      | Define the location for the database files                                                                                                                           | "./data.ms"      |
+| MEILI_HTTP_ADDR      | --http-addr    | Address and port to listen to                                                                                                                                        | "127.0.0.1:7700" |
+| MEILI_MASTER_KEY     | --master-key   | Default admin API key                                                                                                                                                |                  |
+| MEILI_NO_ANALYTICS   | --no-analytics | Deactivate analytics. Analytics help us to know how many users are using our project, knowing which versions and which platforms are used. It is entirely anonymous. |                  |
+| MEILI_ENV            | --env          | Defines the environment in which MeiliSearch is running. Can be `production` or `development`                                                                        | "development"    |
 
 ### Environments
 
 By default, MeiliSearch runs in `development` mode.
 
 - `Production`: the [master key](/guides/advanced_guides/keys.md) is **mandatory**.
-- `Development`: the [master key](/guides/advanced_guides/keys.md) is **optional**, and logs are output in "info" mode (*console output*).
+- `Development`: the [master key](/guides/advanced_guides/keys.md) is **optional**, and logs are output in "info" mode (_console output_).

--- a/guides/advanced_guides/keys.md
+++ b/guides/advanced_guides/keys.md
@@ -5,9 +5,9 @@ In MeiliSearch, there are three types of keys:
 - The **Master** key has access to all routes.
 - The **Private** key has access to all routes except the `/keys` routes.
 - The **Public** key has only access to the following routes:
-    - `GET /indexes/:index_uid/search`
-    - `GET /indexes/:index_uid/documents`
-    - `GET /indexes/:index_uid/documents/:doc_id`
+  - `GET /indexes/:index_uid/search`
+  - `GET /indexes/:index_uid/documents`
+  - `GET /indexes/:index_uid/documents/:doc_id`
 
 When a master key is given to MeiliSearch, the engine will automatically generate the private and the public key. **You cannot create additional keys**.
 

--- a/guides/advanced_guides/prefix.md
+++ b/guides/advanced_guides/prefix.md
@@ -18,15 +18,18 @@ Given a set of words in a dataset:
 
 query: `s`:
 response:
+
 - `show`
 - `shine`
 
 but not
+
 - `movies`
 - `musical`
 
 query: `sho`:
 response:
+
 - `show`
 
 Notice that a prefix search is only done for the last word of a query, other words must be of the same length but can contain typos.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -2,17 +2,17 @@
 
 Search parameters let the user customize his search request.
 
-| Query Parameter           | Description                                        | Default Value |
-|---------------------------|----------------------------------------------------|:-------------:|
-| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                     | query string _(mandatory)_                         |               |
-| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                | number of documents to skip                        | 0             |
-| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                 | number of documents returned                       | 20            |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**  | document attributes to show                        | *             |
-| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**      | which attributes to crop                           | none          |
-| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**            | limit length at which to crop specified attributes | 200           |
-| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | which attributes to highlight                      | none          |
-| **[filters](/guides/advanced_guides/search_parameters.md#filters)**               | attribute with an exact match                     | none          |
-| **[matches](/guides/advanced_guides/search_parameters.md#matches)**               | whether to return the raw matches or not           | false         |
+| Query Parameter                                                                                   | Description                                        | Default Value |
+| ------------------------------------------------------------------------------------------------- | -------------------------------------------------- | :-----------: |
+| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | query string _(mandatory)_                         |               |
+| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | number of documents to skip                        |       0       |
+| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | number of documents returned                       |      20       |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | document attributes to show                        |      \*       |
+| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | which attributes to crop                           |     none      |
+| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | limit length at which to crop specified attributes |      200      |
+| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | which attributes to highlight                      |     none      |
+| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | attribute with an exact match                      |     none      |
+| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | whether to return the raw matches or not           |     false     |
 
 ## Query (q)
 
@@ -52,7 +52,7 @@ Attributes of which the value will be cropped depending on the `cropLength` and 
 This is useful when you have specific needs for displaying results on the front-end application.
 :::
 
-**Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2 ` chars on each side of the first match.
+**Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2` chars on each side of the first match.
 
 #### Example
 
@@ -65,23 +65,23 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
 
 With a `cropLength` of 100 on `shifu` as a search query this is the response.
 
-Our **cropped version is in the _formatted object**.
+Our **cropped version is in the \_formatted object**.
 
 ```json
-   {
-      "id": "50393",
-      "title": "Kung Fu Panda Holiday",
-      "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-      "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
-      "release_date": 1290729600,
-      "_formatted": {
-        "id": "50393",
-        "title": "Kung Fu Panda Holiday",
-        "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-        "overview": "d his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade ",
-        "release_date": 1290729600
-      }
-    }
+{
+  "id": "50393",
+  "title": "Kung Fu Panda Holiday",
+  "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
+  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
+  "release_date": 1290729600,
+  "_formatted": {
+    "id": "50393",
+    "title": "Kung Fu Panda Holiday",
+    "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
+    "overview": "d his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade ",
+    "release_date": 1290729600
+  }
+}
 ```
 
 ## Crop length
@@ -104,26 +104,26 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d attributesToHighlight=overview
 ```
 
-Our **highlight version is in the _formatted object**.
+Our **highlight version is in the \_formatted object**.
 
 ```json
-    {
-      "id": "50393",
-      "title": "Kung Fu Panda Holiday",
-      "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-      "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
-      "release_date": 1290729600,
-      "_formatted": {
-        "id": "50393",
-        "title": "Kung Fu Panda Holiday",
-        "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-        "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year <em>Shifu</em> informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between <em>Shifu</em> and Mr. Ping.",
-        "release_date": 1290729600,
-      }
-    }
+{
+  "id": "50393",
+  "title": "Kung Fu Panda Holiday",
+  "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
+  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
+  "release_date": 1290729600,
+  "_formatted": {
+    "id": "50393",
+    "title": "Kung Fu Panda Holiday",
+    "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
+    "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year <em>Shifu</em> informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between <em>Shifu</em> and Mr. Ping.",
+    "release_date": 1290729600
+  }
+}
 ```
-The **overview attribute in formatted** looks like this when evaluated in HTML:
 
+The **overview attribute in formatted** looks like this when evaluated in HTML:
 
 The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year <em>**Shifu**</em> informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between <em>**Shifu**</em> and Mr. Ping.
 
@@ -143,11 +143,11 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
 
 ```json
 {
-  "id":"569367",
-  "title":"Nightshift",
-  "poster":"https://image.tmdb.org/t/p/w1280/peOeFl8ZTBTCERz5XQZAjYbXYsQ.jpg",
-  "overview":"Amy begins her first night shift in a hotel with a murderous past. Witnessing terrifying events and trapped within a loop, Amy must find a way to escape the flesh obsessed murderer and save residents of the hotel.",
-  "release_date":1536282000
+  "id": "569367",
+  "title": "Nightshift",
+  "poster": "https://image.tmdb.org/t/p/w1280/peOeFl8ZTBTCERz5XQZAjYbXYsQ.jpg",
+  "overview": "Amy begins her first night shift in a hotel with a murderous past. Witnessing terrifying events and trapped within a loop, Amy must find a way to escape the flesh obsessed murderer and save residents of the hotel.",
+  "release_date": 1536282000
 }
 ```
 
@@ -161,7 +161,6 @@ Returns an array of the search query occurrences in all fields. A search query o
 This is useful when you need to highlight the results without the default HTML highlighter.
 :::
 
-
 #### Example
 
 ```bash
@@ -171,23 +170,23 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
 ```
 
 ```json
-  {
-      "id": "50393",
-      "title": "Kung Fu Panda Holiday",
-      "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-      "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
-      "release_date": 1290729600,
-      "_matchesInfo": {
-        "overview": [
-          {
-            "start": 159,
-            "length": 5
-          },
-          {
-            "start": 361,
-            "length": 5
-          }
-        ]
+{
+  "id": "50393",
+  "title": "Kung Fu Panda Holiday",
+  "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
+  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
+  "release_date": 1290729600,
+  "_matchesInfo": {
+    "overview": [
+      {
+        "start": 159,
+        "length": 5
+      },
+      {
+        "start": 361,
+        "length": 5
       }
-    }
-  ```
+    ]
+  }
+}
+```

--- a/guides/advanced_guides/synonyms.md
+++ b/guides/advanced_guides/synonyms.md
@@ -18,6 +18,7 @@ There are several ways to associate words with each other.
 This makes it possible to determine that a word will be synonymous with another but not the other way around.
 
 example:
+
 ```
 phone => iphone
 ```
@@ -28,9 +29,9 @@ By searching `phone` you will get all results containing `iphone` with the same 
 
 To create a one-way synonym list this is the JSON that should be [added to the settings](/references/synonyms.md#update-synonyms).
 
-``` json
+```json
 {
-    "phone": ["iphone"]
+  "phone": ["iphone"]
 }
 ```
 
@@ -39,6 +40,7 @@ To create a one-way synonym list this is the JSON that should be [added to the s
 By associating one or more synonyms with each other, they will be considered the same in both directions.
 
 example:
+
 ```
 shoe <=> boot <=> slipper <=> sneakers
 ```
@@ -48,6 +50,7 @@ When a search is done with one of these words, all the others will be considered
 However, in the case of word to sentence or sentence to sentence
 
 example:
+
 ```
 "San Fransisco" <=> SF
 ```
@@ -58,9 +61,9 @@ The "San Fransisco" search will be considered less relevant than the "SF" search
 
 To create a multi-way synonym list this is the JSON that should be [added to the settings](/references/synonyms.md#update-synonyms).
 
-``` json
+```json
 {
-    "san francisco": ["sf"],
-    "sf": ["san francisco"]
+  "san francisco": ["sf"],
+  "sf": ["san francisco"]
 }
 ```

--- a/guides/advanced_guides/typotolerance.md
+++ b/guides/advanced_guides/typotolerance.md
@@ -5,6 +5,7 @@ MeiliSearch **is [typo tolerant](/guides/advanced_guides/typotolerance.md#typo-t
 #### Example
 
 On a movie dataset, let's search for `botman`.
+
 ```json
 {
   "hits": [

--- a/guides/introduction/README.md
+++ b/guides/introduction/README.md
@@ -3,9 +3,10 @@
 MeiliSearch has been developed to provide an easily integrated search solution. Each step of the implementation process has been designed to be **as simple as possible**.
 
 Contents :
--  🚀 Getting Started
-    * [Download and launch MeiliSearch](/guides/introduction/quick_start_guide.md#download-and-launch)
-    * [Create your index](/guides/introduction/quick_start_guide.md#create-your-index)
-    * [Add documents](/guides/introduction/quick_start_guide.md#add-documents)
-    * [Search!](/guides/introduction/quick_start_guide.md#searches)
+
+- 🚀 Getting Started
+  - [Download and launch MeiliSearch](/guides/introduction/quick_start_guide.md#download-and-launch)
+  - [Create your index](/guides/introduction/quick_start_guide.md#create-your-index)
+  - [Add documents](/guides/introduction/quick_start_guide.md#add-documents)
+  - [Search!](/guides/introduction/quick_start_guide.md#searches)
 - 👩‍🚀 [What's next ?](/guides/introduction/whats_next.md)

--- a/guides/introduction/quick_start_guide.md
+++ b/guides/introduction/quick_start_guide.md
@@ -11,28 +11,33 @@ First of all, let's run MeiliSearch.
 Download the **latest stable release** of MeiliSearch with **curl**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Brew
 Download the **latest stable release** of MeiliSearch with **Homebrew**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ brew update && brew install meilisearch
 $ meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Docker
 Using **Docker** you can choose to run [any available tags](https://hub.docker.com/r/getmeili/meilisearch/tags).
 
 This command starts the **latest stable release** of MeiliSearch.
+
 ```bash
 $ docker run -it --rm -p 7700:7700 -v $(pwd)/data.ms:/data.ms getmeili/meilisearch
 Server is listening on: http://0.0.0.0:7700
@@ -47,12 +52,14 @@ Docker is not persistent. You should share a volume to make your container files
 Download the **latest stable release** of MeiliSearch with **APT**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 $ apt update && apt install meilisearch-http
 $ meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Heroku
@@ -118,6 +125,7 @@ In order to be able to store our documents in an index, we have to create one fi
 ::: tab cURL
 
 [API references](/references/indexes.md)
+
 ```bash
 $ curl \
   -X POST 'http://localhost:7700/indexes' \
@@ -125,15 +133,17 @@ $ curl \
   "uid" : "movies"
 }'
 ```
+
 :::
 
 ::: tab JS
 
 ```js
 meili.createIndex({
-    uid: "movies"
-})
+  uid: "movies",
+});
 ```
+
 :::
 
 ::: tab Ruby
@@ -141,6 +151,7 @@ meili.createIndex({
 ```ruby
 client.create_index(uid: 'movies')
 ```
+
 :::
 
 ::: tab PHP
@@ -148,6 +159,7 @@ client.create_index(uid: 'movies')
 ```php
 $client->createIndex('movies');
 ```
+
 :::
 
 ::: tab Python
@@ -155,10 +167,10 @@ $client->createIndex('movies');
 ```python
 client.create_index(uid="movies")
 ```
+
 :::
 
 ::::
-
 
 ## Add Documents
 
@@ -170,30 +182,29 @@ To be processed by MeiliSearch, all documents need one common <clientGlossary wo
 
 There are [several ways to let MeiliSearch know what the primary key](/guides/main_concepts/documents.md#primary-key) is, the easiest way is to have an <clientGlossary word="attribute" /> that contains the string `id` case-insensitively.
 
-
 Let's use an example [movies.json dataset](https://github.com/meilisearch/MeiliSearch/blob/master/datasets/movies/movies.json) to showcase how to add documents.
-
 
 :::: tabs
 
 ::: tab Curl
 
 [API references](/references/documents.md)
+
 ```bash
 $ curl \
   -X POST 'http://localhost:7700/indexes/movies/documents' \
   --data @movies.json
 ```
+
 :::
 
 ::: tab JS
 
 ```js
-const movies = require('./movies.json')
-meili
-    .Index("movies")
-    .addDocuments(movies)
+const movies = require("./movies.json");
+meili.Index("movies").addDocuments(movies);
 ```
+
 :::
 
 ::: tab Ruby
@@ -201,6 +212,7 @@ meili
 ```ruby
 index.add_documents(movies)
 ```
+
 :::
 
 ::: tab PHP
@@ -208,6 +220,7 @@ index.add_documents(movies)
 ```php
 $index->addOrReplaceDocuments($movies);
 ```
+
 :::
 
 ::: tab Python
@@ -218,6 +231,7 @@ json_file = open('movies.json')
 data = json.load(json_file)
 response = index.add_documents(data)
 ```
+
 :::
 
 ::::
@@ -227,7 +241,6 @@ response = index.add_documents(data)
 In MeiliSearch, most actions are asynchronous. This lets you stack actions. They will be executed in the order in which they were made.
 
 You can [track the state of each action](/guides/advanced_guides/asynchronous_updates.md).
-
 
 ## Searches
 
@@ -248,24 +261,27 @@ MeiliSearch also offers an out-of-the-box [web interface](/guides/advanced_guide
 ::: tab Curl
 
 [API references](/references/search.md)
+
 ```bash
 $ curl \
   -X POST 'http://127.0.0.1:7700/indexes/12345678/search?q=botman'
 ```
+
 :::
 
 ::: tab JS
 
 ```js
 meili
-  .Index('movies')
+  .Index("movies")
   .search({
-    q: 'batman',
+    q: "batman",
   })
   .then((response) => {
-    console.log(response)
-  })
+    console.log(response);
+  });
 ```
+
 :::
 
 ::: tab Ruby
@@ -273,6 +289,7 @@ meili
 ```ruby
 index.search('botman')
 ```
+
 :::
 
 ::: tab PHP
@@ -280,6 +297,7 @@ index.search('botman')
 ```php
 $index->search('botman');
 ```
+
 :::
 
 ::: tab Python
@@ -289,11 +307,13 @@ index.search({
   'q': 'How to Train Your Dragon'
 })
 ```
+
 :::
 
 ::::
 
 MeiliSearch **response** :
+
 ```json
 {
   "hits": [

--- a/guides/introduction/whats_next.md
+++ b/guides/introduction/whats_next.md
@@ -8,9 +8,11 @@ In MeiliSearch, we have some concepts on which we build our search engine. If yo
 - [Relevancy](/guides/main_concepts/search.md)
 
 Finally, you can find the API references here:
+
 - [API References](/references/README.md)
 
 And the different resources here:
+
 - [SDKs](/resources/sdks.md)
 - [FAQ](/resources/faq.md)
 

--- a/guides/introduction/whats_next.md
+++ b/guides/introduction/whats_next.md
@@ -1,6 +1,7 @@
 # What's next?
 
 In MeiliSearch, we have some concepts on which we build our search engine. If you haven't read these pages yet, do not hesitate, they give an essential insight.
+
 - [Indexes](/guides/main_concepts/indexes.md)
 - [Documents](/guides/main_concepts/documents.md)
 - [Search](/guides/main_concepts/search.md)

--- a/guides/main_concepts/README.md
+++ b/guides/main_concepts/README.md
@@ -10,5 +10,5 @@ MeiliSearch is an **asynchronous** API. It means that when it does not behave li
 
 MeiliSearch uses the following terms inside the documentation. You should become familiar with them before continuing.
 
-* **[Index](indexes.md)**: Like a table in `SQL`. It's the entity that gathers all the documents of a given structure.
-* **[Document](documents.md)**: Object containing the defined attributes with their associated data.
+- **[Index](indexes.md)**: Like a table in `SQL`. It's the entity that gathers all the documents of a given structure.
+- **[Document](documents.md)**: Object containing the defined attributes with their associated data.

--- a/guides/main_concepts/documents.md
+++ b/guides/main_concepts/documents.md
@@ -93,11 +93,13 @@ The primary key **value** may contain only `A-Z a-z 0-9` and `-_` characters.
 #### Examples
 
 Good:
+
 ```json
 "id": "_Aabc012_"
 ```
 
 Bad:
+
 ```json
 "id": "@BI+* ^5h2%"
 ```

--- a/guides/main_concepts/documents.md
+++ b/guides/main_concepts/documents.md
@@ -55,12 +55,12 @@ In an index called `movie` there are 200k `documents`. Each of these 200k docume
 ```json
 [
   {
-    "movie_id" : "1564saqw12ss",
-    "title" : "Kung fu Panda"
+    "movie_id": "1564saqw12ss",
+    "title": "Kung fu Panda"
   },
   {
-    "movie_id" : "15k1j2kkw223s",
-    "title" : "Batman"
+    "movie_id": "15k1j2kkw223s",
+    "title": "Batman"
   }
 ]
 ```
@@ -96,9 +96,10 @@ Good:
 ```json
 "id": "_Aabc012_"
 ```
+
 Bad:
 ```json
 "id": "@BI+* ^5h2%"
 ```
 
-The document addition request in MeiliSearch is [atomic](https://en.wikipedia.org/wiki/Atomicity_(database_systems)). Thus, if you add 200 documents in one go and if one of the documents has a badly formatted primary key, an error will occur, and none of the documents will be added.
+The document addition request in MeiliSearch is <!-- prettier-ignore -->[atomic](https://en.wikipedia.org/wiki/Atomicity_(database_systems)). Thus, if you add 200 documents in one go and if one of the documents has a badly formatted primary key, an error will occur, and none of the documents will be added.

--- a/guides/main_concepts/indexes.md
+++ b/guides/main_concepts/indexes.md
@@ -5,11 +5,11 @@ An index is the collection of a certain type of data.
 It is, as a table in SQL, or a collection in MongoDB, an entity that collects a set of documents.
 
 An index is defined by an `uid` and contains the following information:
+
 - One <clientGlossary word="primary key"/>
 - A set of relevancy rules (based on presets and customization)
 - A list of synonyms and stop-words
 - Rules for each field of a document
-
 
 #### Example
 
@@ -26,13 +26,12 @@ The `uid` of an index is its **unique** identifier. It is the `:index_uid` param
 The uid is set on [index creation](/references/indexes.md#create-an-index). After which you cannot create another index with the same `uid`.
 The `uid` cannot be changed.
 
-
 ```json
 {
-    "uid": "movie",
-    "createdAt": "2019-11-20T09:40:33.711324Z",
-    "updatedAt": "2019-11-20T10:16:42.761858Z"
-  }
+  "uid": "movie",
+  "createdAt": "2019-11-20T09:40:33.711324Z",
+  "updatedAt": "2019-11-20T10:16:42.761858Z"
+}
 ```
 
 ## Primary key
@@ -71,6 +70,7 @@ In MeiliSearch, by default, every document field is searchable and returned on s
 The properties of the fields can be changed in the [settings](/references/settings.md).
 
 Fields can have the following properties:
+
 - Searchable
 - Displayed
 

--- a/guides/main_concepts/relevancy.md
+++ b/guides/main_concepts/relevancy.md
@@ -15,7 +15,6 @@ MeiliSearch has built-in ranking rules. These rules are essential to the relevan
 Each of the rules has a role in finding the right documents for the given search query.
 The order in which the rules are set in the settings affects their importance. The first rule is the most important, then the second and so on. By default, MeiliSearch has these rules in a specific order which meets the most standard needs. This order can be changed in the settings.
 
-
 Here is the list of all the rules that are executed in this specific order by default:
 
 #### 1. Typo
@@ -47,6 +46,7 @@ The more the query words are near each other, and in the right order in a docume
 The `attribute` rule sorts by ascending [attribute importance](/guides/main_concepts/relevancy.md#attributes-importance).
 
 #### 5. Words Position
+
 The `wordsPosition` rule sorts according to the position of the query words in the attribute. The start is better than the end.
 
 #### 6. Exactness
@@ -120,15 +120,9 @@ The `word position` rule orders by ascending matching word's index number.
 By default, the built-in rules are in a specific order that MeiliSearch consider the most suitable for common needs.
 
 ```json
-[
-  "typo",
-  "words",
-  "proximity",
-  "attribute",
-  "wordsPosition",
-  "exactness"
-]
+["typo", "words", "proximity", "attribute", "wordsPosition", "exactness"]
 ```
+
 Depending on your needs, you might want to change the order of the rules.
 You can use the [settings route](/references/ranking_rules.md#update-ranking-rules) of your index to do so.
 
@@ -148,11 +142,13 @@ Let's say we have a dataset of movies. The documents contain the fields `release
 ```
 desc(release_date)
 ```
+
 This will create a rule that makes recent movies more relevant than older ones.
 
 ```
 asc(movie_ranking)
 ```
+
 This will create a rule that makes movies with a good rank more relevant than others.
 
 To add this newly created rule to the existing ranking rule, using the [settings route](/references/ranking_rules.md#update-ranking-rules), you need to add the rule in the existing order array.
@@ -183,6 +179,7 @@ If you wish to specify the order of the attributes you can either define them in
 Possibly, you want to change the order after the documents have been added. This is still very possible.
 
 When a document is added to MeiliSearch, every new attribute inside will be added to two lists :
+
 - The [searchable attributes list](/references/searchable_attributes.md): attributes in which to search for matching query words.
 - The [displayed attributes list](/references/displayed_attributes.md): attributes in a document that are shown to the user.
 
@@ -195,10 +192,7 @@ To change this order, you need to send the sorted-list, in the order you want, u
 #### Example
 
 ```json
-[
-  "title",
-  "description",
-  "director"
-]
+["title", "description", "director"]
 ```
+
 With this new order, the matching words found in `title` will make the document more relevant than one with the same matching words found in `description` or `director`.

--- a/guides/main_concepts/search.md
+++ b/guides/main_concepts/search.md
@@ -2,7 +2,7 @@
 
 ## Finding documents
 
-When the query input is received, MeiliSearch is building a more complex query taking into account *typos*, n-grams, and *synonyms* if configured.
+When the query input is received, MeiliSearch is building a more complex query taking into account _typos_, n-grams, and _synonyms_ if configured.
 
 - _Typos_ - For example, if the query string is `botman`, MeiliSearch will return documents containing `batman`. [Read more about the typo rules](/guides/advanced_guides/typotolerance.md).
 - _N-grams_ - MeiliSearch is set to merge multi-words queries into a single word when searching for matching documents. Ex: Searching for `bat mobile` will return documents containing `batmobile`. Each word of the query will also be split in many ways so MeiliSearch can returns documents containing `new york` when querying for `newyork`. [Read more about Concatenate and Split Queries](/guides/advanced_guides/concat.md)
@@ -12,7 +12,7 @@ When the query input is received, MeiliSearch is building a more complex query t
 
 > It would not be a search engine if there was not a notion of relevancy in the results returned.
 
-When all documents corresponding to the request have been collected, *MeiliSearch sorts the documents* using a [bucket sort](/guides/advanced_guides/bucket_sort.md) and a list of built-in [ranking rules](/guides/main_concepts/relevancy.md#ranking-rules).
+When all documents corresponding to the request have been collected, _MeiliSearch sorts the documents_ using a [bucket sort](/guides/advanced_guides/bucket_sort.md) and a list of built-in [ranking rules](/guides/main_concepts/relevancy.md#ranking-rules).
 
 A bucket sort can be described as an ordered set of sorting rules. All the documents are sorted within the first rule, then documents that can not be distinguished will be sorted using the second rule, and so on. Thus, every document is not sorted for every rule, which induces a reduced compute time.
 Here is the ordered list of the default ranking rules used in MeiliSearch:
@@ -28,7 +28,7 @@ You can change the order of these rules, but you should know that these work wel
 
 ## Search options
 
-A lot of configuration can be made at *query-time* using the [search paramaters](/guides/advanced_guides/search_parameters.md). Here are some usage examples:
+A lot of configuration can be made at _query-time_ using the [search paramaters](/guides/advanced_guides/search_parameters.md). Here are some usage examples:
 
 - _Pagination_ - Results can be paginated using the query params `limit` and `offset`
 

--- a/index.md
+++ b/index.md
@@ -24,6 +24,7 @@ MeiliSearch is open-source. You can **support the project by starring** it on [o
 ## Demo
 
 ![crates.io demo gif](/crates-io-demo.gif)
+
 > Meili helps the Rust community find crates on [crates.meilisearch.com](https://crates.meilisearch.com)
 
 ## Alternatives
@@ -32,15 +33,15 @@ Why should you use MeiliSearch instead of any other existing solution? If it is 
 
 ## Features
 
-* **Instant Search** (answers < 50ms): Priority on fast answers for smooth search experience.
-* **Search as you type** (*prefix search*): Results are updated on each keystroke. To make this possible, we use a [prefix-search](/guides/advanced_guides/prefix.md#prefix-search).
-* [Typo tolerance](/guides/advanced_guides/typotolerance.md#typo-tolerance): Understands typo and spelling mistakes.
-* [Tokenization](https://en.wikipedia.org/wiki/Lexical_analysis#Tokenization) in English, kanji and latin based languages.
-* **Return the whole document**: The entire document is returned upon search.
-* **Highly customizable search and indexation**:
-    - [Custom ranking](/guides/main_concepts/relevancy.md): Customize the relevancy of the search engine and the ranking of the search results.
-    - [Stop words](/guides/advanced_guides/stop_words.md): Ignore common non-relevant words like `of` or `the`.
-    - [Highlights](/guides/advanced_guides/search_parameters.md#attributes-to-highlight): Highlighted search results in documents
-    - Ability to create [synonyms](/guides/advanced_guides/synonyms.md) for a better search experience.
-* **RESTful API**
-* **Friendly web interface**: [Integrated web interface](/guides/advanced_guides/web_interface) in MeiliSearch that lets you try the search engine when developing.
+- **Instant Search** (answers < 50ms): Priority on fast answers for smooth search experience.
+- **Search as you type** (_prefix search_): Results are updated on each keystroke. To make this possible, we use a [prefix-search](/guides/advanced_guides/prefix.md#prefix-search).
+- [Typo tolerance](/guides/advanced_guides/typotolerance.md#typo-tolerance): Understands typo and spelling mistakes.
+- [Tokenization](https://en.wikipedia.org/wiki/Lexical_analysis#Tokenization) in English, kanji and latin based languages.
+- **Return the whole document**: The entire document is returned upon search.
+- **Highly customizable search and indexation**:
+  - [Custom ranking](/guides/main_concepts/relevancy.md): Customize the relevancy of the search engine and the ranking of the search results.
+  - [Stop words](/guides/advanced_guides/stop_words.md): Ignore common non-relevant words like `of` or `the`.
+  - [Highlights](/guides/advanced_guides/search_parameters.md#attributes-to-highlight): Highlighted search results in documents
+  - Ability to create [synonyms](/guides/advanced_guides/synonyms.md) for a better search experience.
+- **RESTful API**
+- **Friendly web interface**: [Integrated web interface](/guides/advanced_guides/web_interface) in MeiliSearch that lets you try the search engine when developing.

--- a/index.md
+++ b/index.md
@@ -18,8 +18,8 @@ Our solution is **instant**; it **accepts typos**; it understands **filters**, *
 MeiliSearch is open-source. You can **support the project by starring** it on [our GitHub](https://github.com/meilisearch/MeiliSearch)!
 
 <a class="github-button" href="https://github.com/meilisearch/MeiliSearch" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star meilisearch/MeiliSearch on GitHub">Star</a>
-<a class="github-button" href="https://github.com/meilisearch/MeiliSearch/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="false" aria-label="Fork meilisearch/MeiliSearch on GitHub">Fork</a>
-<script async defer src="https://buttons.github.io/buttons.js"></script>
+<a class="github-button" href="https://github.com/meilisearch/MeiliSearch/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="false" aria-label="Fork meilisearch/MeiliSearch on GitHub">Fork</a><!-- prettier-ignore
+--><script async defer src="https://buttons.github.io/buttons.js"></script>
 
 ## Demo
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,18 @@
   "description": "Documentation for MeiliSearch",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "pretest": "yarn check-style",
+    "test": "yarn check-links",
+    "prebuild": "yarn test",
     "build": "vuepress build .",
     "dev": "vuepress dev",
-    "check-links": "vuepress check-md ."
+    "check-links": "vuepress check-md .",
+    "check-style": "yarn lint && yarn prettier-md-check",
+    "style:fix": "yarn lint:fix && yarn prettier:fix",
+    "lint": "npx eslint . --ext .js,.vue",
+    "lint:fix": "npx eslint . --ext .js,.vue --fix",
+    "prettier:fix": "prettier *.md **/*.md **/**/*.md --write",
+    "prettier-md-check": "prettier *.md **/*.md **/**/*.md --check"
   },
   "repository": {
     "type": "git",
@@ -24,12 +32,24 @@
     "@popperjs/core": "^2.1.1",
     "docs-searchbar.js": "^1.0.0",
     "mermaid": "^8.4.8",
+    "vue-eslint-parser": "^7.0.0",
     "vuepress": "^1.3.1",
     "vuepress-plugin-element-tabs": "^0.2.8",
     "vuepress-plugin-seo": "^0.1.2",
     "vuepress-plugin-sitemap": "^2.3.1"
   },
   "devDependencies": {
+    "babel-eslint": "^10.1.0",
+    "eslint": "^6.8.0",
+    "eslint-config-prettier": "^6.10.1",
+    "eslint-config-standard": "^14.1.1",
+    "eslint-plugin-import": "^2.20.1",
+    "eslint-plugin-node": "^11.0.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "eslint-plugin-promise": "^4.2.1",
+    "eslint-plugin-standard": "^4.0.1",
+    "eslint-plugin-vue": "^6.2.2",
+    "prettier": "2.0.2",
     "vuepress-plugin-check-md": "^0.0.2"
   }
 }

--- a/references/README.md
+++ b/references/README.md
@@ -58,6 +58,7 @@ Please read the [advanced part about keys](/guides/advanced_guides/keys.md) and 
 All errors contain a `JSON` body that explains the error.
 
 Response body:
+
 ```json
 {
   "message": "The error message"
@@ -70,7 +71,7 @@ MeiliSearch is an **asynchronous API**. It means that, in a lot of cases, you wi
 
 ```json
 {
-    "updateId": 2
+  "updateId": 2
 }
 ```
 

--- a/references/accept_new_fields.md
+++ b/references/accept_new_fields.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 `accept-new-fields` determines what MeiliSearch should do with new fields found during documents addition.
 
-When `accept-new-fields` is set to **true** (*default*), every new field will be added to the [searchable-attributes](/references/searchable_attributes.md) and the [displayed-attributes](/references/displayed_attributes.md) list.<br>
+When `accept-new-fields` is set to **true** (_default_), every new field will be added to the [searchable-attributes](/references/searchable_attributes.md) and the [displayed-attributes](/references/displayed_attributes.md) list.<br>
 When `accept-new-fields` is set to **false**, they will be stored but neither searchable or displayed on the returned documents.
 
 ::: tip
@@ -27,9 +27,9 @@ Get if MeiliSearch accepts new fields for an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -39,7 +39,6 @@ $ curl \
 ```
 
 #### Response: `200 Ok`
-
 
 ```json
 false
@@ -53,9 +52,9 @@ Update if MeiliSearch should accept new fields for an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
@@ -76,4 +75,5 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/displayed_attributes.md
+++ b/references/displayed_attributes.md
@@ -18,9 +18,9 @@ Get the displayed attributes of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -34,13 +34,7 @@ $ curl \
 List the settings.
 
 ```json
-[
-    "title",
-    "description",
-    "release_date",
-    "rank",
-    "poster"
-]
+["title", "description", "release_date", "rank", "poster"]
 ```
 
 ## Update displayed attributes
@@ -51,9 +45,9 @@ Update the displayed attributes of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
@@ -80,6 +74,7 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset displayed attributes
@@ -94,11 +89,12 @@ All attributes found in the documents added to the index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Example
+
 ```bash
 $ curl \
   -X DELETE 'http://localhost:7700/indexes/movies/settings/displayed-attributes'
@@ -111,4 +107,5 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/distinct_attribute.md
+++ b/references/distinct_attribute.md
@@ -18,9 +18,9 @@ Get the distinct attribute field of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -43,8 +43,8 @@ Update the distinct attribute field of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 #### Body
@@ -66,6 +66,7 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset distinct attribute
@@ -78,11 +79,12 @@ Reset the distinct attribute field of an index to its default value.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 #### Example
+
 ```bash
 $ curl \
   -X DELETE 'http://localhost:7700/indexes/movies/settings/distinct-attribute'
@@ -95,4 +97,5 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/documents.md
+++ b/references/documents.md
@@ -8,10 +8,10 @@ Get one document using its unique id.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
-| **document_id**    | [The document id](/guides/main_concepts/documents.md#primary-key) |
+| Variable        | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| **index_uid**   | The index UID                                                     |
+| **document_id** | [The document id](/guides/main_concepts/documents.md#primary-key) |
 
 ### Example
 
@@ -46,17 +46,17 @@ Documents are ordered by MeiliSearch depending on the hash of their id.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Query Parameters
 
-| Query Parameter           | Description                          | Default Value |
-|---------------------------|--------------------------------------|:-------------:|
-| **offset**                | number of documents to skip          | 0             |
-| **limit**                 | number of documents to take          | 20            |
-| **attributesToRetrieve**  | document attributes to show          | *             |
+| Query Parameter          | Description                 | Default Value |
+| ------------------------ | --------------------------- | :-----------: |
+| **offset**               | number of documents to skip |       0       |
+| **limit**                | number of documents to take |      20       |
+| **attributesToRetrieve** | document attributes to show |      \*       |
 
 ### Example
 
@@ -72,7 +72,8 @@ $ curl \
   {
     "id": 25684,
     "release_date": "1993-01-01",
-    "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg","title": "American Ninja 5",
+    "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
+    "title": "American Ninja 5",
     "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja."
   },
   {
@@ -97,15 +98,15 @@ For a partial update of the document see [add or update documents](/references/d
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Query Parameters
 
-| Query Parameter           | Description                          | Default Value |
-|---------------------------|--------------------------------------|:-------------:|
-| **primaryKey**    | The [primary key](/guides/main_concepts/documents.md#primary-key) of the documents _(optional)_| none |
+| Query Parameter | Description                                                                                     | Default Value |
+| --------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
+| **primaryKey**  | The [primary key](/guides/main_concepts/documents.md#primary-key) of the documents _(optional)_ |     none      |
 
 If you want to set the **primary key** of your index through this route, it only has to be done **the first time you add documents** to the index. After which it will be ignored if given.
 
@@ -150,6 +151,7 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Add or update documents
@@ -164,18 +166,17 @@ To completely overwrite a document, check out the [add and replace documents rou
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 If you want to set the **primary key** of your index through this route, it only has to be done **the first time you add documents** to the index. After which it will be ignored if given.
 
 #### Query Parameters
 
-| Query Parameter           | Description                          | Default Value |
-|---------------------------|--------------------------------------|:-------------:|
-| **primaryKey**    | The [primary key](/guides/main_concepts/documents.md#primary-key) of the documents _(optional)_| none |
-
+| Query Parameter | Description                                                                                     | Default Value |
+| --------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
+| **primaryKey**  | The [primary key](/guides/main_concepts/documents.md#primary-key) of the documents _(optional)_ |     none      |
 
 #### Body
 
@@ -209,6 +210,7 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete all documents
@@ -217,12 +219,10 @@ This `updateId` allows you to [track the current update](/references/updates.md)
 
 Delete all documents in the specified index.
 
-
-
 #### Path Variables
 
-| Variable  | Description           |
-|-----------|-----------------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 ### Example
@@ -239,6 +239,7 @@ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete one document
@@ -249,10 +250,10 @@ Delete one document based on its unique id.<br/>
 
 #### Path Variables
 
-| Variable  | Description           |
-|-----------|-----------------------|
-| **index_uid** | The index UID |
-| **document_id**    | [The document id](/guides/main_concepts/documents.md#primary-key) |
+| Variable        | Description                                                       |
+| --------------- | ----------------------------------------------------------------- |
+| **index_uid**   | The index UID                                                     |
+| **document_id** | [The document id](/guides/main_concepts/documents.md#primary-key) |
 
 ### Example
 
@@ -268,8 +269,8 @@ Delete one document based on its unique id.<br/>
   "updateId": 1
 }
 ```
-This `updateId` allows you to [track the current update](/references/updates.md).
 
+This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Delete documents
 
@@ -279,8 +280,8 @@ Delete a selection of documents based on array of document id's.<br/>
 
 #### Path Variables
 
-| Variable  | Description           |
-|-----------|-----------------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 #### Body
@@ -311,4 +312,5 @@ The body must be a **JSON Array** with the unique id's of the documents to delet
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/health.md
+++ b/references/health.md
@@ -1,6 +1,7 @@
 # Health
 
 ## Get health
+
 <RouteHighlighter method="GET" route="/health"/>
 
 Get health of MeiliSearch server.

--- a/references/indexes.md
+++ b/references/indexes.md
@@ -6,7 +6,6 @@
 
 List all indexes.
 
-
 ### Example
 
 ```bash
@@ -30,7 +29,6 @@ $ curl \
     "createdAt": "2019-11-20T09:40:33.711324Z",
     "updatedAt": "2019-11-20T10:16:42.761858Z"
   }
-
 ]
 ```
 
@@ -40,11 +38,10 @@ $ curl \
 
 Get information about an index.
 
-
 #### Path Variables
 
-| Variable  | Description           |
-|-----------|-----------------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 ### Example
@@ -75,11 +72,10 @@ This route takes as parameter an unique `uid` and **optionally** the [primary ke
 
 #### Body
 
-
-| Variable  | Description           |
-|-----------|-----------------------|
-| **index_uid** | The index unique identifier (*mandatory*)|
-| **primaryKey** | The <clientGlossary word="primary key" /> of the documents  |
+| Variable       | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| **index_uid**  | The index unique identifier (_mandatory_)                  |
+| **primaryKey** | The <clientGlossary word="primary key" /> of the documents |
 
 ```json
 {
@@ -100,6 +96,7 @@ $ curl \
 ```
 
 #### Response: `201 created`
+
 ```json
 {
   "uid": "movies",
@@ -117,19 +114,17 @@ This `updateId` allows you to [track the current update](/references/updates.md)
 
 Update an index.
 
-
 #### Path Variables
 
-| Variable  | Description           |
-|-----------|-----------------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
-
 
 #### Body
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **primaryKey** | The <clientGlossary word="primary key" /> of the documents  |
+| Variable       | Description                                                |
+| -------------- | ---------------------------------------------------------- |
+| **primaryKey** | The <clientGlossary word="primary key" /> of the documents |
 
 The `uid` of an index cannot be changed.<br>
 The `primaryKey` can be added if it does not already exist (to know if it has been set, use [the get index route](/references/indexes.md#get-one-index)).
@@ -151,7 +146,7 @@ $ curl \
 ```json
 {
   "uid": "movie_review",
-  "primaryKey" : "movie_review_id",
+  "primaryKey": "movie_review_id",
   "createdAt": "2019-11-20T09:40:33.711324Z",
   "updatedAt": "2019-11-20T10:16:42.761858Z"
 }
@@ -165,9 +160,9 @@ Delete an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID        |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 

--- a/references/keys.md
+++ b/references/keys.md
@@ -5,6 +5,7 @@ Each instance of MeiliSearch has three keys: a master, a private, and a public. 
 You must have the master key to access the `keys` route.
 
 [More information about the keys and their rights](/guides/advanced_guides/keys.md).
+
 ## Get keys
 
 <RouteHighlighter method="GET" route="/keys"/>

--- a/references/ranking_rules.md
+++ b/references/ranking_rules.md
@@ -18,9 +18,9 @@ Get the ranking rules of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -35,13 +35,13 @@ List the settings.
 
 ```json
 [
-    "typo",
-    "words",
-    "proximity",
-    "attribute",
-    "wordsPosition",
-    "exactness",
-    "dsc(release_date)",
+  "typo",
+  "words",
+  "proximity",
+  "attribute",
+  "wordsPosition",
+  "exactness",
+  "dsc(release_date)"
 ]
 ```
 
@@ -53,9 +53,9 @@ Update the ranking rules of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
@@ -91,6 +91,7 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset ranking rules
@@ -102,23 +103,18 @@ Reset the [ranking rules](/guides/main_concepts/relevancy.md#ranking-rules) of a
 #### Default value
 
 Array with the [built-in ranking rules](/guides/main_concepts/relevancy.md#order-of-the-rules) ordered by importance.
+
 ```json
-[
-    "typo",
-    "words",
-    "proximity",
-    "attribute",
-    "wordsPosition",
-    "exactness"
-]
+["typo", "words", "proximity", "attribute", "wordsPosition", "exactness"]
 ```
+
 To remove all ranking rules, which is not recommended for any use-case, you should send an empty array on the [add or replace ranking rules route](/references/ranking_rules.md#update-ranking-rules).
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Example
 
@@ -134,4 +130,5 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/search.md
+++ b/references/search.md
@@ -8,23 +8,23 @@ Search for documents matching a specific query in the given index.
 
 #### Path Variables
 
-| Variable  | Description   |
-|-----------|---------------|
+| Variable      | Description   |
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 #### Query Parameters
 
 | Query Parameter           | Description                                        | Default Value |
-|---------------------------|----------------------------------------------------|:-------------:|
+| ------------------------- | -------------------------------------------------- | :-----------: |
 | **q**                     | query string _(mandatory)_                         |               |
-| **offset**                | number of documents to skip                        | 0             |
-| **limit**                 | number of documents to take                        | 20            |
-| **attributesToRetrieve**  | document attributes to show                        | *             |
-| **attributesToCrop**      | which attributes to crop                           | none          |
-| **cropLength**            | limit length at which to crop specified attributes | 200           |
-| **attributesToHighlight** | which attributes to highlight                      | none          |
-| **filters**               | attribute with an exact match                     | none          |
-| **matches**               | whether to return the raw matches or not           | false         |
+| **offset**                | number of documents to skip                        |       0       |
+| **limit**                 | number of documents to take                        |      20       |
+| **attributesToRetrieve**  | document attributes to show                        |      \*       |
+| **attributesToCrop**      | which attributes to crop                           |     none      |
+| **cropLength**            | limit length at which to crop specified attributes |      200      |
+| **attributesToHighlight** | which attributes to highlight                      |     none      |
+| **filters**               | attribute with an exact match                      |     none      |
+| **matches**               | whether to return the raw matches or not           |     false     |
 
 > `filters` takes `key:value` as parameter, with the key to be the name of the field to filter, and the value the filter to be applied on this field, e.g.: `filters=first_name:John`. Only a single filter is supported in a query.
 

--- a/references/searchable_attributes.md
+++ b/references/searchable_attributes.md
@@ -18,9 +18,9 @@ Get the searchable attributes of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -34,11 +34,7 @@ $ curl \
 List the settings.
 
 ```json
-[
-    "title",
-    "description",
-    "uid",
-]
+["title", "description", "uid"]
 ```
 
 ## Update searchable attributes
@@ -49,9 +45,9 @@ Update the searchable attributes of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
@@ -80,6 +76,7 @@ A match in title will make a document more relevant than another document with a
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset searchable attributes
@@ -94,9 +91,9 @@ All attributes found in the documents added to the index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Example
 
@@ -112,4 +109,5 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/settings.md
+++ b/references/settings.md
@@ -5,6 +5,7 @@
 It is possible to update all the settings in one go or individually with the dedicated routes.
 
 These are the reference pages for the dedicated routes:
+
 - [Synonyms](/references/synonyms.md)
 - [Stop-words](/references/stop_words.md)
 - [Ranking rules](/references/ranking_rules.md)
@@ -25,9 +26,9 @@ Get the settings of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -43,31 +44,27 @@ List the settings.
 ```json
 {
   "rankingRules": [
-      "typo",
-      "words",
-      "proximity",
-      "attribute",
-      "wordsPosition",
-      "exactness",
-      "dsc(release_date)",
+    "typo",
+    "words",
+    "proximity",
+    "attribute",
+    "wordsPosition",
+    "exactness",
+    "dsc(release_date)"
   ],
   "rankingDistinct": null,
-  "searchableAttributes": [
-      "title",
-      "description",
-      "uid",
-  ],
+  "searchableAttributes": ["title", "description", "uid"],
   "displayedAttributes": [
-      "title",
-      "description",
-      "release_date",
-      "rank",
-      "poster",
+    "title",
+    "description",
+    "release_date",
+    "rank",
+    "poster"
   ],
   "stopWords": null,
   "synonyms": {
-      "wolverine": ["xmen", "logan"],
-      "logan": ["wolverine", "xmen"],
+    "wolverine": ["xmen", "logan"],
+    "logan": ["wolverine", "xmen"]
   },
   "indexNewFields": false
 }
@@ -81,21 +78,21 @@ Update the settings of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
-| Variable          | Type | Description | Default value |
-|-------------------|-----------------------| --- | --- |
-| **rankingRules** | [Strings] | Ranking rules in their order of importance | [built-in ranking rules list in order](/guides/main_concepts/relevancy.md#order-of-the-rules) |
-| **rankingDistinct** | String | Returns only distinct (different) values of the given field | `null` |
-| **searchableAttributes** | [Strings] | Fields in which to search for matching query words (*ordered by importance*) | All attributes found in the documents |
-| **displayedAttributes** | [Strings] | Fields present in the returned documents | All attributes found in the documents |
-| **stopWords** | [Strings] | Words in the search query that will be ignored | `[]` |
-| **synonyms** | Object | List of associated words that are considered the same in a search query | `{}` |
-| **indexNewFields** | Boolean | New fields in newly added document are/aren't added to MeiliSearch | `true` |
+| Variable                 | Type      | Description                                                                  | Default value                                                                                 |
+| ------------------------ | --------- | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **rankingRules**         | [Strings] | Ranking rules in their order of importance                                   | [built-in ranking rules list in order](/guides/main_concepts/relevancy.md#order-of-the-rules) |
+| **rankingDistinct**      | String    | Returns only distinct (different) values of the given field                  | `null`                                                                                        |
+| **searchableAttributes** | [Strings] | Fields in which to search for matching query words (_ordered by importance_) | All attributes found in the documents                                                         |
+| **displayedAttributes**  | [Strings] | Fields present in the returned documents                                     | All attributes found in the documents                                                         |
+| **stopWords**            | [Strings] | Words in the search query that will be ignored                               | `[]`                                                                                          |
+| **synonyms**             | Object    | List of associated words that are considered the same in a search query      | `{}`                                                                                          |
+| **indexNewFields**       | Boolean   | New fields in newly added document are/aren't added to MeiliSearch           | `true`                                                                                        |
 
 Any parameters not provided will be left unchanged.
 
@@ -154,6 +151,7 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset settings
@@ -164,24 +162,24 @@ Reset the settings of an index.
 
 All settings will be reset to their default value.
 
-| Variable          |  Description | Default value |
-|-------------------|-----------------------| --- | --- |
-| **rankingRules**  | Ranking rules in their order of importance  | [built-in ranking rules list in order](/guides/main_concepts/relevancy.md#order-of-the-rules) |
-| **rankingDistinct** | Returns only distinct (different) values of the given field | `null` |
-| **searchableAttributes** | Fields in which to search for matching query words (*ordered by importance*) | All attributes found in the documents |
-| **displayedAttributes** | Fields present in the returned documents | All attributes found in the documents |
-| **stopWords** | Words in the search query that will be ignored | `[]` |
-| **synonyms** | List of associated words that are considered the same in a search query | `{}` |
-| **indexNewFields** | New fields in newly added document are/aren't added to MeiliSearch | `true` |
+| Variable                 | Description                                                                  | Default value                                                                                 |
+| ------------------------ | ---------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| **rankingRules**         | Ranking rules in their order of importance                                   | [built-in ranking rules list in order](/guides/main_concepts/relevancy.md#order-of-the-rules) |
+| **rankingDistinct**      | Returns only distinct (different) values of the given field                  | `null`                                                                                        |
+| **searchableAttributes** | Fields in which to search for matching query words (_ordered by importance_) | All attributes found in the documents                                                         |
+| **displayedAttributes**  | Fields present in the returned documents                                     | All attributes found in the documents                                                         |
+| **stopWords**            | Words in the search query that will be ignored                               | `[]`                                                                                          |
+| **synonyms**             | List of associated words that are considered the same in a search query      | `{}`                                                                                          |
+| **indexNewFields**       | New fields in newly added document are/aren't added to MeiliSearch           | `true`                                                                                        |
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**         | The index UID |
-
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Example
+
 ```bash
 $ curl \
   -X DELETE 'http://localhost:7700/indexes/movies/settings'
@@ -194,4 +192,5 @@ $ curl \
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/stats.md
+++ b/references/stats.md
@@ -6,12 +6,11 @@
 
 Get stats of an index.
 
-
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -36,15 +35,11 @@ $ curl \
 }
 ```
 
-
-
 ## Get stats of all indexes
 
 <RouteHighlighter method="GET" route="/stats"/>
 
 Get stats of all indexes.
-
-
 
 ### Example
 

--- a/references/stop_words.md
+++ b/references/stop_words.md
@@ -18,9 +18,9 @@ Get the [stop-words](/guides/advanced_guides/stop_words.md) list of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -32,7 +32,7 @@ $ curl \
 #### Response: `200 Ok`
 
 ```json
-["of","the","to"]
+["of", "the", "to"]
 ```
 
 ## Update stop-words
@@ -43,15 +43,15 @@ Update the list of [stop-words](/guides/advanced_guides/stop_words.md) of an ind
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
 An array of strings containing the [stop-words](/guides/advanced_guides/stop_words.md).
 
-If a list of stop-words already exists it will be overwritten (*replaced*).
+If a list of stop-words already exists it will be overwritten (_replaced_).
 
 ### Example
 
@@ -65,9 +65,10 @@ $ curl \
 
 ```json
 {
-  "updateId": 1,
+  "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset stop-words
@@ -82,9 +83,9 @@ Empty array: `[]`
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -97,7 +98,8 @@ $ curl \
 
 ```json
 {
-  "updateId": 1,
+  "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/synonyms.md
+++ b/references/synonyms.md
@@ -18,11 +18,12 @@ Get the list of synonyms of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Example
+
 ```bash
  curl \
   -X GET 'http://localhost:7700/indexes/12345678/settings/synonyms'
@@ -32,17 +33,9 @@ Get the list of synonyms of an index.
 
 ```json
 {
- "wolverine": [
-   "xmen",
-   "logan"
-  ],
-  "logan": [
-    "wolverine",
-    "xmen"
-  ],
-  "wow": [
-    "world of warcraft"
-  ]
+  "wolverine": ["xmen", "logan"],
+  "logan": ["wolverine", "xmen"],
+  "wow": ["world of warcraft"]
 }
 ```
 
@@ -54,15 +47,16 @@ Update the list of synonyms of an index.
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Body
 
 An object with every synonym and its associated words.
 
 #### Example
+
 ```bash
  curl \
   -X POST 'http://localhost:7700/indexes/12345678/settings/synonyms' \
@@ -80,6 +74,7 @@ An object with every synonym and its associated words.
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).
 
 ## Reset synonyms
@@ -94,11 +89,12 @@ Empty object : `{}`
 
 #### Path Variables
 
-| Variable          | Description           |
-|-------------------|-----------------------|
-| **index_uid**     | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 #### Example
+
 ```bash
  curl \
   -X DELETE 'http://localhost:7700/indexes/12345678/settings/synonyms'
@@ -111,4 +107,5 @@ Empty object : `{}`
   "updateId": 1
 }
 ```
+
 This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/sys-info.md
+++ b/references/sys-info.md
@@ -6,8 +6,6 @@
 
 Get pretty system information.
 
-
-
 ### Example
 
 ```bash

--- a/references/updates.md
+++ b/references/updates.md
@@ -9,7 +9,7 @@ Get the status of an [update](/guides/advanced_guides/asynchronous_updates.md) i
 #### Path Variables
 
 | Variable      | Description           |
-|---------------|-----------------------|
+| ------------- | --------------------- |
 | **index_uid** | The index UID         |
 | **updateId**  | The update identifier |
 
@@ -46,9 +46,9 @@ Get the status of all [updates](/guides/advanced_guides/asynchronous_updates.md)
 
 #### Path Variables
 
-| Variable      | Description           |
-|---------------|-----------------------|
-| **index_uid** | The index UID         |
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
 
 ### Example
 

--- a/references/version.md
+++ b/references/version.md
@@ -6,8 +6,6 @@
 
 Get version of MeiliSearch.
 
-
-
 ### Example
 
 ```bash

--- a/resources/README.md
+++ b/resources/README.md
@@ -1,4 +1,5 @@
 Content:
+
 - [SDKs](/resources/sdks.md)
 - [Comparison to alternatives](/resources/comparison_to_alternatives.md)
 - [FAQ](/resources/faq.md)

--- a/resources/comparison_to_alternatives.md
+++ b/resources/comparison_to_alternatives.md
@@ -43,9 +43,10 @@ MeiliSearch currently delivers a search engine and is not in a position to provi
 Apache Lucene is a free and open-source search library, written in Java, used for the full-text indexing and search of documents. This project was first created in 1999 by Doug Cutting, who had previously written search engines at Xerox's Palo Alto Research Center (PARC) and Apple. Since Lucene has been developed to build web search applications such as Google, you can see that DuckDuckGo still uses it for some specific searches.
 
 Lucene has since been divided into several projects:
-* **Lucene itself**: the full-text search library.
-* **Solr**: an enterprise search server with a powerful REST API.
-* **Nutch**: an extensible and scalable web crawler relying on Apache Hadoop.
+
+- **Lucene itself**: the full-text search library.
+- **Solr**: an enterprise search server with a powerful REST API.
+- **Nutch**: an extensible and scalable web crawler relying on Apache Hadoop.
 
 Since Lucene is the technology behind many open source or closed source search engines, it is considered as the reference search library.
 
@@ -76,7 +77,6 @@ Bleve and Tantivy are search engine projects, respectively written in Golang and
 Elasticsearch is a search engine based on the Lucene library and is most popular for full-text search. It provides a REST API accessed by JSON over HTTP. One of its key options, called index sharding, gives you the ability to divide indexes into physical spaces in order to increase performance and ensure high availability. Both Lucene and Elasticsearch have been designed for processing high-volume data streams, analyzing logs, and running complex queries. You can perform operations and analysis (e.g., calculate the average age of all users named "Thomas") on documents that match a specified query.
 
 Today, Lucene and Elasticsearch are dominant players in the open-source search engine landscape. They both are solid solutions for a lot of different use cases in search, and also for building your own recommendation engine. They are good general products, but they require to be configured properly to get similar results to those of MeiliSearch or Algolia.
-
 
 ### Closed Source
 

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -48,7 +48,7 @@ It means that in many cases (e.g., documents addition), you will receive as serv
 
 ```json
 {
-    "updateId": 2
+  "updateId": 2
 }
 ```
 
@@ -70,35 +70,39 @@ In case of a [document addition](/references/documents.md#add-or-replace-documen
 The `400 - Invalid data` response probably means that your data is not in an expected format.
 
 Most common errors:
+
 - Extraneous comma at the end of a line.
 - Data is not an array of objects: for the [document addition route](/references/documents.md#add-or-replace-documents), MeiliSearch only accepts an array in the body even if there is only one document.
 
 Wrong:
+
 ```json
-{ "id": 123,  "title": "Pride and Prejudice" }
+{ "id": 123, "title": "Pride and Prejudice" }
 ```
 
 Good:
+
 ```json
-[
-    { "id": 123,  "title": "Pride and Prejudice" }
-]
+[{ "id": 123, "title": "Pride and Prejudice" }]
 ```
 
 :::tip
 The [jq](https://github.com/stedolan/jq) command line tool can greatly help you check the format of your data.
+
 ```bash
 $ cat your_file.json | jq
 ```
+
 :::
 
 ## My document upload failed with the `document id is missing` error.
 
 ::: note TLDR;
 Most common reasons:
+
 - A unique identifier in your document is missing.
 - The unique identifier of your document is not well-formatted.
-:::
+  :::
 
 Each document is required to contain a unique identifier. This identifier attribute is the `primary key`.
 
@@ -111,11 +115,13 @@ If you get a `document id is missing` error, the primary key was not recognized.
 Note that the primary key value must contain only `A-Z a-z 0-9` and `-_` characters.
 
 Wrong:
+
 ```json
 "id": "@BI+* ^5h2%"
 ```
 
 Good:
+
 ```json
 "id": "_Aabc012_"
 ```
@@ -154,6 +160,7 @@ For more accurate features and issues, everything is detailed in the issues of a
 ## How can I contact the MeiliSearch team?
 
 There are many ways to contact us:
+
 - At [bonjour@meilisearch.com](mailto:bonjour@meilisearch.com): English or French is welcome! 🇫🇷 🇬🇧
 - Via the chat box at the bottom right of this page which is available on every page of this documentation and on [our landing page](https://www.meilisearch.com/).
 - By opening an issue in the [MeiliSearch repository](https://github.com/meilisearch/MeiliSearch) or in the [documentation repository](https://github.com/meilisearch/documentation/) depending on your need.

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -3,5 +3,6 @@
 The purpose of this part is to provide solutions to different concrete use-cases of MeiliSearch.
 
 Here is the content:
+
 - [Cookbooks](/tutorials/cookbooks/): coming soon.
 - [How to's](/tutorials/howtos/).

--- a/tutorials/howtos/quickstart.md
+++ b/tutorials/howtos/quickstart.md
@@ -12,28 +12,33 @@ You can deploy the server on your own machine. It will listen to HTTP requests o
 Download the **latest stable release** of MeiliSearch with **curl**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ curl -L https://install.meilisearch.com | sh
 $ ./meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Brew
 Download the **latest stable release** of MeiliSearch with **Homebrew**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ brew update && brew install meilisearch
 $ meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Docker
 Using **Docker** you can choose to run [any available tags](https://hub.docker.com/r/getmeili/meilisearch/tags).
 
 This command starts the **latest stable release** of MeiliSearch.
+
 ```bash
 $ docker run -it --rm -p 7700:7700 -v $(pwd)/data.ms:/data.ms getmeili/meilisearch
 Server is listening on: http://0.0.0.0:7700
@@ -48,12 +53,14 @@ Docker is not persistent. You should share a volume to make your container files
 Download the **latest stable release** of MeiliSearch with **APT**.
 
 Launch MeiliSearch to start the server.
+
 ```bash
 $ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
 $ apt update && apt install meilisearch-http
 $ meilisearch
 Server is listening on: http://127.0.0.1:7700
 ```
+
 :::
 
 ::: tab Heroku
@@ -66,13 +73,11 @@ You can deploy the latest stable build of MeiliSearch straight on Heroku.
   </a>
 </p>
 
-
 The deploy can take up to 20 minutes because it will compile the whole project from the GitHub repository.
 
 ::: warning
 The [Heroku filesystem is ephemeral](https://help.heroku.com/K1PPS2WM/why-are-my-file-uploads-missing-deleted), which means you may lose your data on any restart of the Heroku instance. **The Heroku deploy is okay for testing purposes, but it won't work for production.**
 :::
-
 
 ::: tab Source
 
@@ -120,7 +125,6 @@ This `uid` is the `:index_uid` identifier used in all `indexes/:index_uid` route
 Now that the server knows about our brand new index, we can send our data to it.
 
 If you have no dataset, [here is a movie dataset](https://www.notion.so/meilisearch/A-movies-dataset-to-test-Meili-1cbf7c9cfa4247249c40edfa22d7ca87#b5ae399b81834705ba5420ac70358a65) you can use.
-
 
 ```bash
 $ curl -i -X POST 'http://127.0.0.1:7700/indexes/movies/documents' \

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.8.3":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
   integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
@@ -45,6 +45,16 @@
   integrity sha512-HKyUVu69cZoclptr8t8U5b6sx6zoWjh8jiUhnuj3MpZuKT2dJ8zPTuiy31luq32swhI0SpwItCIlU8XW7BZeJg==
   dependencies:
     "@babel/types" "^7.8.7"
+    jsesc "^2.5.1"
+    lodash "^4.17.13"
+    source-map "^0.5.0"
+
+"@babel/generator@^7.9.0":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.4.tgz#12441e90c3b3c4159cdecf312075bf1a8ce2dbce"
+  integrity sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==
+  dependencies:
+    "@babel/types" "^7.9.0"
     jsesc "^2.5.1"
     lodash "^4.17.13"
     source-map "^0.5.0"
@@ -227,6 +237,11 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
+"@babel/helper-validator-identifier@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz#ad53562a7fc29b3b9a91bbf7d10397fd146346ed"
+  integrity sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==
+
 "@babel/helper-wrap-function@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-wrap-function/-/helper-wrap-function-7.8.3.tgz#9dbdb2bb55ef14aaa01fe8c99b629bd5352d8610"
@@ -254,6 +269,11 @@
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^4.0.0"
+
+"@babel/parser@^7.7.0", "@babel/parser@^7.9.0":
+  version "7.9.4"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
+  integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
 
 "@babel/parser@^7.8.6", "@babel/parser@^7.8.7":
   version "7.8.8"
@@ -746,6 +766,21 @@
     "@babel/parser" "^7.8.6"
     "@babel/types" "^7.8.6"
 
+"@babel/traverse@^7.7.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.0.tgz#d3882c2830e513f4fe4cec9fe76ea1cc78747892"
+  integrity sha512-jAZQj0+kn4WTHO5dUZkZKhbFrqZE7K5LAQ5JysMnmvGij+wOdr+8lWqPeW0BcF4wFwrEXXtdGO7wcV6YPJcf3w==
+  dependencies:
+    "@babel/code-frame" "^7.8.3"
+    "@babel/generator" "^7.9.0"
+    "@babel/helper-function-name" "^7.8.3"
+    "@babel/helper-split-export-declaration" "^7.8.3"
+    "@babel/parser" "^7.9.0"
+    "@babel/types" "^7.9.0"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.13"
+
 "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4", "@babel/traverse@^7.8.6":
   version "7.8.6"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.6.tgz#acfe0c64e1cd991b3e32eae813a6eb564954b5ff"
@@ -760,6 +795,15 @@
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.13"
+
+"@babel/types@^7.7.0", "@babel/types@^7.9.0":
+  version "7.9.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.0.tgz#00b064c3df83ad32b2dbf5ff07312b15c7f1efb5"
+  integrity sha512-BS9JKfXkzzJl8RluW4JGknzpiUV7ZrvTayM6yfqLTVBEnFtyowVIOu6rqxRd5cVO6yGoWf4T8u8dgK9oB+GCng==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.9.0"
+    lodash "^4.17.13"
+    to-fast-properties "^2.0.0"
 
 "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.8.7":
   version "7.8.7"
@@ -1244,10 +1288,20 @@ accepts@~1.3.4, accepts@~1.3.5, accepts@~1.3.7:
     mime-types "~2.1.24"
     negotiator "0.6.2"
 
+acorn-jsx@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
+  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+
 acorn@^6.2.1:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
   integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+
+acorn@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
+  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
 
 agentkeepalive@^2.2.0:
   version "2.2.0"
@@ -1264,7 +1318,7 @@ ajv-keywords@^3.1.0, ajv-keywords@^3.4.1:
   resolved "https://registry.yarnpkg.com/ajv-keywords/-/ajv-keywords-3.4.1.tgz#ef916e271c64ac12171fd8384eaae6b2345854da"
   integrity sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==
 
-ajv@^6.1.0, ajv@^6.10.2, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
   version "6.12.0"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.0.tgz#06d60b96d87b8454a5adaba86e7854da629db4b7"
   integrity sha512-D6gFiFA0RRLyUbvijN74DWAjXSFxWKaWP7mldxkVhyhAV3+SWA9HEJPHQ2c9soIeTFJqcSdFDGFgdqs1iUU2Hw==
@@ -1317,7 +1371,7 @@ ansi-colors@^3.0.0:
   resolved "https://registry.yarnpkg.com/ansi-colors/-/ansi-colors-3.2.4.tgz#e3a3da4bfbae6c86a9c285625de124a234026fbf"
   integrity sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==
 
-ansi-escapes@^4.1.0:
+ansi-escapes@^4.1.0, ansi-escapes@^4.2.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
   integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
@@ -1427,6 +1481,15 @@ array-flatten@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-2.1.2.tgz#24ef80a28c1a893617e2149b0c6d0d788293b099"
   integrity sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==
 
+array-includes@^3.0.3:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/array-includes/-/array-includes-3.1.1.tgz#cdd67e6852bdf9c1215460786732255ed2459348"
+  integrity sha512-c2VXaCHl7zPsvpkFsw4nxvFie4fh1ur9bpcgsVkIjqn0H/Xwdg+7fv3n2r/isyS8EBj5b06M9kHyZuIr4El6WQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0"
+    is-string "^1.0.5"
+
 array-union@^1.0.1, array-union@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-1.0.2.tgz#9a34410e4f4e3da23dea375be5be70f24778ec39"
@@ -1443,6 +1506,14 @@ array-unique@^0.3.2:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/array-unique/-/array-unique-0.3.2.tgz#a894b75d4bc4f6cd679ef3244a9fd8f46ae2d428"
   integrity sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
+array.prototype.flat@^1.2.1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/array.prototype.flat/-/array.prototype.flat-1.2.3.tgz#0de82b426b0318dbfdb940089e38b043d37f6c7b"
+  integrity sha512-gBlRZV0VSmfPIeWfuuy56XZMvbVfbEUnOXUvt3F/eUUUSyzlgLxhEX4YAEpxNAogRGehPSnfXyPtYyKAhkzQhQ==
+  dependencies:
+    define-properties "^1.1.3"
+    es-abstract "^1.17.0-next.1"
 
 asn1.js@^4.0.0:
   version "4.10.1"
@@ -1477,6 +1548,11 @@ assign-symbols@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/assign-symbols/-/assign-symbols-1.0.0.tgz#59667f41fadd4f20ccbc2bb96b8d4f7f78ec0367"
   integrity sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
+astral-regex@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+  integrity sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==
 
 async-each@^1.0.1:
   version "1.0.3"
@@ -1546,6 +1622,18 @@ axios@0.19.2:
   integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
   dependencies:
     follow-redirects "1.5.10"
+
+babel-eslint@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
+  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.7.0"
+    "@babel/traverse" "^7.7.0"
+    "@babel/types" "^7.7.0"
+    eslint-visitor-keys "^1.0.0"
+    resolve "^1.12.0"
 
 babel-loader@^8.0.4:
   version "8.0.6"
@@ -1917,6 +2005,11 @@ callsites@^2.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-2.0.0.tgz#06eb84f00eea413da86affefacbffb36093b3c50"
   integrity sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA=
 
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
 camel-case@3.0.x, camel-case@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/camel-case/-/camel-case-3.0.0.tgz#ca3c3688a4e9cf3a4cda777dc4dcbc713249cf73"
@@ -1979,7 +2072,7 @@ chalk@^1.1.1, chalk@^1.1.3:
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
 
-chalk@^2.0.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
+chalk@^2.0.0, chalk@^2.1.0, chalk@^2.3.2, chalk@^2.4.1, chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
@@ -1995,6 +2088,11 @@ chalk@^3.0.0:
   dependencies:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
+
+chardet@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
+  integrity sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==
 
 check-md@1.0.0:
   version "1.0.0"
@@ -2077,6 +2175,18 @@ cli-boxes@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-boxes/-/cli-boxes-2.2.0.tgz#538ecae8f9c6ca508e3c3c95b453fe93cb4c168d"
   integrity sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==
+
+cli-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
+  integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
+  dependencies:
+    restore-cursor "^3.1.0"
+
+cli-width@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
+  integrity sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=
 
 clipboard@^2.0.0:
   version "2.0.6"
@@ -2317,6 +2427,11 @@ constants-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
   integrity sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=
+
+contains-path@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/contains-path/-/contains-path-0.1.0.tgz#fe8cf184ff6670b6baef01a9d4861a5cbec4120a"
+  integrity sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=
 
 content-disposition@0.5.3:
   version "0.5.3"
@@ -2980,7 +3095,7 @@ debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1:
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -3020,6 +3135,11 @@ deep-extend@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+
+deep-is@~0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
+  integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
 deepmerge@^1.5.2:
   version "1.5.2"
@@ -3186,6 +3306,21 @@ docsearch.js@^2.5.2:
     stack-utils "^1.0.1"
     to-factory "^1.0.0"
     zepto "^1.2.0"
+
+doctrine@1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-1.5.0.tgz#379dce730f6166f76cefa4e6707a159b02c5a6fa"
+  integrity sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=
+  dependencies:
+    esutils "^2.0.2"
+    isarray "^1.0.0"
+
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/doctrine/-/doctrine-3.0.0.tgz#addebead72a6574db783639dc87a121773973961"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
 
 dom-converter@^0.2:
   version "0.2.0"
@@ -3376,6 +3511,23 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
+es-abstract@^1.17.0:
+  version "1.17.5"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
+  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.1.5"
+    is-regex "^1.0.5"
+    object-inspect "^1.7.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.0"
+    string.prototype.trimleft "^2.1.1"
+    string.prototype.trimright "^2.1.1"
+
 es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
   version "1.17.4"
   resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.4.tgz#e3aedf19706b20e7c2594c35fc0d57605a79e184"
@@ -3427,6 +3579,98 @@ escaper@^2.5.3:
   resolved "https://registry.yarnpkg.com/escaper/-/escaper-2.5.3.tgz#8b8fe90ba364054151ab7eff18b4ce43b1e13ab5"
   integrity sha512-QGb9sFxBVpbzMggrKTX0ry1oiI4CSDAl9vIL702hzl1jGW8VZs7qfqTRX7WDOjoNDoEVGcEtu1ZOQgReSfT2kQ==
 
+eslint-config-prettier@^6.10.1:
+  version "6.10.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-6.10.1.tgz#129ef9ec575d5ddc0e269667bf09defcd898642a"
+  integrity sha512-svTy6zh1ecQojvpbJSgH3aei/Rt7C6i090l5f2WQ4aB05lYHeZIR1qL4wZyyILTbtmnbHP5Yn8MrsOJMGa8RkQ==
+  dependencies:
+    get-stdin "^6.0.0"
+
+eslint-config-standard@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-14.1.1.tgz#830a8e44e7aef7de67464979ad06b406026c56ea"
+  integrity sha512-Z9B+VR+JIXRxz21udPTL9HpFMyoMUEeX1G251EQ6e05WD9aPVtVBn09XUmZ259wCMlCDmYDSZG62Hhm+ZTJcUg==
+
+eslint-import-resolver-node@^0.3.2:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz#dbaa52b6b2816b50bc6711af75422de808e98404"
+  integrity sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==
+  dependencies:
+    debug "^2.6.9"
+    resolve "^1.13.1"
+
+eslint-module-utils@^2.4.1:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/eslint-module-utils/-/eslint-module-utils-2.5.2.tgz#7878f7504824e1b857dd2505b59a8e5eda26a708"
+  integrity sha512-LGScZ/JSlqGKiT8OC+cYRxseMjyqt6QO54nl281CK93unD89ijSeRV6An8Ci/2nvWVKe8K/Tqdm75RQoIOCr+Q==
+  dependencies:
+    debug "^2.6.9"
+    pkg-dir "^2.0.0"
+
+eslint-plugin-es@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz#98cb1bc8ab0aa807977855e11ad9d1c9422d014b"
+  integrity sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==
+  dependencies:
+    eslint-utils "^2.0.0"
+    regexpp "^3.0.0"
+
+eslint-plugin-import@^2.20.1:
+  version "2.20.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz#802423196dcb11d9ce8435a5fc02a6d3b46939b3"
+  integrity sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==
+  dependencies:
+    array-includes "^3.0.3"
+    array.prototype.flat "^1.2.1"
+    contains-path "^0.1.0"
+    debug "^2.6.9"
+    doctrine "1.5.0"
+    eslint-import-resolver-node "^0.3.2"
+    eslint-module-utils "^2.4.1"
+    has "^1.0.3"
+    minimatch "^3.0.4"
+    object.values "^1.1.0"
+    read-pkg-up "^2.0.0"
+    resolve "^1.12.0"
+
+eslint-plugin-node@^11.0.0:
+  version "11.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-node/-/eslint-plugin-node-11.0.0.tgz#365944bb0804c5d1d501182a9bc41a0ffefed726"
+  integrity sha512-chUs/NVID+sknFiJzxoN9lM7uKSOEta8GC8365hw1nDfwIPIjjpRSwwPvQanWv8dt/pDe9EV4anmVSwdiSndNg==
+  dependencies:
+    eslint-plugin-es "^3.0.0"
+    eslint-utils "^2.0.0"
+    ignore "^5.1.1"
+    minimatch "^3.0.4"
+    resolve "^1.10.1"
+    semver "^6.1.0"
+
+eslint-plugin-prettier@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz#432e5a667666ab84ce72f945c72f77d996a5c9ba"
+  integrity sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
+eslint-plugin-promise@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.2.1.tgz#845fd8b2260ad8f82564c1222fce44ad71d9418a"
+  integrity sha512-VoM09vT7bfA7D+upt+FjeBO5eHIJQBUWki1aPvB+vbNiHS3+oGIJGIeyBtKQTME6UPXXy3vV07OL1tHd3ANuDw==
+
+eslint-plugin-standard@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-standard/-/eslint-plugin-standard-4.0.1.tgz#ff0519f7ffaff114f76d1bd7c3996eef0f6e20b4"
+  integrity sha512-v/KBnfyaOMPmZc/dmc6ozOdWqekGp7bBGq4jLAecEfPGmfKiWS4sA8sC0LqiV9w5qmXAtXVn4M3p1jSyhY85SQ==
+
+eslint-plugin-vue@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-6.2.2.tgz#27fecd9a3a24789b0f111ecdd540a9e56198e0fe"
+  integrity sha512-Nhc+oVAHm0uz/PkJAWscwIT4ijTrK5fqNqz9QB1D35SbbuMG1uB6Yr5AJpvPSWg+WOw7nYNswerYh0kOk64gqQ==
+  dependencies:
+    natural-compare "^1.4.0"
+    semver "^5.6.0"
+    vue-eslint-parser "^7.0.0"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -3435,10 +3679,96 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-scope@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
+  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
+eslint-utils@^1.4.3:
+  version "1.4.3"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-1.4.3.tgz#74fec7c54d0776b6f67e0251040b5806564e981f"
+  integrity sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-utils@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-utils/-/eslint-utils-2.0.0.tgz#7be1cc70f27a72a76cd14aa698bcabed6890e1cd"
+  integrity sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==
+  dependencies:
+    eslint-visitor-keys "^1.1.0"
+
+eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
+  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+
+eslint@^6.8.0:
+  version "6.8.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-6.8.0.tgz#62262d6729739f9275723824302fb227c8c93ffb"
+  integrity sha512-K+Iayyo2LtyYhDSYwz5D5QdWw0hCacNzyq1Y821Xna2xSJj7cijoLLYmLxTQgcgZ9mC61nryMy9S7GRbYpI5Ig==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    ajv "^6.10.0"
+    chalk "^2.1.0"
+    cross-spawn "^6.0.5"
+    debug "^4.0.1"
+    doctrine "^3.0.0"
+    eslint-scope "^5.0.0"
+    eslint-utils "^1.4.3"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
+    esutils "^2.0.2"
+    file-entry-cache "^5.0.1"
+    functional-red-black-tree "^1.0.1"
+    glob-parent "^5.0.0"
+    globals "^12.1.0"
+    ignore "^4.0.6"
+    import-fresh "^3.0.0"
+    imurmurhash "^0.1.4"
+    inquirer "^7.0.0"
+    is-glob "^4.0.0"
+    js-yaml "^3.13.1"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.3.0"
+    lodash "^4.17.14"
+    minimatch "^3.0.4"
+    mkdirp "^0.5.1"
+    natural-compare "^1.4.0"
+    optionator "^0.8.3"
+    progress "^2.0.0"
+    regexpp "^2.0.1"
+    semver "^6.1.2"
+    strip-ansi "^5.2.0"
+    strip-json-comments "^3.0.1"
+    table "^5.2.3"
+    text-table "^0.2.0"
+    v8-compile-cache "^2.0.3"
+
+espree@^6.1.2:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/espree/-/espree-6.2.1.tgz#77fc72e1fd744a2052c20f38a5b575832e82734a"
+  integrity sha512-ysCxRQY3WaXJz9tdbWOwuWr5Y/XrPTGX9Kiz3yoUXwW0VZ4w30HTkQLaGx/+ttFjF8i+ACbArnB4ce68a9m5hw==
+  dependencies:
+    acorn "^7.1.1"
+    acorn-jsx "^5.2.0"
+    eslint-visitor-keys "^1.1.0"
+
 esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
+esquery@^1.0.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.2.0.tgz#a010a519c0288f2530b3404124bfb5f02e9797fe"
+  integrity sha512-weltsSqdeWIX9G2qQZz7KlTRJdkkOCTPgLYJUz1Hacf48R4YOwGPHO3+ORfWedqJKbq5WQmsgK90n+pFLIKt/Q==
+  dependencies:
+    estraverse "^5.0.0"
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -3451,6 +3781,11 @@ estraverse@^4.1.0, estraverse@^4.1.1:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+
+estraverse@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.0.0.tgz#ac81750b482c11cca26e4b07e83ed8f75fbcdc22"
+  integrity sha512-j3acdrMzqrxmJTNj5dbr1YbjacrYgAxVMeF0gK16E3j494mOe7xygM/ZLIguEQ0ETwAg2hlJCtHRGav+y0Ny5A==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -3574,6 +3909,15 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
+external-editor@^3.0.3:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
+  integrity sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==
+  dependencies:
+    chardet "^0.7.0"
+    iconv-lite "^0.4.24"
+    tmp "^0.0.33"
+
 extglob@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-2.0.4.tgz#ad00fe4dc612a9232e8718711dc5cb5ab0285543"
@@ -3603,6 +3947,11 @@ fast-deep-equal@^3.1.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
   integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
 
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
+
 fast-glob@^2.2.6:
   version "2.2.7"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-2.2.7.tgz#6953857c3afa475fff92ee6015d52da70a4cd39d"
@@ -3619,6 +3968,11 @@ fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
   integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@~2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
+  integrity sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
 
 faye-websocket@^0.10.0:
   version "0.10.0"
@@ -3645,6 +3999,13 @@ figures@^3.0.0:
   integrity sha512-yaduQFRKLXYOGgEn6AZau90j3ggSOyiqXU0F9JZfeXYhNa+Jk4X+s45A2zg5jns87GAFa34BBm2kXw4XpNcbdg==
   dependencies:
     escape-string-regexp "^1.0.5"
+
+file-entry-cache@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-5.0.1.tgz#ca0f6efa6dd3d561333fb14515065c2fafdf439c"
+  integrity sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==
+  dependencies:
+    flat-cache "^2.0.1"
 
 file-loader@^3.0.1:
   version "3.0.1"
@@ -3699,12 +4060,33 @@ find-up@^1.0.0:
     path-exists "^2.0.0"
     pinkie-promise "^2.0.0"
 
+find-up@^2.0.0, find-up@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/find-up/-/find-up-2.1.0.tgz#45d1b7e506c717ddd482775a2b77920a3c0c57a7"
+  integrity sha1-RdG35QbHF93UgndaK3eSCjwMV6c=
+  dependencies:
+    locate-path "^2.0.0"
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
   integrity sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
   dependencies:
     locate-path "^3.0.0"
+
+flat-cache@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-2.0.1.tgz#5d296d6f04bda44a4630a301413bdbc2ec085ec0"
+  integrity sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==
+  dependencies:
+    flatted "^2.0.0"
+    rimraf "2.6.3"
+    write "1.0.3"
+
+flatted@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
+  integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
 flush-write-stream@^1.0.0:
   version "1.1.1"
@@ -3824,6 +4206,11 @@ function-bind@^1.1.1:
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
 
+functional-red-black-tree@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
+  integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
 gauge@~2.7.3:
   version "2.7.4"
   resolved "https://registry.yarnpkg.com/gauge/-/gauge-2.7.4.tgz#2c03405c7538c39d7eb37b317022e325fb018bf7"
@@ -3865,6 +4252,11 @@ get-stdin@^4.0.1:
   resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-4.0.1.tgz#b968c6b0a04384324902e8bf1a5df32579a450fe"
   integrity sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4=
 
+get-stdin@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/get-stdin/-/get-stdin-6.0.0.tgz#9e09bf712b360ab9225e812048f71fde9c89657b"
+  integrity sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==
+
 get-stream@^4.0.0, get-stream@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-4.1.0.tgz#c1b255575f3dc21d59bfc79cd3d2b46b1c3a54b5"
@@ -3898,6 +4290,13 @@ glob-parent@^3.1.0:
   dependencies:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
+
+glob-parent@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
 
 glob-to-regexp@^0.3.0:
   version "0.3.0"
@@ -3935,6 +4334,13 @@ globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+
+globals@^12.1.0:
+  version "12.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-12.4.0.tgz#a18813576a41b00a24a97e7f815918c2e19925f8"
+  integrity sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+  dependencies:
+    type-fest "^0.8.1"
 
 globby@^6.1.0:
   version "6.1.0"
@@ -4322,7 +4728,7 @@ https-browserify@^1.0.0:
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
 
-iconv-lite@0.4, iconv-lite@0.4.24:
+iconv-lite@0.4, iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -4356,10 +4762,15 @@ ignore@^3.3.5:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
   integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
-ignore@^4.0.3:
+ignore@^4.0.3, ignore@^4.0.6:
   version "4.0.6"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-4.0.6.tgz#750e3db5862087b4737ebac8207ffd1ef27b25fc"
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+
+ignore@^5.1.1:
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
+  integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
 immediate@^3.2.3:
   version "3.2.3"
@@ -4380,6 +4791,14 @@ import-fresh@^2.0.0:
   dependencies:
     caller-path "^2.0.0"
     resolve-from "^3.0.0"
+
+import-fresh@^3.0.0:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
+  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
 
 import-from@^2.1.0:
   version "2.1.0"
@@ -4455,6 +4874,25 @@ ini@^1.3.5, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+inquirer@^7.0.0:
+  version "7.1.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
+  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^3.0.0"
+    cli-cursor "^3.1.0"
+    cli-width "^2.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.15"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.5.3"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
 
 internal-ip@^4.3.0:
   version "4.3.0"
@@ -4727,6 +5165,11 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
+is-promise@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
+  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
+
 is-regex@^1.0.4, is-regex@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
@@ -4748,6 +5191,11 @@ is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
+is-string@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.5.tgz#40493ed198ef3ff477b8c7f92f644ec82a5cd3a6"
+  integrity sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==
 
 is-svg@^3.0.0:
   version "3.0.0"
@@ -4883,6 +5331,11 @@ json-schema@0.2.3:
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
   integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
 
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
+  integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
 json-stringify-safe@~5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
@@ -5006,6 +5459,14 @@ levenary@^1.1.1:
   dependencies:
     leven "^3.1.0"
 
+levn@^0.3.0, levn@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/levn/-/levn-0.3.0.tgz#3b09924edf9f083c0490fdd4c0bc4421e04764ee"
+  integrity sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+  dependencies:
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+
 linkify-it@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/linkify-it/-/linkify-it-2.2.0.tgz#e3b54697e78bf915c70a38acd78fd09e0058b1cf"
@@ -5023,6 +5484,16 @@ load-json-file@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
     strip-bom "^2.0.0"
+
+load-json-file@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
+  integrity sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=
+  dependencies:
+    graceful-fs "^4.1.2"
+    parse-json "^2.2.0"
+    pify "^2.0.0"
+    strip-bom "^3.0.0"
 
 load-script@^1.0.0:
   version "1.0.0"
@@ -5052,6 +5523,14 @@ loader-utils@^1.0.1, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2
     big.js "^5.2.2"
     emojis-list "^3.0.0"
     json5 "^1.0.1"
+
+locate-path@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/locate-path/-/locate-path-2.0.0.tgz#2b568b265eec944c6d9c0de9c3dbbbca0354cd8e"
+  integrity sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=
+  dependencies:
+    p-locate "^2.0.0"
+    path-exists "^3.0.0"
 
 locate-path@^3.0.0:
   version "3.0.0"
@@ -5424,7 +5903,7 @@ mime@^2.0.3, mime@^2.4.4:
   resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.4.tgz#bd7b91135fc6b01cde3e9bae33d659b63d8857e5"
   integrity sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==
 
-mimic-fn@^2.0.0:
+mimic-fn@^2.0.0, mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
   integrity sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
@@ -5574,6 +6053,11 @@ multicast-dns@^6.0.1:
     dns-packet "^1.3.1"
     thunky "^1.0.2"
 
+mute-stream@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
+  integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
 nan@^2.12.1, nan@^2.13.2:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
@@ -5595,6 +6079,11 @@ nanomatch@^1.2.9:
     regex-not "^1.0.0"
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+  integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -5899,6 +6388,13 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   dependencies:
     wrappy "1"
 
+onetime@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
+  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  dependencies:
+    mimic-fn "^2.1.0"
+
 opencollective-postinstall@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.2.tgz#5657f1bede69b6e33a45939b061eb53d3c6c3a89"
@@ -5918,6 +6414,18 @@ optimize-css-assets-webpack-plugin@^5.0.1:
   dependencies:
     cssnano "^4.1.10"
     last-call-webpack-plugin "^3.0.0"
+
+optionator@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/optionator/-/optionator-0.8.3.tgz#84fa1d036fe9d3c7e21d99884b601167ec8fb495"
+  integrity sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+  dependencies:
+    deep-is "~0.1.3"
+    fast-levenshtein "~2.0.6"
+    levn "~0.3.0"
+    prelude-ls "~1.1.2"
+    type-check "~0.3.2"
+    word-wrap "~1.2.3"
 
 original@^1.0.0:
   version "1.0.2"
@@ -5952,7 +6460,7 @@ os-locale@^3.0.0:
     lcid "^2.0.0"
     mem "^4.0.0"
 
-os-tmpdir@^1.0.0:
+os-tmpdir@^1.0.0, os-tmpdir@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/os-tmpdir/-/os-tmpdir-1.0.2.tgz#bbe67406c79aa85c5cfec766fe5734555dfa1274"
   integrity sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=
@@ -5985,12 +6493,26 @@ p-is-promise@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-2.1.0.tgz#918cebaea248a62cf7ffab8e3bca8c5f882fc42e"
   integrity sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==
 
+p-limit@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
+  integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
+  dependencies:
+    p-try "^1.0.0"
+
 p-limit@^2.0.0, p-limit@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.2.2.tgz#61279b67721f5287aa1c13a9a7fbbc48c9291b1e"
   integrity sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==
   dependencies:
     p-try "^2.0.0"
+
+p-locate@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/p-locate/-/p-locate-2.0.0.tgz#20a0103b222a70c8fd39cc2e580680f3dde5ec43"
+  integrity sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=
+  dependencies:
+    p-limit "^1.1.0"
 
 p-locate@^3.0.0:
   version "3.0.0"
@@ -6010,6 +6532,11 @@ p-retry@^3.0.1:
   integrity sha512-XE6G4+YTTkT2a0UWb2kjZe8xNwf8bIbnqpc/IS/idOBVhyves0mK5OJgeocjx7q5pvX/6m23xuzVPYT1uGM73w==
   dependencies:
     retry "^0.12.0"
+
+p-try@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/p-try/-/p-try-1.0.0.tgz#cbc79cdbaf8fd4228e13f621f2b1a237c1b207b3"
+  integrity sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -6046,6 +6573,13 @@ param-case@2.1.x, param-case@^2.1.1:
   integrity sha1-35T9jPZTHs915r75oIWPvHK+Ikc=
   dependencies:
     no-case "^2.2.0"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
 
 parse-asn1@^5.0.0:
   version "5.1.5"
@@ -6140,6 +6674,13 @@ path-type@^1.0.0:
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
 
+path-type@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-2.0.0.tgz#f012ccb8415b7096fc2daa1054c3d72389594c73"
+  integrity sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=
+  dependencies:
+    pify "^2.0.0"
+
 path-type@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
@@ -6189,6 +6730,13 @@ pinkie@^2.0.0:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pinkie/-/pinkie-2.0.4.tgz#72556b80cfa0d48a974e80e77248e80ed4f7f870"
   integrity sha1-clVrgM+g1IqXToDnckjoDtT3+HA=
+
+pkg-dir@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-2.0.0.tgz#f6d5d1109e19d63edf428e0bd57e12777615334b"
+  integrity sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=
+  dependencies:
+    find-up "^2.1.0"
 
 pkg-dir@^3.0.0:
   version "3.0.0"
@@ -6559,10 +7107,27 @@ postcss@^7.0.0, postcss@^7.0.1, postcss@^7.0.14, postcss@^7.0.26, postcss@^7.0.2
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
+prelude-ls@~1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
+  integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
 prepend-http@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/prepend-http/-/prepend-http-2.0.0.tgz#e92434bfa5ea8c19f41cdfd401d741a3c819d897"
   integrity sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.0.2.tgz#1ba8f3eb92231e769b7fcd7cb73ae1b6b74ade08"
+  integrity sha512-5xJQIPT8BraI7ZnaDwSbu5zLrB6vvi8hVV58yHQ+QK64qrY40dULy0HSRlQ2/2IdzeBpjhDkqdcFBnFeDEMVdg==
 
 prettier@^1.18.2:
   version "1.19.1"
@@ -6603,6 +7168,11 @@ process@^0.11.10:
   version "0.11.10"
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
+
+progress@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
+  integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 promise-inflight@^1.0.1:
   version "1.0.1"
@@ -6778,6 +7348,14 @@ read-pkg-up@^1.0.1:
     find-up "^1.0.0"
     read-pkg "^1.0.0"
 
+read-pkg-up@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg-up/-/read-pkg-up-2.0.0.tgz#6b72a8048984e0c41e79510fd5e9fa99b3b549be"
+  integrity sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=
+  dependencies:
+    find-up "^2.0.0"
+    read-pkg "^2.0.0"
+
 read-pkg@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-1.1.0.tgz#f5ffaa5ecd29cb31c0474bca7d756b6bb29e3f28"
@@ -6786,6 +7364,15 @@ read-pkg@^1.0.0:
     load-json-file "^1.0.0"
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
+
+read-pkg@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-2.0.0.tgz#8ef1c0623c6a6db0dc6713c4bfac46332b2368f8"
+  integrity sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=
+  dependencies:
+    load-json-file "^2.0.0"
+    normalize-package-data "^2.3.2"
+    path-type "^2.0.0"
 
 read-pkg@^4.0.1:
   version "4.0.1"
@@ -6882,6 +7469,16 @@ regexp.prototype.flags@^1.2.0:
   dependencies:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
+
+regexpp@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
+  integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
 regexpu-core@^4.7.0:
   version "4.7.0"
@@ -7022,12 +7619,17 @@ resolve-from@^3.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-3.0.0.tgz#b22c7af7d9d6881bc8b6e653335eebcb0a188748"
   integrity sha1-six699nWiBvItuZTM17rywoYh0g=
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-4.0.0.tgz#4abcd852ad32dd7baabfe9b40e00a36db5f392e6"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
 resolve-url@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.10.0, resolve@^1.2.0, resolve@^1.3.2, resolve@^1.8.1:
+resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.2.0, resolve@^1.3.2, resolve@^1.8.1:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -7040,6 +7642,14 @@ responselike@^1.0.2:
   integrity sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
   dependencies:
     lowercase-keys "^1.0.0"
+
+restore-cursor@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
+  integrity sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==
+  dependencies:
+    onetime "^5.1.0"
+    signal-exit "^3.0.2"
 
 ret@~0.1.10:
   version "0.1.15"
@@ -7068,6 +7678,13 @@ rimraf@2, rimraf@^2.5.4, rimraf@^2.6.3:
   dependencies:
     glob "^7.1.3"
 
+rimraf@2.6.3:
+  version "2.6.3"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
+  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+  dependencies:
+    glob "^7.1.3"
+
 ripemd160@^2.0.0, ripemd160@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/ripemd160/-/ripemd160-2.0.2.tgz#a1c1a6f624751577ba5d07914cbc92850585890c"
@@ -7075,6 +7692,13 @@ ripemd160@^2.0.0, ripemd160@^2.0.1:
   dependencies:
     hash-base "^3.0.0"
     inherits "^2.0.1"
+
+run-async@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
+  integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
+  dependencies:
+    is-promise "^2.1.0"
 
 run-queue@^1.0.0, run-queue@^1.0.3:
   version "1.0.3"
@@ -7088,7 +7712,7 @@ rw@1:
   resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
   integrity sha1-P4Yt+pGrdmsUiF700BEkv9oHT7Q=
 
-rxjs@^6.5.2:
+rxjs@^6.5.2, rxjs@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.4.tgz#e0777fe0d184cec7872df147f303572d414e211c"
   integrity sha512-naMQXcgEo3csAEGvw/NydRA0fuS2nDZJiw1YUWFKU7aPPAPGZEsD4Iimit96qwCieH6y614MCLYwdkrWx7z/7Q==
@@ -7211,7 +7835,7 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
-semver@^6.0.0, semver@^6.2.0, semver@^6.3.0:
+semver@^6.0.0, semver@^6.1.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -7356,6 +7980,15 @@ slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
   integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
+
+slice-ansi@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-2.1.0.tgz#cacd7693461a637a5788d92a7dd4fba068e81636"
+  integrity sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==
+  dependencies:
+    ansi-styles "^3.2.0"
+    astral-regex "^1.0.0"
+    is-fullwidth-code-point "^2.0.0"
 
 slugify@^1.3.1:
   version "1.4.0"
@@ -7747,6 +8380,11 @@ strip-bom@^2.0.0:
   dependencies:
     is-utf8 "^0.2.0"
 
+strip-bom@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-3.0.0.tgz#2334c18e9c759f7bdd56fdef7e9ae3d588e68ed3"
+  integrity sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=
+
 strip-css-comments@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/strip-css-comments/-/strip-css-comments-3.0.0.tgz#7a5625eff8a2b226cf8947a11254da96e13dae89"
@@ -7765,6 +8403,11 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
+
+strip-json-comments@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
+  integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
 
 strip-json-comments@~2.0.1:
   version "2.0.1"
@@ -7853,6 +8496,16 @@ svgo@^1.0.0:
     unquote "~1.1.1"
     util.promisify "~1.0.0"
 
+table@^5.2.3:
+  version "5.4.6"
+  resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"
+  integrity sha512-wmEc8m4fjnob4gt5riFRtTu/6+4rSe12TpAELNSqHMfF3IqnA+CH37USM6/YR3qRZv7e56kAEAtd6nKZaxe0Ug==
+  dependencies:
+    ajv "^6.10.2"
+    lodash "^4.17.14"
+    slice-ansi "^2.1.0"
+    string-width "^3.0.0"
+
 tapable@^1.0.0, tapable@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-1.1.3.tgz#a1fccc06b58db61fd7a45da2da44f5f3a3e67ba2"
@@ -7909,7 +8562,7 @@ through2@^2.0.0:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
-through@~2.3.4:
+through@^2.3.6, through@~2.3.4:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
@@ -7935,6 +8588,13 @@ tiny-emitter@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
   integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
+tmp@^0.0.33:
+  version "0.0.33"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
+  integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
+  dependencies:
+    os-tmpdir "~1.0.2"
 
 to-arraybuffer@^1.0.0:
   version "1.0.1"
@@ -8064,6 +8724,13 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   version "0.14.5"
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
+type-check@~0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/type-check/-/type-check-0.3.2.tgz#5884cab512cf1d355e3fb784f30804b2b520db72"
+  integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+  dependencies:
+    prelude-ls "~1.1.2"
 
 type-fest@^0.11.0:
   version "0.11.0"
@@ -8333,6 +9000,11 @@ uuid@^3.0.1, uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+v8-compile-cache@^2.0.3:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
+  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+
 validate-npm-package-license@^3.0.1:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
@@ -8364,6 +9036,18 @@ vm-browserify@^1.0.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
+
+vue-eslint-parser@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz#a4ed2669f87179dedd06afdd8736acbb3a3864d6"
+  integrity sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==
+  dependencies:
+    debug "^4.1.1"
+    eslint-scope "^5.0.0"
+    eslint-visitor-keys "^1.1.0"
+    espree "^6.1.2"
+    esquery "^1.0.1"
+    lodash "^4.17.15"
 
 vue-hot-reload-api@^2.3.0:
   version "2.3.4"
@@ -8705,6 +9389,11 @@ widest-line@^3.1.0:
   dependencies:
     string-width "^4.0.0"
 
+word-wrap@~1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
+  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+
 worker-farm@^1.7.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/worker-farm/-/worker-farm-1.7.0.tgz#26a94c5391bbca926152002f69b84a4bf772e5a8"
@@ -8743,6 +9432,13 @@ write-file-atomic@^3.0.0:
     is-typedarray "^1.0.0"
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
+
+write@1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/write/-/write-1.0.3.tgz#0800e14523b923a387e415123c865616aae0f5c3"
+  integrity sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==
+  dependencies:
+    mkdirp "^0.5.1"
 
 ws@^6.2.1:
   version "6.2.1"


### PR DESCRIPTION
Because of many styling mistakes and missing a common styling guide I added a linter and a styler.

A test was added that will check - without fixing - the style of any `.js` `.vue` and `.md` files.
- `js` and `vue` files are checked by `prettier` and `es-lint`
- `md` files are checked by `prettier` only

During contribution it will be expected from all contributors to use the following script before submitting a PR :
```bash
yarn style:fix
```
This script will fix all styling and linting errors that are fixable.
All warning and errors that this script will raise is expected to be fixed by the contributor.
This information will be added to the README.md on a later PR (because a PR is made on the same file for the moment #216 ). 

### Note
- Two `vue` files are being ignored voluntarily by the linter because they will be fixed by @curquiza.
- There is a problem with the URL `https://en.wikipedia.org/wiki/Atomicity_(database_systems)` in the documents guide. Prettier does not like the parentheses in the URL. This is why you will find a comment in front of it stating : `<!-- prettier-ignore -->` In order to tell prettier to ignore this link.
- (Also little styling update on the tooltip that had a bad color. )