### PR TITLE
Search parameters

### DIFF
--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -159,7 +159,7 @@ You will get the following response with the **cropped version in the \_formatte
 }
 ```
 
-In the example above, the cropped version of `overview` is 200 characters longs. There are 100 characters before `shifu` (the first match) and 100 more characters from the first letter of `shifu`.
+In the example above, the cropped version of `overview` is 200 characters longs. There are 100 characters before `shifu` (the first match) and 100 more characters starting at the first letter of `shifu`.
 
 ## Attributes to highlight
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -7,7 +7,7 @@ Search parameters let the user customize their search request.
 | **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                         |               |
 | **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                        |      `0`      |
 | **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Number of documents returned                       |     `20`      |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Document attributes to show                        |     `\*`      |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Document attributes to show                        |     `*`      |
 | **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Which attributes to crop                           |    `none`     |
 | **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Limit length at which to crop specified attributes |     `200`     |
 | **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Which attributes to highlight                      |    `none`     |
@@ -23,6 +23,8 @@ It is the string used by the search engine to find relevant documents.
 ::: tip
 Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.
 :::
+
+## Query parameters
 
 ## Offset
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -105,7 +105,9 @@ Attributes whose values will be cropped if they contain a matched query word.
 
 - `<Attribute>` (Optional, string, defaults to empty)
 
-  Comma-separated list of attributes whose values shall be cropped according to the `cropLength` value.
+  Comma-separated list of attributes whose values will be cropped if they contain a matched query word. 
+  
+In the case a matched query word is found, the field's value will be cropped around the first matched query word according to the `cropLength` value (default `200` see below).
 
 ::: tip
 This is especially useful when you have to display content on the front-end in a specific way.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -221,7 +221,7 @@ This is useful when you need to highlight the results without the default HTML h
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d q=shifu \
-        -d attributesToHighlight=overview
+        -d attributesToHighlight=overview \
         -d matches=true
 ```
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -193,7 +193,7 @@ This is useful when you need to highlight the results without the default HTML h
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d q=shifu \
-        -d attributesToHighlight=overview
+        -d matches=overview
 ```
 
 ```json

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -2,17 +2,17 @@
 
 Search parameters let the user customize their search request.
 
-| Query Parameter                                                                                   | Description                                        | Default Value |
-| ------------------------------------------------------------------------------------------------- | -------------------------------------------------- | :-----------: |
-| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                         |               |
-| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                        |      `0`      |
-| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Number of documents returned                       |     `20`      |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Document attributes to show                        |      `*`      |
-| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Which attributes to crop                           |    `none`     |
-| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Limit length at which to crop specified attributes |     `200`     |
-| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Which attributes to highlight                      |    `none`     |
-| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Attribute with an exact match                      |    `none`     |
-| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Whether to return the raw matches or not           |    `false`    |
+| Query Parameter                                                                                   | Description                                                     | Default Value |
+| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | :-----------: |
+| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                                      |               |
+| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                                     |      `0`      |
+| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Maximum number of documents returned                            |     `20`      |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                 |      `*`      |
+| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                      |    `none`     |
+| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Maximum length of field values                                  |     `200`     |
+| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms |    `none`     |
+| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                            |    `none`     |
+| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Defines whether the raw matches should be returned or not       |    `false`    |
 
 ## Query (q)
 
@@ -201,7 +201,7 @@ $ curl --request GET  -G 'http://localhost:7700/indexes/movies/search' \
 
 ## Matches
 
-This setting takes a **Boolean value** (`true` or `false`) and defines whether to return raw matches or not.
+This setting takes a **Boolean value** (`true` or `false`) and defines whether the raw matches should be returned or not.
 
 `matches=<Boolean>`
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -24,6 +24,15 @@ The query parameter is the **only mandatory** parameter. This is the string used
 
   The query string.
 
+#### Example
+
+Suppose you would like to search `shifu` in a movie database, you would send:
+
+```bash
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu
+```
+
 ::: tip
 Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API will respond.
 :::
@@ -48,6 +57,35 @@ Set a limit to the number of documents returned by search queries.
 
   If the value of the parameter `limit` is _n_, there will be _n_ documents in the search query response. This is helpful for **pagination**.
 
+#### Example
+
+If you set limit to the number of documents returned to `2`:
+
+```bash
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d limit=2
+```
+
+You will get two documents:
+
+```json
+({
+  "id": "50393",
+  "title": "Kung Fu Panda Holiday",
+  "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
+  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
+  "release_date": 1290729600
+},
+{
+  "id": "9502",
+  "title": "Kung Fu Panda",
+  "poster": "https://image.tmdb.org/t/p/w1280/2Paj1nufT0jeSY0G4u3RC31HIGT.jpg",
+  "overview": "When the Valley of Peace is threatened, lazy Po the panda discovers his destiny as the 'chosen one' and trains to become a kung fu hero, but transforming the unsleek slacker into a brave warrior won't be easy. It's up to Master Shifu and the Furious Five -- Tigress, Crane, Mantis, Viper and Monkey -- to give it a try.",
+  "release_date": 1212541200
+})
+```
+
 ## Attributes to retrieve
 
 Attributes to display in the returned documents.
@@ -57,6 +95,28 @@ Attributes to display in the returned documents.
 - `<Attribute>` (Optional, string, Defaults to `*`)
 
   Comma-separated list of attributes that shall be in the returned documents.
+
+#### Example
+
+If you input `shifu` as a search query and want to retrieve only the `overview` field values (in the following example, the limit to the number of documents returned is set to 2):
+
+```bash
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d attributesToRetrieve=overview \
+      -d limit=2
+```
+
+You will get the following response:
+
+```json
+({
+  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping."
+},
+{
+  "overview": "When the Valley of Peace is threatened, lazy Po the panda discovers his destiny as the 'chosen one' and trains to become a kung fu hero, but transforming the unsleek slacker into a brave warrior won't be easy. It's up to Master Shifu and the Furious Five -- Tigress, Crane, Mantis, Viper and Monkey -- to give it a try."
+})
+```
 
 ## Attributes to crop
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -56,7 +56,7 @@ Although the API will send back documents even if the query is only one characte
 
 `attributesToCrop=<Attribute>,<Attribute>,...`
 
