### PR TITLE
Remove unecessary node download during github actions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -6,12 +6,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-
     - name: Cache dependencies
       uses: actions/cache@v1
       with:

--- a/.github/workflows/check-style.yml
+++ b/.github/workflows/check-style.yml
@@ -6,12 +6,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v1
-
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-
     - name: Cache dependencies
       uses: actions/cache@v1
       with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -10,12 +10,6 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@master
-
-    - name: Setup Node
-      uses: actions/setup-node@v1
-      with:
-        node-version: '12.x'
-
     - name: Cache dependencies
       uses: actions/cache@v1
       with:


### PR DESCRIPTION
Since the github action `actions/setup-node@v1` regularly timeout ( multiple times in the last few months [[1]](https://github.com/actions/setup-node/issues/132)[[2]](https://github.com/nodejs/build/issues/1993))

<img width="984" alt="Screenshot 2020-04-06 at 17 13 41" src="https://user-images.githubusercontent.com/33010418/78574236-ff462200-7829-11ea-9498-4230d1ecf716.png">

> 15 min before timeout on this C/I

And since latest version of node is builtin with the [OS](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md) our github actions uses (search for `Node` [here](https://github.com/actions/virtual-environments/blob/master/images/linux/Ubuntu1804-README.md)):     
```yml
runs-on: ubuntu-18.04
```

I completely removed `actions/setup-node@v1` from our g/a. Which was really useful in the case you need a specific version of node. We do not need an older version of node and we should keep up with node latest release.

Other possibility would be to run a node container with the version we want: 
```yml
your_job:
  runs-on: ubuntu-latest
  container: node:10.9
```

