### PR TITLE
Fix mistake in method to update settings

### DIFF
--- a/references/settings.md
+++ b/references/settings.md
@@ -102,7 +102,7 @@ Any parameters not provided will be left unchanged.
 
 ```bash
 $ curl \
-  -X GET 'http://localhost:7700/indexes/movies/settings' \
+  -X POST 'http://localhost:7700/indexes/movies/settings' \
   --data '{
    "rankingRules": [
             "typo",


### PR DESCRIPTION
The update settings example had `GET` as a method instead of `POST`