-- `<Attribute>` (Optional, string, defaults to `none`)
+- `<Attribute>` (Optional, string, defaults to empty)
 
   Comma-separated list of attributes whose values will be cropped according to the `cropLength` value and the matches.
 
@@ -110,7 +110,7 @@ You would get this response:
 
 `attributesToHighlight=<Attribute>,<Attribute>,...`
 
-- `<Attribute>` (Optional, string, defaults to `none`)
+- `<Attribute>` (Optional, string, defaults to empty)
 
   Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag.
 
@@ -151,7 +151,7 @@ This setting allows to **filter queries by an attribute value**.
 
 `filters=<Attribute>:<Value>`
 
-- `<Attribute>:<Value>` (Optional, string, defaults to `none`)
+- `<Attribute>:<Value>` (Optional, string, defaults to empty)
 
   Two strings separated by a colon.
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -113,7 +113,7 @@ This is especially useful when you have to display content on the front-end in a
 
 ## Crop length
 
-Set a **limit on the length** of field values.
+Set a length for the cropping around the matching query words (see attributesToCrop).
 
 `cropLength=<Integer>`
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -9,7 +9,7 @@ Search parameters let the user customize their search request.
 | **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Maximum number of documents returned                            |     `20`      |
 | **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                 |      `*`      |
 | **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                      |    `none`     |
-| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Maximum length of field values                                  |     `200`     |
+| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Length used to crop field values                                |     `200`     |
 | **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms |    `none`     |
 | **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                            |    `none`     |
 | **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Defines whether the raw matches should be returned or not       |    `false`    |
@@ -66,7 +66,7 @@ Attributes whose values have to be cropped.
 
 - `<Attribute>` (Optional, string, defaults to empty)
 
-  Comma-separated list of attributes whose values shall be cropped according to the `cropLength` value and the matches.
+  Comma-separated list of attributes whose values shall be cropped according to the `cropLength` value.
 
 ::: tip
 This is especially useful when you have to display content on the front-end in a specific way.
@@ -80,11 +80,11 @@ Set a limit on the length of field values.
 
 - `<Integer>` (Optional, positive integer, defaults to `200`)
 
-  If the value of the parameter `cropLength` is _n_, _n_ is the length used to crop field values.
+  The length used to crop field values.
 
 Cropping start at the **first occurrence of the search query**.
 
-If the value of the parameter `cropLength` is _n_, the returned field value will consist of **_n_ characters before the query word** and **_n_ characters from the first character of the query word**.
+If the value of the parameter `cropLength` is _n_, the returned field value will consist of **_n_ characters before the query word** and **_n_ characters from the first character of the query word**. Below is a simple representation:
 
 ```json
 _n_ characters + _n_ characters including the query word
@@ -120,7 +120,7 @@ You will get the following response with the **cropped version in the \_formatte
 }
 ```
 
-In the example above, the cropped version of overview is 200 characters longs. There are 100 characters before `shifu`, the first match, and 100 characters again from the first letter of `shifu`.
+In the example above, the cropped version of `overview` is 200 characters longs. There are 100 characters before `shifu` (the first match) and 100 more characters from the first letter of `shifu`.
 
 ## Attributes to highlight
 
@@ -130,7 +130,7 @@ Attributes whose values will contain highlighted matching terms.
 
 - `<Attribute>` (Optional, string, defaults to empty)
 
-  Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag.
+  Comma-separated list of attributes. Every matching string sequence in the given attribute field will be wrapped around an `<em>` tag.
 
 #### Example
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -254,7 +254,7 @@ $ curl --request GET  -G 'http://localhost:7700/indexes/movies/search' \
 
 ## Matches
 
-This setting takes a **Boolean value** (`true` or `false`) and defines whether the raw matches should be returned or not.
+This setting takes a **Boolean value** (`true` or `false`) and defines whether an object that contains information about the matches should be returned or not.
 
 `matches=<Boolean>`
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -28,7 +28,7 @@ Search parameters let the user customize their search request.
 Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.
 :::
 
-## Query parameters
+### Query parameters
 
 ## Offset
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -62,6 +62,14 @@ This is useful when you have specific needs for displaying results on the front-
 
 **Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2` chars on each side of the first match.
 
+## Crop length
+
+`cropLength=<Integer>`
+
+- `<Integer>` (Optional, positive integer)
+
+  If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field.
+
 #### Example
 
 If you input `shifu` as a search query and set the value of the parameter `cropLength` to 100 as below:
@@ -93,14 +101,6 @@ You would get this response:
   }
 }
 ```
-
-## Crop length
-
-`cropLength=<Integer>`
-
-- `<Integer>` (Optional, positive integer)
-
-  If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field. See [attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)
 
 ## Attributes to highlight
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -72,8 +72,6 @@ Attributes whose values have to be cropped.
 This is especially useful when you have to display content on the front-end in a specific way.
 :::
 
-**Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2` characters on each side of the first match.
-
 ## Crop length
 
 Set a limit on the length of field values.
@@ -82,7 +80,15 @@ Set a limit on the length of field values.
 
 - `<Integer>` (Optional, positive integer, defaults to `200`)
 
-  If the value of the parameter `cropLength` is _n_, _n_ is the total length of cropped field values.
+  If the value of the parameter `cropLength` is _n_, _n_ is the length used to crop field values.
+
+Cropping start at the **first occurrence of the search query**.
+
+If the value of the parameter `cropLength` is _n_, the returned field value will consist of **_n_ characters before the query word** and **_n_ characters from the first character of the query word**.
+
+```json
+_n_ characters + _n_ characters including the query word
+```
 
 #### Example
 
@@ -113,6 +119,8 @@ You will get the following response with the **cropped version in the \_formatte
   }
 }
 ```
+
+In the example above, the cropped version of overview is 200 characters longs. There are 100 characters before `shifu`, the first match, and 100 characters again from the first letter of `shifu`.
 
 ## Attributes to highlight
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -25,7 +25,7 @@ The query parameter is the **only mandatory** parameter. This is the string used
   The query string.
 
 ::: tip
-Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.
+Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API will respond.
 :::
 
 ## Offset
@@ -72,7 +72,7 @@ Attributes whose values have to be cropped.
 This is especially useful when you have to display content on the front-end in a specific way.
 :::
 
