### PR TITLE
search result nbHits

### DIFF
--- a/references/search.md
+++ b/references/search.md
@@ -14,17 +14,17 @@ Search for documents matching a specific query in the given index.
 
 #### Query Parameters
 
-| Query Parameter           | Description                                        | Default Value |
-| ------------------------- | -------------------------------------------------- | :-----------: |
-| **q**                     | query string _(mandatory)_                         |               |
-| **offset**                | number of documents to skip                        |       0       |
-| **limit**                 | number of documents to take                        |      20       |
-| **attributesToRetrieve**  | document attributes to show                        |      \*       |
-| **attributesToCrop**      | which attributes to crop                           |     none      |
-| **cropLength**            | limit length at which to crop specified attributes |      200      |
-| **attributesToHighlight** | which attributes to highlight                      |     none      |
-| **filters**               | adds a fitler expression  		                 |     none      |
-| **matches**               | whether to return the raw matches or not           |     false     |
+| Query Parameter           | Description                                                                                     | Default Value |
+| ------------------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
+| **q**                     | Query string \_(mandatory)                                                                      |               |
+| **offset**                | Number of documents to skip                                                                     |      `0`      |
+| **limit**                 | Maximum number of documents returned                                                            |     `20`      |
+| **attributesToRetrieve**  | Attributes to display in the returned documents                                                 |      `*`      |
+| **attributesToCrop**      | Attributes whose values have to be cropped                                                      |    `none`     |
+| **cropLength**            | Length used to crop field values                                                                |     `200`     |
+| **attributesToHighlight** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
+| **filters**               | Add fitler expressions                                                           |    `none`     |
+| **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).
 

--- a/references/search.md
+++ b/references/search.md
@@ -9,36 +9,36 @@ Search for documents matching a specific query in the given index.
 #### Path Variables
 
 | Variable      | Description   |
-|---------------|---------------|
+| ------------- | ------------- |
 | **index_uid** | The index UID |
 
 #### Query Parameters
 
 | Query Parameter           | Description                                        | Default Value |
-|---------------------------|----------------------------------------------------|:-------------:|
+| ------------------------- | -------------------------------------------------- | :-----------: |
 | **q**                     | query string _(mandatory)_                         |               |
-| **offset**                | number of documents to skip                        | 0             |
-| **limit**                 | number of documents to take                        | 20            |
-| **attributesToRetrieve**  | document attributes to show                        | *             |
-| **attributesToCrop**      | which attributes to crop                           | none          |
-| **cropLength**            | limit length at which to crop specified attributes | 200           |
-| **attributesToHighlight** | which attributes to highlight                      | none          |
-| **filters**               | attribute with an exact match                      | none          |
-| **matches**               | whether to return the raw matches or not           | false         |
+| **offset**                | number of documents to skip                        |       0       |
+| **limit**                 | number of documents to take                        |      20       |
+| **attributesToRetrieve**  | document attributes to show                        |      \*       |
+| **attributesToCrop**      | which attributes to crop                           |     none      |
+| **cropLength**            | limit length at which to crop specified attributes |      200      |
+| **attributesToHighlight** | which attributes to highlight                      |     none      |
+| **filters**               | attribute with an exact match                      |     none      |
+| **matches**               | whether to return the raw matches or not           |     false     |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).
 
-
 ### Response
-| field                     | Description                                        | type          |
-|---------------------------|----------------------------------------------------|:-------------:|
-| **hits**                  | results of the query                               | `[result]`    |
-| **offset**                | number of documents skipped                        | `number`      |
-| **limit**                 | number of documents to take                        | `number`      |
-| **nbHits**                | total number of matches                            | `number`      |
-| **exhaustiveNbHits**      | whether `nbHits` is exhaustive                     | `boolean`     |
-| **processingTimeMs**      | processing time of the query                       | `number`      |
-| **query**                 | query originating the response                     | `string`      |
+
+| field                | Description                    |    type    |
+| -------------------- | ------------------------------ | :--------: |
+| **hits**             | results of the query           | `[result]` |
+| **offset**           | number of documents skipped    |  `number`  |
+| **limit**            | number of documents to take    |  `number`  |
+| **nbHits**           | total number of matches        |  `number`  |
+| **exhaustiveNbHits** | whether `nbHits` is exhaustive | `boolean`  |
+| **processingTimeMs** | processing time of the query   |  `number`  |
+| **query**            | query originating the response |  `string`  |
 
 ### Example
 
@@ -46,6 +46,7 @@ Search for documents matching a specific query in the given index.
 $ curl \
   -X GET 'http://localhost:7700/indexes/4eb345y7/search?q=american%20ninja%205'
 ```
+
 #### Response: `200 Ok`
 
 ```json
@@ -57,7 +58,7 @@ $ curl \
       "poster": "https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg",
       "overview": "The whole gang are back and as close as ever. They decide to
       get even closer by spending the summer together at a beach house. They
-      decide to hold the biggest...", 
+      decide to hold the biggest...",
       "release_date": 997405200
     },
     {

--- a/references/search.md
+++ b/references/search.md
@@ -23,7 +23,7 @@ Search for documents matching a specific query in the given index.
 | **attributesToCrop**      | which attributes to crop                           |     none      |
 | **cropLength**            | limit length at which to crop specified attributes |      200      |
 | **attributesToHighlight** | which attributes to highlight                      |     none      |
-| **filters**               | attribute with an exact match                      |     none      |
+| **filters**               | adds a fitler expression  		                 |     none      |
 | **matches**               | whether to return the raw matches or not           |     false     |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).

