### PR TITLE
Place route prop back to the root of the prop object

### DIFF
--- a/.vuepress/components/RouteHighlighter.vue
+++ b/.vuepress/components/RouteHighlighter.vue
@@ -33,10 +33,10 @@ export default {
           x.toLowerCase()
         );
       },
-      route: {
-        type: String,
-        default: "my/route",
-      },
+    },
+    route: {
+      type: String,
+      default: "my/route",
     },
   },
 };


### PR DESCRIPTION
The route prop in highlightRoute component was declared inside the method prop. I put it back at the root of the prop object.