-**Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2` chars on each side of the first match.
+**Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2` characters on each side of the first match.
 
 ## Crop length
 
@@ -82,22 +82,20 @@ Set a limit on the length of field values.
 
 - `<Integer>` (Optional, positive integer, defaults to `200`)
 
-  If the value of the parameter `cropLength` is _n_, _n_ is the total length of cropped fields.
+  If the value of the parameter `cropLength` is _n_, _n_ is the total length of cropped field values.
 
 #### Example
 
-If you input `shifu` as a search query and set the value of the parameter `cropLength` to 100 as below:
+If you input `shifu` as a search query and set the value of the parameter `cropLength` to `100` as below:
 
 ```bash
-$ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
-        -d q=shifu \
-        -d attributesToCrop=overview \
-        -d cropLength=100 \
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d attributesToCrop=overview \
+      -d cropLength=100
 ```
 
-Our **cropped version is in the \_formatted object**.
-
-You would get this response:
+You will get the following response with the **cropped version in the \_formatted object**:
 
 ```json
 {
@@ -129,9 +127,9 @@ Attributes whose values will contain highlighted matching terms.
 #### Example
 
 ```bash
-$ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
-        -d q=shifu \
-        -d attributesToHighlight=overview
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d attributesToHighlight=overview
 ```
 
 Our **highlight version is in the \_formatted object**.
@@ -177,8 +175,8 @@ This setting allows to **filter queries by an attribute value**.
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
-        -d q=n \
-        -d filters='title:Nightshift'
+      -d q=n \
+      -d filters='title:Nightshift'
 ```
 
 With the settings in the example above, only documents that contain the value `Nightshift` in their `title` attribute will be returned upon search.
@@ -196,10 +194,9 @@ With the settings in the example above, only documents that contain the value `N
 The parameter shall be **URL-encoded**.
 
 ```bash
-$ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \
-        -d q=shifu \
-        -d filters='title:Kung%20Fu%20Panda' \
-        -i
+$ curl --request GET  -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d filters='title:Kung%20Fu%20Panda'
 ```
 
 ## Matches
@@ -219,10 +216,10 @@ This is useful when you need to highlight the results without the default HTML h
 #### Example
 
 ```bash
-$ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
-        -d q=shifu \
-        -d attributesToHighlight=overview \
-        -d matches=true
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d attributesToHighlight=overview \
+      -d matches=true
 ```
 
 ```json

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -85,7 +85,7 @@ Attributes to **display** in the returned documents.
 
 - `<Attribute>` (Optional, string, Defaults to `*`)
 
-  Comma-separated list of attributes that will be in the returned documents.
+  Comma-separated list of attributes whose fields will be present in the returned documents.
 
 #### Example
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -169,7 +169,7 @@ Attributes whose values will contain **highlighted matching terms**.
 
 - `<Attribute>` (Optional, string, defaults to empty)
 
-  Comma-separated list of attributes. Every matching string sequence in the given attribute field will be wrapped around an `<em>` tag.
+  Comma-separated list of attributes. Every matching query words in the given attribute field will be wrapped around an `<em>` tag.
 
 #### Example
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -141,11 +141,13 @@ Our **highlight version is in the \_formatted object**.
 }
 ```
 
-The **overview attribute in formatted** looks like this when evaluated in HTML:
+When evaluated in HTML, the **overview attribute in \_formatted** will look like as follows:
 
 The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year <em>**Shifu**</em> informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between <em>**Shifu**</em> and Mr. Ping.
 
 ## Filters
+
+This setting allows to **filter queries by an attribute value**.
 
 `filters=<Attribute>:<Value>`
 
@@ -153,11 +155,11 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 
   Two strings separated by a colon.
 
-  - `<Attribute>`: An attribute name.
+  - `<Attribute>`: The attribute name.
 
-  - `<Value>`: Its corresponding value.
+  - `<Value>`: The value which will be used to filter documents.
 
-  The given attribute's value must be **equal** to the value of the attribute in the documents. Filters accept **only one** parameter.
+  The attribute value used for filtering must be **equal** to the existing attribute value in the documents. Filters accept **only one** parameter.
 
   The **comparison is done in a case-insensitive manner**.
 
@@ -166,6 +168,8 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d q=n \
         -d filters='title:Nightshift'
 ```
+
+With the settings in the example above, only documents that contain the value `Nightshift` in their `title` attribute will be returned upon search.
 
 ```json
 {
@@ -177,7 +181,7 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
 }
 ```
 