--- a/references/search.md
+++ b/references/search.md
@@ -23,7 +23,7 @@ Search for documents matching a specific query in the given index.
 | **attributesToCrop**      | Attributes whose values have to be cropped                                                      |    `none`     |
 | **cropLength**            | Length used to crop field values                                                                |     `200`     |
 | **attributesToHighlight** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
-| **filters**               | Add fitler expressions                                                           |    `none`     |
+| **filters**               | Add fitler expression                                                                           |    `none`     |
 | **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).

--- a/references/search.md
+++ b/references/search.md
@@ -9,24 +9,36 @@ Search for documents matching a specific query in the given index.
 #### Path Variables
 
 | Variable      | Description   |
-| ------------- | ------------- |
+|---------------|---------------|
 | **index_uid** | The index UID |
 
 #### Query Parameters
 
-| Query Parameter           | Description                                                                                     | Default Value |
-| ------------------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
-| **q**                     | Query string \_(mandatory)                                                                      |               |
-| **offset**                | Number of documents to skip                                                                     |      `0`      |
-| **limit**                 | Maximum number of documents returned                                                            |     `20`      |
-| **attributesToRetrieve**  | Attributes to display in the returned documents                                                 |      `*`      |
-| **attributesToCrop**      | Attributes whose values have to be cropped                                                      |    `none`     |
-| **cropLength**            | Length used to crop field values                                                                |     `200`     |
-| **attributesToHighlight** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
-| **filters**               | Filter queries by an attribute value                                                            |    `none`     |
-| **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
+| Query Parameter           | Description                                        | Default Value |
+|---------------------------|----------------------------------------------------|:-------------:|
+| **q**                     | query string _(mandatory)_                         |               |
+| **offset**                | number of documents to skip                        | 0             |
+| **limit**                 | number of documents to take                        | 20            |
+| **attributesToRetrieve**  | document attributes to show                        | *             |
+| **attributesToCrop**      | which attributes to crop                           | none          |
+| **cropLength**            | limit length at which to crop specified attributes | 200           |
+| **attributesToHighlight** | which attributes to highlight                      | none          |
+| **filters**               | attribute with an exact match                      | none          |
+| **matches**               | whether to return the raw matches or not           | false         |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).
+
+
+### Response
+| field                     | Description                                        | type          |
+|---------------------------|----------------------------------------------------|:-------------:|
+| **hits**                  | results of the query                               | `[result]`    |
+| **offset**                | number of documents skipped                        | `number`      |
+| **limit**                 | number of documents to take                        | `number`      |
+| **nbHits**                | total number of matches                            | `number`      |
+| **exhaustiveNbHits**      | whether `nbHits` is exhaustive                     | `boolean`     |
+| **processingTimeMs**      | processing time of the query                       | `number`      |
+| **query**                 | query originating the response                     | `string`      |
 
 ### Example
 
@@ -34,33 +46,37 @@ Search for documents matching a specific query in the given index.
 $ curl \
   -X GET 'http://localhost:7700/indexes/4eb345y7/search?q=american%20ninja%205'
 ```
-
 #### Response: `200 Ok`
 
 ```json
 {
   "hits": [
     {
-      "id": "25684",
-      "title": "American Ninja 5",
-      "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-      "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
-      "release_date": "1993-01-01"
+      "id": "2770",
+      "title": "American Pie 2",
+      "poster": "https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg",
+      "overview": "The whole gang are back and as close as ever. They decide to
+      get even closer by spending the summer together at a beach house. They
+      decide to hold the biggest...", 
+      "release_date": 997405200
     },
     {
-      "id": "25682",
-      "title": "American Ninja 3: Blood Hunt",
-      "poster": "https://image.tmdb.org/t/p/w1280/c7oNrk8bRg0BlmtvidhVD8ivPYT.jpg",
-      "overview": "Jackson is back, and now he has a new partner, karate champion Sean, as they must face a deadly terrorist known as 'The Cobra', who has infected Sean with a virus. Sean and Jackson have no choice but to fight the Cobra and his bands of ninjas.",
-      "release_date": "1989-02-24"
+      "id": "190859",
+      "title": "American Sniper",
+      "poster": "https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg",
+      "overview": "U.S. Navy SEAL Chris Kyle takes his sole mission—protect his
+      comrades—to heart and becomes one of the most lethal snipers in American
+      history. His pinpoint accuracy not only saves countless lives but also
+      makes him a prime...",
+      "release_date": 1418256000
     },
     ...
   ],
   "offset": 0,
   "limit": 20,
-  "nbHits": 2,
+  "nbHits": 976,
   "exhaustiveNbHits": false,
-  "processingTimeMs": 32,
-  "query": "american ninja 5"
+  "processingTimeMs": 35,
+  "query": "american "
 }
 ```

--- a/references/search.md
+++ b/references/search.md
@@ -58,6 +58,8 @@ $ curl \
   ],
   "offset": 0,
   "limit": 20,
+  "nbHits": 2,
+  "exhaustiveNbHits": false,
   "processingTimeMs": 32,
   "query": "american ninja 5"
 }


### PR DESCRIPTION
documents the addition of `nbHits` and `exhaustiveNbHits` to search result.

Adds response documentation for search result

Changes the example for the search result response so it's clear that `nbHits` is not the number of result in the response. 