### PR TITLE
Replace 12345678 with the correct movies index

### DIFF
--- a/guides/introduction/quick_start_guide.md
+++ b/guides/introduction/quick_start_guide.md
@@ -362,7 +362,7 @@ The search engine is now aware of our documents and can serve those via our HTTP
 
 ```bash
 $ curl \
-  -X GET 'http://127.0.0.1:7700/indexes/12345678/search?q=botman'
+  -X GET 'http://127.0.0.1:7700/indexes/movies/search?q=botman'
 ```
 
 :::

--- a/references/stats.md
+++ b/references/stats.md
@@ -16,7 +16,7 @@ Get stats of an index.
 
 ```bash
 $ curl \
-  -X GET 'http://localhost:7700/indexes/12345678/stats'
+  -X GET 'http://localhost:7700/indexes/movies/stats'
 ```
 
 #### Response: `200 Ok`

--- a/references/stop_words.md
+++ b/references/stop_words.md
@@ -26,7 +26,7 @@ Get the [stop-words](/guides/advanced_guides/stop_words.md) list of an index.
 
 ```bash
 $ curl \
-  -X GET 'http://localhost:7700/indexes/12345678/settings/stop-words'
+  -X GET 'http://localhost:7700/indexes/movies/settings/stop-words'
 ```
 
 #### Response: `200 Ok`
@@ -57,7 +57,7 @@ If a list of stop-words already exists it will be overwritten (_replaced_).
 
 ```bash
 $ curl \
-  -X POST 'http://localhost:7700/indexes/12345678/settings/stop-words' \
+  -X POST 'http://localhost:7700/indexes/movies/settings/stop-words' \
   --data '["the", "of", "to"]'
 ```
 
@@ -91,7 +91,7 @@ Empty array: `[]`
 
 ```bash
 $ curl \
-  -X DELETE 'http://localhost:7700/indexes/12345678/settings/stop-words' \
+  -X DELETE 'http://localhost:7700/indexes/movies/settings/stop-words' \
 ```
 
 #### Response: `202 Accepted`

--- a/references/synonyms.md
+++ b/references/synonyms.md
@@ -26,7 +26,7 @@ Get the list of synonyms of an index.
 
 ```bash
  curl \
-  -X GET 'http://localhost:7700/indexes/12345678/settings/synonyms'
+  -X GET 'http://localhost:7700/indexes/movies/settings/synonyms'
 ```
 
 #### Response: `200 OK`
@@ -59,7 +59,7 @@ An object with every synonym and its associated words.
 
 ```bash
  curl \
-  -X POST 'http://localhost:7700/indexes/12345678/settings/synonyms' \
+  -X POST 'http://localhost:7700/indexes/movies/settings/synonyms' \
   --data '{
     "wolverine": ["xmen", "logan"],
     "logan": ["wolverine", "xmen"],
@@ -97,7 +97,7 @@ Empty object : `{}`
 
 ```bash
  curl \
-  -X DELETE 'http://localhost:7700/indexes/12345678/settings/synonyms'
+  -X DELETE 'http://localhost:7700/indexes/movies/settings/synonyms'
 ```
 
 #### Response: `202 Accepted`

--- a/references/updates.md
+++ b/references/updates.md
@@ -17,7 +17,7 @@ Get the status of an [update](/guides/advanced_guides/asynchronous_updates.md) i
 
 ```bash
 $ curl \
-  -X GET 'http://localhost:7700/indexes/12345678/updates/1'
+  -X GET 'http://localhost:7700/indexes/movies/updates/1'
 ```
 
 #### Response: `200 Ok`
@@ -54,7 +54,7 @@ Get the status of all [updates](/guides/advanced_guides/asynchronous_updates.md)
 
 ```bash
 $ curl \
-  -X GET 'http://localhost:7700/indexes/12345678/updates'
+  -X GET 'http://localhost:7700/indexes/movies/updates'
 ```
 
 #### Response: `200 Ok`


### PR DESCRIPTION
I noticed this issue when I was testing the documentation for the first time, the index starts with `movies` and it changes to `12345678` later. This PR fix this issue making everything use the index `movies`.