-The parameter should be **URL-encoded**.
+The parameter shall be **URL-encoded**.
 
 ```bash
 $ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -163,7 +163,7 @@ In the example above, the cropped version of `overview` is 200 characters longs.
 
 ## Attributes to highlight
 
-Attributes whose values will contain **highlighted matching terms**.
+Attributes whose values will contain **highlighted matching query words**.
 
 `attributesToHighlight=<Attribute>,<Attribute>,...`
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -39,7 +39,7 @@ Although the API will send back documents even if the query is only one characte
 
 ## Offset
 
-A number of documents to skip.
+A number of **documents to skip**.
 
 `offset=<Integer>`
 
@@ -59,7 +59,7 @@ $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
 
 ## Limit
 
-Set a limit to the number of documents returned by search queries.
+Set a **limit to the number of documents returned** by search queries.
 
 `limit=<Integer>`
 
@@ -79,7 +79,7 @@ $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
 
 ## Attributes to retrieve
 
-Attributes to display in the returned documents.
+Attributes to **display** in the returned documents.
 
 `attributesToRetrieve=<Attribute>,<Attribute>,...`
 
@@ -113,7 +113,7 @@ This is especially useful when you have to display content on the front-end in a
 
 ## Crop length
 
-Set a limit on the length of field values.
+Set a **limit on the length** of field values.
 
 `cropLength=<Integer>`
 
@@ -163,7 +163,7 @@ In the example above, the cropped version of `overview` is 200 characters longs.
 
 ## Attributes to highlight
 
-Attributes whose values will contain highlighted matching terms.
+Attributes whose values will contain **highlighted matching terms**.
 
 `attributesToHighlight=<Attribute>,<Attribute>,...`
 
@@ -208,6 +208,8 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 
 This setting allows to **filter queries by an attribute value**.
 
+Filters accept **only one** parameter.
+
 `filters=<Attribute>:<Value>`
 
 - `<Attribute>:<Value>` (Optional, string, defaults to empty)
@@ -218,9 +220,7 @@ This setting allows to **filter queries by an attribute value**.
 
   - `<Value>`: The value which will be used to filter documents.
 
-  The attribute value used for filtering must be **equal to** the existing attribute value in the documents. Filters accept **only one** parameter.
-
-  The **comparison is done in a case-insensitive manner**.
+The attribute value used for filtering must be **equal to** the existing attribute value in the documents. The **comparison is done in a case-insensitive manner**.
 
 #### Example
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -58,7 +58,7 @@ Although the API will send back documents even if the query is only one characte
 
 - `<Attribute>` (Optional, string, defaults to `none`)
 
-  Comma-separated list of attributes whose values will be cropped depending on the `cropLength` and the matches.
+  Comma-separated list of attributes whose values will be cropped according to the `cropLength` value and the matches.
 
 ::: tip
 This is useful when you have specific needs for displaying results on the front-end application.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -28,47 +28,37 @@ Search parameters let the user customize their search request.
 Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.
 :::
 
-### Query parameters
-
 ## Offset
 
 `offset=<Integer>`
 
-- `<Integer>` (Optional, positive integer)
+- `<Integer>` (Optional, positive integer, defaults to `0`)
 
   If the value of the parameter `offset` is _n_, _n_ first documents to skip. This is helpful for **pagination**.
-
-  Defaults to `0`.
 
 ## Limit
 
 `limit=<Integer>`
 
-- `<Integer>` (Optional, positive integer)
+- `<Integer>` (Optional, positive integer, defaults to `20`)
 
   If the value of the parameter `limit` is _n_, there will be _n_ documents in the search query response. This is helpful for **pagination**.
-
-  Defaults to `20`.
 
 ## Attributes to retrieve
 
 `attributesToRetrieve=<Attribute>,<Attribute>,...`
 
-- `<Attribute>` (Optional, string)
+- `<Attribute>` (Optional, string, Defaults to `*`)
 
   Comma-separated list of attributes that will appear in the returned documents.
-
-  Defaults to `*`.
 
 ## Attributes to crop
 
 `attributesToCrop=<Attribute>,<Attribute>,...`
 
-- `<Attribute>` (Optional, string)
+- `<Attribute>` (Optional, string, defaults to `none`)
 
   Comma-separated list of attributes whose values will be cropped depending on the `cropLength` and the matches.
-
-  Defaults to `none`.
 
 ::: tip
 This is useful when you have specific needs for displaying results on the front-end application.
@@ -80,11 +70,9 @@ This is useful when you have specific needs for displaying results on the front-
 
 `cropLength=<Integer>`
 
-- `<Integer>` (Optional, positive integer)
+- `<Integer>` (Optional, positive integer, defaults to `200`)
 
   If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field.
-
-  Defaults to `200`.
 
 #### Example
 
@@ -122,11 +110,9 @@ You would get this response:
 
 `attributesToHighlight=<Attribute>,<Attribute>,...`
 
-- `<Attribute>` (Optional, string)
+- `<Attribute>` (Optional, string, defaults to `none`)
 
   Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag.
-
-  Defaults to `none`.
 
 #### Example
 
@@ -163,11 +149,9 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 
 `filters=<Attribute>:<Value>`
 
-- `<Attribute>:<Value>` (Optional, string)
+- `<Attribute>:<Value>` (Optional, string, defaults to `none`)
 
   Two strings separated by a colon.
-
-  Defaults to `none`.
 
   - `<Attribute>`: An attribute name.
 
@@ -206,11 +190,9 @@ $ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \
 
 `matches=<Boolean>`
 
-- `<Boolean>` (Optional, boolean)
+- `<Boolean>` (Optional, boolean, defaults to `false`)
 
   If `true`, returns an array of the search query occurrences in all fields. A search query occurrence is given by a `start` position in the field and the `length` of the occurrence.
-
-  Defaults to `false`.
 
 ::: tip
 This is useful when you need to highlight the results without the default HTML highlighter.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -47,6 +47,16 @@ A number of documents to skip.
 
   If the value of the parameter `offset` is _n_, _n_ first documents to skip. This is helpful for **pagination**.
 
+#### Example
+
+If you want to skip the **first** document, set `offset` to `1`.
+
+```bash
+$ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
+      -d q=shifu \
+      -d offset=1
+```
+
 ## Limit
 
 Set a limit to the number of documents returned by search queries.
@@ -59,31 +69,12 @@ Set a limit to the number of documents returned by search queries.
 
 #### Example
 
-If you set limit to the number of documents returned to `2`:
+If you want to get only **two** documents, set `limit` to `2`.
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
       -d q=shifu \
       -d limit=2
-```
-
-You will get two documents:
-
-```json
-({
-  "id": "50393",
-  "title": "Kung Fu Panda Holiday",
-  "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
-  "release_date": 1290729600
-},
-{
-  "id": "9502",
-  "title": "Kung Fu Panda",
-  "poster": "https://image.tmdb.org/t/p/w1280/2Paj1nufT0jeSY0G4u3RC31HIGT.jpg",
-  "overview": "When the Valley of Peace is threatened, lazy Po the panda discovers his destiny as the 'chosen one' and trains to become a kung fu hero, but transforming the unsleek slacker into a brave warrior won't be easy. It's up to Master Shifu and the Furious Five -- Tigress, Crane, Mantis, Viper and Monkey -- to give it a try.",
-  "release_date": 1212541200
-})
 ```
 
 ## Attributes to retrieve
@@ -110,12 +101,12 @@ $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
 You will get the following response:
 
 ```json
-({
+{
   "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping."
 },
 {
   "overview": "When the Valley of Peace is threatened, lazy Po the panda discovers his destiny as the 'chosen one' and trains to become a kung fu hero, but transforming the unsleek slacker into a brave warrior won't be easy. It's up to Master Shifu and the Furious Five -- Tigress, Crane, Mantis, Viper and Monkey -- to give it a try."
-})
+}
 ```
 
 ## Attributes to crop

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -26,19 +26,19 @@ Although the API will send back documents even if the query is only one characte
 
 ## Offset
 
-`offset=<Integer>`.
+`offset=<Integer>`
 
 X first documents to skip. This is helpful for **pagination**
 
 ## Limit
 
-`limit=<Integer>`.
+`limit=<Integer>`
 
 X number of documents in the search query response. This is helpful for **pagination**
 
 ## Attributes to retrieve
 
-`attributesToRetrieve=<Attribute>,<Attribute>,...`.
+`attributesToRetrieve=<Attribute>,<Attribute>,...`
 
 Attributes that will appear in the returned documents.
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -118,6 +118,8 @@ You would get this response:
 
 ## Attributes to highlight
 
+Attributes whose values will contain highlighted matching terms.
+
 `attributesToHighlight=<Attribute>,<Attribute>,...`
 
 - `<Attribute>` (Optional, string, defaults to empty)
@@ -201,6 +203,8 @@ $ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \
 ```
 
 ## Matches
+
+This setting takes a **Boolean value** (`true` or `false`) and defines whether to return raw matches or not.
 
 `matches=<Boolean>`
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -7,7 +7,7 @@ Search parameters let the user customize their search request.
 | **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                         |               |
 | **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                        |      `0`      |
 | **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Number of documents returned                       |     `20`      |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Document attributes to show                        |     `*`      |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Document attributes to show                        |      `*`      |
 | **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Which attributes to crop                           |    `none`     |
 | **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Limit length at which to crop specified attributes |     `200`     |
 | **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Which attributes to highlight                      |    `none`     |
@@ -16,9 +16,13 @@ Search parameters let the user customize their search request.
 
 ## Query (q)
 
-The query parameter is the **only mandatory** parameter.
+`q=<String>`
 
-It is the string used by the search engine to find relevant documents.
+- `<String>` (Mandatory, string)
+
+  The query parameter is the **only mandatory** parameter.
+
+  It is the string used by the search engine to find relevant documents.
 
 ::: tip
 Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -119,7 +119,7 @@ Set a **limit on the length** of field values.
 
 - `<Integer>` (Optional, positive integer, defaults to `200`)
 
-  The length used to crop field values.
+  The length used to crop field values around the first matched query word if the field's attribute is in the `attributedToCrop` list.
 
 Cropping start at the **first occurrence of the search query**.
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -30,6 +30,8 @@ Although the API will send back documents even if the query is only one characte
 
 ## Offset
 
+A number of documents to skip.
+
 `offset=<Integer>`
 
 - `<Integer>` (Optional, positive integer, defaults to `0`)
@@ -37,6 +39,8 @@ Although the API will send back documents even if the query is only one characte
   If the value of the parameter `offset` is _n_, _n_ first documents to skip. This is helpful for **pagination**.
 
 ## Limit
+
+Set a limit to the number of documents returned by search queries.
 
 `limit=<Integer>`
 
@@ -46,33 +50,39 @@ Although the API will send back documents even if the query is only one characte
 
 ## Attributes to retrieve
 
+Attributes to display in the returned documents.
+
 `attributesToRetrieve=<Attribute>,<Attribute>,...`
 
 - `<Attribute>` (Optional, string, Defaults to `*`)
 
-  Comma-separated list of attributes that will appear in the returned documents.
+  Comma-separated list of attributes that shall be in the returned documents.
 
 ## Attributes to crop
+
+Attributes whose values have to be cropped.
 
 `attributesToCrop=<Attribute>,<Attribute>,...`
 
 - `<Attribute>` (Optional, string, defaults to empty)
 
-  Comma-separated list of attributes whose values will be cropped according to the `cropLength` value and the matches.
+  Comma-separated list of attributes whose values shall be cropped according to the `cropLength` value and the matches.
 
 ::: tip
-This is useful when you have specific needs for displaying results on the front-end application.
+This is especially useful when you have to display content on the front-end in a specific way.
 :::
 
 **Cropping start at the first occurrence of the search query**. It only keeps `(cropLength - matchLength)/2` chars on each side of the first match.
 
 ## Crop length
 
+Set a limit on the length of field values.
+
 `cropLength=<Integer>`
 
 - `<Integer>` (Optional, positive integer, defaults to `200`)
 
-  If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field.
+  If the value of the parameter `cropLength` is _n_, _n_ is the total length of cropped fields.
 
 #### Example
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -36,19 +36,25 @@ Although the API will send back documents even if the query is only one characte
 
 `limit=<Integer>`
 
-X number of documents in the search query response. This is helpful for **pagination**
+- `<Integer>` (Optional, positive integer)
+
+  If the value of the parameter `limit` is _n_, there will be _n_ documents in the search query response. This is helpful for **pagination**.
 
 ## Attributes to retrieve
 
 `attributesToRetrieve=<Attribute>,<Attribute>,...`
 
-Attributes that will appear in the returned documents.
+- `<Attribute>` (Optional, string)
+
+  Comma-separated list of attributes that will appear in the returned documents.
 
 ## Attributes to crop
 
 `attributesToCrop=<Attribute>,<Attribute>,...`
 
-Attributes of which the value will be cropped depending on the `cropLength` and the matches.
+- `<Attribute>` (Optional, string)
+
+  Comma-separated list of attributes whose values will be cropped depending on the `cropLength` and the matches.
 
 ::: tip
 This is useful when you have specific needs for displaying results on the front-end application.
@@ -58,6 +64,8 @@ This is useful when you have specific needs for displaying results on the front-
 
 #### Example
 
+If you input `shifu` as a search query and set the value of the parameter `cropLength` to 100 as below:
+
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d q=shifu \
@@ -65,9 +73,9 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d cropLength=100 \
 ```
 
-With a `cropLength` of 100 on `shifu` as a search query this is the response.
-
 Our **cropped version is in the \_formatted object**.
+
+You would get this response:
 
 ```json
 {
@@ -90,13 +98,17 @@ Our **cropped version is in the \_formatted object**.
 
 `cropLength=<Integer>`
 
-Total length of the cropped field. See [attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)
+- `<Integer>` (Optional, positive integer)
+
+  If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field. See [attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)
 
 ## Attributes to highlight
 
 `attributesToHighlight=<Attribute>,<Attribute>,...`
 
-Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag
+- `<Attribute>` (Optional, string)
+
+  Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag
 
 #### Example
 
@@ -131,11 +143,15 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 
 ## Filters
 
-`filters=<Attribute>:<String>`
+`filters=<Attribute>:<Value>`
 
-The given attribute's value must be **equal** to the value of the attribute in the documents. Filters accept **only one** parameter.
+- `<Attribute>:<Value>` (Optional, string)
 
-The **comparison is done in a case-insensitive manner**.
+  Two strings separated by a colon.
+
+  The given attribute's value must be **equal** to the value of the attribute in the documents. Filters accept **only one** parameter.
+
+  The **comparison is done in a case-insensitive manner**.
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -121,7 +121,7 @@ Set a **limit on the length** of field values.
 
   The length used to crop field values around the first matched query word if the field's attribute is in the `attributedToCrop` list.
 
-Cropping start at the **first occurrence of the search query**.
+Cropping start at the **first occurrence of the matched query word**.
 
 If the value of the parameter `cropLength` is _n_, the returned field value will consist of **_n_ characters before the query word** and **_n_ characters from the first character of the query word**. Below is a simple representation:
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -193,7 +193,7 @@ This is useful when you need to highlight the results without the default HTML h
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d q=shifu \
-        -d matches=overview
+        -d attributesToHighlight=overview
 ```
 
 ```json

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -92,7 +92,7 @@ _n_ characters + _n_ characters including the query word
 
 #### Example
 
-If you input `shifu` as a search query and set the value of the parameter `cropLength` to `100` as below:
+If you input `shifu` as a search query and set the value of the parameter `cropLength` to `100`:
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
@@ -134,13 +134,15 @@ Attributes whose values will contain highlighted matching terms.
 
 #### Example
 
+If you choose to highlight the content of `overview`:
+
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
       -d q=shifu \
       -d attributesToHighlight=overview
 ```
 
-Our **highlight version is in the \_formatted object**.
+You will get the following response with the **highlighted version in the \_formatted object**:
 
 ```json
 {
@@ -177,9 +179,13 @@ This setting allows to **filter queries by an attribute value**.
 
   - `<Value>`: The value which will be used to filter documents.
 
-  The attribute value used for filtering must be **equal** to the existing attribute value in the documents. Filters accept **only one** parameter.
+  The attribute value used for filtering must be **equal to** the existing attribute value in the documents. Filters accept **only one** parameter.
 
   The **comparison is done in a case-insensitive manner**.
+
+#### Example
+
+If you add this filter:
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
@@ -187,7 +193,7 @@ $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
       -d filters='title:Nightshift'
 ```
 
-With the settings in the example above, only documents that contain the value `Nightshift` in their `title` attribute will be returned upon search.
+Only documents that contain the value `Nightshift` in their `title` attribute will be returned upon search.
 
 ```json
 {
@@ -223,12 +229,16 @@ This is useful when you need to highlight the results without the default HTML h
 
 #### Example
 
+If you set `matches` to `true`:
+
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
       -d q=shifu \
       -d attributesToHighlight=overview \
       -d matches=true
 ```
+
+You will get the following response with the **raw matches in the \_matchesInfo object**:
 
 ```json
 {

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -2,17 +2,17 @@
 
 Search parameters let the user customize their search request.
 
-| Query Parameter                                                                                   | Description                                                     | Default Value |
-| ------------------------------------------------------------------------------------------------- | --------------------------------------------------------------- | :-----------: |
-| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                                      |               |
-| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                                     |      `0`      |
-| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Maximum number of documents returned                            |     `20`      |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                 |      `*`      |
-| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                      |    `none`     |
-| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Length used to crop field values                                |     `200`     |
-| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms |    `none`     |
-| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                            |    `none`     |
-| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Defines whether the raw matches should be returned or not       |    `false`    |
+| Query Parameter                                                                                   | Description                                                                                     | Default Value |
+| ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
+| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                                                                      |               |
+| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                                                                     |      `0`      |
+| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Maximum number of documents returned                                                            |     `20`      |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                                                 |      `*`      |
+| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                                                      |    `none`     |
+| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Length used to crop field values                                                                |     `200`     |
+| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
+| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                                                            |    `none`     |
+| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
 ## Query (q)
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -182,7 +182,10 @@ $ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \
 
 `matches=<Boolean>`
 
-Returns an array of the search query occurrences in all fields. A search query occurrence is given by a `start` position in the field and the `length` of the occurrence.
+- `<Boolean>` (Optional, boolean)
+
+  If `true`, returns an array of the search query occurrences in all fields. A search query occurrence is given by a `start` position in the field and the `length` of the occurrence.
+  Defaults to `false`.
 
 ::: tip
 This is useful when you need to highlight the results without the default HTML highlighter.
@@ -194,6 +197,7 @@ This is useful when you need to highlight the results without the default HTML h
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
         -d q=shifu \
         -d attributesToHighlight=overview
+        -d matches=true
 ```
 
 ```json

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -1,6 +1,6 @@
 # Search Parameters
 
-Search parameters let the user customize his search request.
+Search parameters let the user customize their search request.
 
 | Query Parameter                                                                                   | Description                                        | Default Value |
 | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- | :-----------: |

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -89,7 +89,7 @@ Attributes to **display** in the returned documents.
 
 #### Example
 
-If you want to get only the `overview` field values, set `attributesToRetrieve` to `overview`.
+If you want to get only the `overview` and `title` field and not the other fields, set `attributesToRetrieve` to `overview,title`.
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -37,6 +37,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Integer>` (Optional, positive integer)
 
   If the value of the parameter `offset` is _n_, _n_ first documents to skip. This is helpful for **pagination**.
+
   Defaults to `0`.
 
 ## Limit
@@ -46,6 +47,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Integer>` (Optional, positive integer)
 
   If the value of the parameter `limit` is _n_, there will be _n_ documents in the search query response. This is helpful for **pagination**.
+
   Defaults to `20`.
 
 ## Attributes to retrieve
@@ -55,6 +57,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Attribute>` (Optional, string)
 
   Comma-separated list of attributes that will appear in the returned documents.
+
   Defaults to `*`.
 
 ## Attributes to crop
@@ -64,6 +67,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Attribute>` (Optional, string)
 
   Comma-separated list of attributes whose values will be cropped depending on the `cropLength` and the matches.
+
   Defaults to `none`.
 
 ::: tip
@@ -79,6 +83,7 @@ This is useful when you have specific needs for displaying results on the front-
 - `<Integer>` (Optional, positive integer)
 
   If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field.
+
   Defaults to `200`.
 
 #### Example
@@ -119,7 +124,8 @@ You would get this response:
 
 - `<Attribute>` (Optional, string)
 
-  Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag
+  Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag.
+
   Defaults to `none`.
 
 #### Example
@@ -160,6 +166,7 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 - `<Attribute>:<Value>` (Optional, string)
 
   Two strings separated by a colon.
+
   Defaults to `none`.
 
   - `<Attribute>`: An attribute name.
@@ -202,6 +209,7 @@ $ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \
 - `<Boolean>` (Optional, boolean)
 
   If `true`, returns an array of the search query occurrences in all fields. A search query occurrence is given by a `start` position in the field and the `length` of the occurrence.
+
   Defaults to `false`.
 
 ::: tip

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -94,7 +94,7 @@ If you want to get only the `overview` field values, set `attributesToRetrieve` 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
       -d q=shifu \
-      -d attributesToRetrieve=overview
+      -d attributesToRetrieve=overview,title
 ```
 
 ## Attributes to crop

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -4,15 +4,15 @@ Search parameters let the user customize their search request.
 
 | Query Parameter                                                                                   | Description                                        | Default Value |
 | ------------------------------------------------------------------------------------------------- | -------------------------------------------------- | :-----------: |
-| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | query string _(mandatory)_                         |               |
-| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | number of documents to skip                        |       0       |
-| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | number of documents returned                       |      20       |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | document attributes to show                        |      \*       |
-| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | which attributes to crop                           |     none      |
-| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | limit length at which to crop specified attributes |      200      |
-| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | which attributes to highlight                      |     none      |
-| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | attribute with an exact match                      |     none      |
-| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | whether to return the raw matches or not           |     false     |
+| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string _(mandatory)_                         |               |
+| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                        |      `0`      |
+| **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Number of documents returned                       |     `20`      |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Document attributes to show                        |     `\*`      |
+| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Which attributes to crop                           |    `none`     |
+| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Limit length at which to crop specified attributes |     `200`     |
+| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Which attributes to highlight                      |    `none`     |
+| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Attribute with an exact match                      |    `none`     |
+| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Whether to return the raw matches or not           |    `false`    |
 
 ## Query (q)
 
@@ -31,6 +31,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Integer>` (Optional, positive integer)
 
   If the value of the parameter `offset` is _n_, _n_ first documents to skip. This is helpful for **pagination**.
+  Defaults to `0`.
 
 ## Limit
 
@@ -39,6 +40,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Integer>` (Optional, positive integer)
 
   If the value of the parameter `limit` is _n_, there will be _n_ documents in the search query response. This is helpful for **pagination**.
+  Defaults to `20`.
 
 ## Attributes to retrieve
 
@@ -47,6 +49,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Attribute>` (Optional, string)
 
   Comma-separated list of attributes that will appear in the returned documents.
+  Defaults to `*`.
 
 ## Attributes to crop
 
@@ -55,6 +58,7 @@ Although the API will send back documents even if the query is only one characte
 - `<Attribute>` (Optional, string)
 
   Comma-separated list of attributes whose values will be cropped depending on the `cropLength` and the matches.
+  Defaults to `none`.
 
 ::: tip
 This is useful when you have specific needs for displaying results on the front-end application.
@@ -69,6 +73,7 @@ This is useful when you have specific needs for displaying results on the front-
 - `<Integer>` (Optional, positive integer)
 
   If the value of the parameter `cropLength` is _n_, _n_ is the total length of the cropped field.
+  Defaults to `200`.
 
 #### Example
 
@@ -109,6 +114,7 @@ You would get this response:
 - `<Attribute>` (Optional, string)
 
   Comma-separated list of attributes. Every matching string sequence in the given attribute's field will be wrapped around an `<em>` tag
+  Defaults to `none`.
 
 #### Example
 
@@ -148,6 +154,7 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 - `<Attribute>:<Value>` (Optional, string)
 
   Two strings separated by a colon.
+  Defaults to `none`.
 
   The given attribute's value must be **equal** to the value of the attribute in the documents. Filters accept **only one** parameter.
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -105,8 +105,8 @@ Attributes whose values will be cropped if they contain a matched query word.
 
 - `<Attribute>` (Optional, string, defaults to empty)
 
-  Comma-separated list of attributes whose values will be cropped if they contain a matched query word. 
-  
+  Comma-separated list of attributes whose values will be cropped if they contain a matched query word.
+
 In the case a matched query word is found, the field's value will be cropped around the first matched query word according to the `cropLength` value (default `200` see below).
 
 ::: tip

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -99,7 +99,7 @@ $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
 
 ## Attributes to crop
 
-Attributes whose values have to be cropped.
+Attributes whose values will be cropped if they contain a matched query word.
 
 `attributesToCrop=<Attribute>,<Attribute>,...`
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -18,10 +18,10 @@ Search parameters let the user customize their search request.
 
 The query parameter is the **only mandatory** parameter.
 
-It is the string the search engine uses to find relevant documents.
+It is the string used by the search engine to find relevant documents.
 
 ::: tip
-Although the API will send back documents even with only one letter, the more precise the search query is, the faster the API responds.
+Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.
 :::
 
 ## Offset

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -162,6 +162,10 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
   Two strings separated by a colon.
   Defaults to `none`.
 
+  - `<Attribute>`: An attribute name.
+
+  - `<Value>`: Its corresponding value.
+
   The given attribute's value must be **equal** to the value of the attribute in the documents. Filters accept **only one** parameter.
 
   The **comparison is done in a case-insensitive manner**.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -89,24 +89,12 @@ Attributes to display in the returned documents.
 
 #### Example
 
-If you input `shifu` as a search query and want to retrieve only the `overview` field values (in the following example, the limit to the number of documents returned is set to 2):
+If you want to get only the `overview` field values, set `attributesToRetrieve` to `overview`.
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/movies/search' \
       -d q=shifu \
-      -d attributesToRetrieve=overview \
-      -d limit=2
-```
-
-You will get the following response:
-
-```json
-{
-  "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping."
-},
-{
-  "overview": "When the Valley of Peace is threatened, lazy Po the panda discovers his destiny as the 'chosen one' and trains to become a kung fu hero, but transforming the unsleek slacker into a brave warrior won't be easy. It's up to Master Shifu and the Furious Five -- Tigress, Crane, Mantis, Viper and Monkey -- to give it a try."
-}
+      -d attributesToRetrieve=overview
 ```
 
 ## Attributes to crop

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -85,7 +85,7 @@ Attributes to **display** in the returned documents.
 
 - `<Attribute>` (Optional, string, Defaults to `*`)
 
-  Comma-separated list of attributes that shall be in the returned documents.
+  Comma-separated list of attributes that will be in the returned documents.
 
 #### Example
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -244,7 +244,7 @@ Only documents that contain the value `Nightshift` in their `title` attribute wi
 }
 ```
 
-The parameter shall be **URL-encoded**.
+The parameter must be **URL-encoded**.
 
 ```bash
 $ curl --request GET  -G 'http://localhost:7700/indexes/movies/search' \

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -28,7 +28,9 @@ Although the API will send back documents even if the query is only one characte
 
 `offset=<Integer>`
 
-X first documents to skip. This is helpful for **pagination**
+- `<Integer>` (Optional, positive integer)
+
+  If the value of the parameter `offset` is _n_, _n_ first documents to skip. This is helpful for **pagination**.
 
 ## Limit
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -16,13 +16,13 @@ Search parameters let the user customize their search request.
 
 ## Query (q)
 
+The query parameter is the **only mandatory** parameter. This is the string used by the search engine to find relevant documents.
+
 `q=<String>`
 
 - `<String>` (Mandatory, string)
 
-  The query parameter is the **only mandatory** parameter.
-
-  It is the string used by the search engine to find relevant documents.
+  The query string.
 
 ::: tip
 Although the API will send back documents even if the query is only one character long, the more precise the search query is, the faster the API responds.

--- a/references/search.md
+++ b/references/search.md
@@ -14,17 +14,17 @@ Search for documents matching a specific query in the given index.
 
 #### Query Parameters
 
-| Query Parameter           | Description                                        | Default Value |
-| ------------------------- | -------------------------------------------------- | :-----------: |
-| **q**                     | query string _(mandatory)_                         |               |
-| **offset**                | number of documents to skip                        |       0       |
-| **limit**                 | number of documents to take                        |      20       |
-| **attributesToRetrieve**  | document attributes to show                        |      \*       |
-| **attributesToCrop**      | which attributes to crop                           |     none      |
-| **cropLength**            | limit length at which to crop specified attributes |      200      |
-| **attributesToHighlight** | which attributes to highlight                      |     none      |
-| **filters**               | attribute with an exact match                      |     none      |
-| **matches**               | whether to return the raw matches or not           |     false     |
+| Query Parameter           | Description                                                     | Default Value |
+| ------------------------- | --------------------------------------------------------------- | :-----------: |
+| **q**                     | Query string \_(mandatory)                                      |               |
+| **offset**                | Number of documents to skip                                     |      `0`      |
+| **limit**                 | Maximum number of documents returned                            |     `20`      |
+| **attributesToRetrieve**  | Attributes to display in the returned documents                 |      `*`      |
+| **attributesToCrop**      | Attributes whose values have to be cropped                      |    `none`     |
+| **cropLength**            | Length used to crop field values                                |     `200`     |
+| **attributesToHighlight** | Attributes whose values will contain highlighted matching terms |    `none`     |
+| **filters**               | Filter queries by an attribute value                            |    `none`     |
+| **matches**               | Defines whether the raw matches should be returned or not       |    `false`    |
 
 > `filters` takes `key:value` as parameter, with the key to be the name of the field to filter, and the value the filter to be applied on this field, e.g.: `filters=first_name:John`. Only a single filter is supported in a query.
 

--- a/references/search.md
+++ b/references/search.md
@@ -14,17 +14,17 @@ Search for documents matching a specific query in the given index.
 
 #### Query Parameters
 
-| Query Parameter           | Description                                                     | Default Value |
-| ------------------------- | --------------------------------------------------------------- | :-----------: |
-| **q**                     | Query string \_(mandatory)                                      |               |
-| **offset**                | Number of documents to skip                                     |      `0`      |
-| **limit**                 | Maximum number of documents returned                            |     `20`      |
-| **attributesToRetrieve**  | Attributes to display in the returned documents                 |      `*`      |
-| **attributesToCrop**      | Attributes whose values have to be cropped                      |    `none`     |
-| **cropLength**            | Length used to crop field values                                |     `200`     |
-| **attributesToHighlight** | Attributes whose values will contain highlighted matching terms |    `none`     |
-| **filters**               | Filter queries by an attribute value                            |    `none`     |
-| **matches**               | Defines whether the raw matches should be returned or not       |    `false`    |
+| Query Parameter           | Description                                                                                     | Default Value |
+| ------------------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
+| **q**                     | Query string \_(mandatory)                                                                      |               |
+| **offset**                | Number of documents to skip                                                                     |      `0`      |
+| **limit**                 | Maximum number of documents returned                                                            |     `20`      |
+| **attributesToRetrieve**  | Attributes to display in the returned documents                                                 |      `*`      |
+| **attributesToCrop**      | Attributes whose values have to be cropped                                                      |    `none`     |
+| **cropLength**            | Length used to crop field values                                                                |     `200`     |
+| **attributesToHighlight** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
+| **filters**               | Filter queries by an attribute value                                                            |    `none`     |
+| **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
 > `filters` takes `key:value` as parameter, with the key to be the name of the field to filter, and the value the filter to be applied on this field, e.g.: `filters=first_name:John`. Only a single filter is supported in a query.
 


### PR DESCRIPTION
New formatting

Changed:
`filters=<Attribute>:<String>`
to:
`filters=<Attribute>:<Value>`