### PR TITLE
Prepare documentation for meilisearch v0.10

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,37 +1,37 @@
 module.exports = {
-    "env": {
-        "browser": true,
-        "es6": true,
-        "node": true
-    },
-    "extends": [
-      "standard",
-      'plugin:vue/recommended',
-      "plugin:prettier/recommended"
+  env: {
+    browser: true,
+    es6: true,
+    node: true,
+  },
+  extends: [
+    "standard",
+    "plugin:vue/recommended",
+    "plugin:prettier/recommended",
+  ],
+  globals: {
+    Atomics: "readonly",
+    SharedArrayBuffer: "readonly",
+  },
+  parserOptions: {
+    parser: "babel-eslint",
+    allowImportExportEverywhere: true,
+    ecmaVersion: 2018,
+    sourceType: "module",
+  },
+  plugins: ["vue", "prettier"],
+  rules: {
+    "vue/no-v-html": "off", //used in cases where HTML is needed
+    "prettier/prettier": "error",
+    "vue/max-attributes-per-line": [
+      2,
+      {
+        singleline: 20,
+        multiline: {
+          max: 1,
+          allowFirstLine: false,
+        },
+      },
     ],
-    "globals": {
-        "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
-    },
-    "parserOptions": {
-        "parser": "babel-eslint",
-        "allowImportExportEverywhere": true,
-        "ecmaVersion": 2018,
-        "sourceType": "module"
-    },
-    "plugins": [
-        "vue",
-        "prettier"
-    ],
-    "rules": {
-      "vue/no-v-html":"off", //used in cases where HTML is needed
-      "prettier/prettier": "error",
-      'vue/max-attributes-per-line': [2, {
-        'singleline': 20,
-        'multiline': {
-           'max': 1,
-           'allowFirstLine': false
-         }
-      }]
-    }
+  },
 };

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -47,6 +47,7 @@ module.exports = {
             "/guides/advanced_guides/installation",
             "/guides/advanced_guides/search_parameters",
             "/guides/advanced_guides/authentication",
+            "/guides/advanced_guides/filtering",
             "/guides/advanced_guides/asynchronous_updates",
             "/guides/advanced_guides/web_interface",
             "/guides/advanced_guides/settings",

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,6 +1,6 @@
 const ogprefix = "og: http://ogp.me/ns#";
 module.exports = {
-  title: "MeiliSearch Documentation v0.9",
+  title: "MeiliSearch Documentation v0.10",
   description: "Open source Instant Search Engine",
   themeConfig: {
     repo: "meilisearch/MeiliSearch",

--- a/.vuepress/scraper/config.json
+++ b/.vuepress/scraper/config.json
@@ -1,8 +1,6 @@
 {
   "index_uid": "docs",
-  "start_urls": [
-    "https://docs.meilisearch.com"
-  ],
+  "start_urls": ["https://docs.meilisearch.com"],
   "stop_urls": [],
   "selectors": {
     "lvl0": {
@@ -22,9 +20,7 @@
       "global": true
     }
   },
-  "selectors_exclude": [
-    ".table-of-contents"
-  ],
+  "selectors_exclude": [".table-of-contents"],
   "strip_chars": " .,;:#",
   "scrap_start_urls": true,
   "nb_hits": 1185

--- a/.vuepress/theme/components/MeiliSearchBox.vue
+++ b/.vuepress/theme/components/MeiliSearchBox.vue
@@ -8,64 +8,65 @@
       id="meilisearch-search-input"
       class="search-query"
       :placeholder="placeholder"
-    >
+    />
   </form>
 </template>
 
 <script>
 export default {
-  name: 'MeiliSearchBox',
+  name: "MeiliSearchBox",
   props: {
     options: {
       type: Object,
-      default: () => ({})
-    }
+      default: () => ({}),
+    },
   },
-  data () {
+  data() {
     return {
-      placeholder: undefined
-    }
+      placeholder: undefined,
+    };
   },
   watch: {
-    options (newValue) {
-      this.update(newValue)
-    }
+    options(newValue) {
+      this.update(newValue);
+    },
   },
-  mounted () {
-    this.initialize(this.options)
-    this.placeholder = this.$site.themeConfig.searchPlaceholder || ''
+  mounted() {
+    this.initialize(this.options);
+    this.placeholder = this.$site.themeConfig.searchPlaceholder || "";
   },
 
   methods: {
-    initialize (userOptions) {
+    initialize(userOptions) {
       Promise.all([
-        import(/* webpackChunkName: "docs-searchbar" */ 'docs-searchbar.js/dist/cdn/docs-searchbar.min.js'),
-        import(/* webpackChunkName: "docs-searchbar" */ 'docs-searchbar.js/dist/cdn/docs-searchbar.min.css')
+        import(
+          /* webpackChunkName: "docs-searchbar" */ "docs-searchbar.js/dist/cdn/docs-searchbar.min.js"
+        ),
+        import(
+          /* webpackChunkName: "docs-searchbar" */ "docs-searchbar.js/dist/cdn/docs-searchbar.min.css"
+        ),
       ]).then(([docsSearchBar]) => {
-        docsSearchBar = docsSearchBar.default
-        const input = Object.assign(
-          {},
-          userOptions,
-          {
-            inputSelector: '#meilisearch-search-input',
-            meilisearchOptions: { cropLength: 40 },
-            handleSelected: (input, event, suggestion) => {
-              const { pathname, hash } = new URL(suggestion.url)
-              const routepath = pathname.replace(this.$site.base, '/')
-              this.$router.push(`${routepath}${hash}`)
-            }
-          }
-        )
-        docsSearchBar(input)
-      })
+        docsSearchBar = docsSearchBar.default;
+        const input = Object.assign({}, userOptions, {
+          inputSelector: "#meilisearch-search-input",
+          meilisearchOptions: { cropLength: 40 },
+          handleSelected: (input, event, suggestion) => {
+            const { pathname, hash } = new URL(suggestion.url);
+            const routepath = pathname.replace(this.$site.base, "/");
+            this.$router.push(`${routepath}${hash}`);
+          },
+        });
+        docsSearchBar(input);
+      });
     },
 
-    update (options) {
-      this.$el.innerHTML = '<input id="meilisearch-search-input" class="search-query">'
-      this.initialize(options)
-    }
-  }
-}
+    update(options) {
+      this.$el.innerHTML =
+        '<input id="meilisearch-search-input" class="search-query">';
+      this.initialize(options);
+    },
+  },
+};
 </script>
 
 <style lang="stylus">

--- a/.vuepress/theme/components/Navbar.vue
+++ b/.vuepress/theme/components/Navbar.vue
@@ -2,83 +2,86 @@
   <header class="navbar">
     <SidebarButton @toggle-sidebar="$emit('toggle-sidebar')" />
 
-    <RouterLink
-      :to="$localePath"
-      class="home-link"
-    >
+    <RouterLink :to="$localePath" class="home-link">
       <img
         v-if="$site.themeConfig.logo"
         class="logo"
         :src="$withBase($site.themeConfig.logo)"
         :alt="$siteTitle"
-      >
+      />
       <span
         v-if="$siteTitle"
         ref="siteName"
         class="site-name"
         :class="{ 'can-hide': $site.themeConfig.logo }"
-      >{{ $siteTitle }}</span>
+        >{{ $siteTitle }}</span
+      >
     </RouterLink>
 
     <div class="links">
-      <MeiliSearchBox
-        :options="meilisearchOptions"
-      />
+      <MeiliSearchBox :options="meilisearchOptions" />
       <NavLinks class="can-hide" />
     </div>
   </header>
 </template>
 
 <script>
-import MeiliSearchBox from '@theme/components/MeiliSearchBox'
-import SearchBox from '@SearchBox' // for CSS
-import SidebarButton from '@parent-theme/components/SidebarButton.vue'
-import NavLinks from '@parent-theme/components/NavLinks.vue'
+import MeiliSearchBox from "@theme/components/MeiliSearchBox";
+import SearchBox from "@SearchBox"; // for CSS
+import SidebarButton from "@parent-theme/components/SidebarButton.vue";
+import NavLinks from "@parent-theme/components/NavLinks.vue";
 
 export default {
-  name: 'Navbar',
+  name: "Navbar",
 
   components: {
     SidebarButton,
     NavLinks,
     SearchBox,
-    MeiliSearchBox
+    MeiliSearchBox,
   },
 
-  data () {
+  data() {
     return {
-      linksWrapMaxWidth: null
-    }
+      linksWrapMaxWidth: null,
+    };
   },
 
   computed: {
-    meilisearchOptions () {
-      return this.$themeLocaleConfig.meilisearch || this.$site.themeConfig.meilisearch || {}
-    }
-
+    meilisearchOptions() {
+      return (
+        this.$themeLocaleConfig.meilisearch ||
+        this.$site.themeConfig.meilisearch ||
+        {}
+      );
+    },
   },
 
-  mounted () {
-    const MOBILE_DESKTOP_BREAKPOINT = 719 // refer to config.styl
-    const NAVBAR_VERTICAL_PADDING = parseInt(css(this.$el, 'paddingLeft')) + parseInt(css(this.$el, 'paddingRight'))
+  mounted() {
+    const MOBILE_DESKTOP_BREAKPOINT = 719; // refer to config.styl
+    const NAVBAR_VERTICAL_PADDING =
+      parseInt(css(this.$el, "paddingLeft")) +
+      parseInt(css(this.$el, "paddingRight"));
     const handleLinksWrapWidth = () => {
       if (document.documentElement.clientWidth < MOBILE_DESKTOP_BREAKPOINT) {
-        this.linksWrapMaxWidth = null
+        this.linksWrapMaxWidth = null;
       } else {
-        this.linksWrapMaxWidth = this.$el.offsetWidth - NAVBAR_VERTICAL_PADDING -
-          (this.$refs.siteName && this.$refs.siteName.offsetWidth || 0)
+        this.linksWrapMaxWidth =
+          this.$el.offsetWidth -
+          NAVBAR_VERTICAL_PADDING -
+          ((this.$refs.siteName && this.$refs.siteName.offsetWidth) || 0);
       }
-    }
-    handleLinksWrapWidth()
-    window.addEventListener('resize', handleLinksWrapWidth, false)
-  }
-}
+    };
+    handleLinksWrapWidth();
+    window.addEventListener("resize", handleLinksWrapWidth, false);
+  },
+};
 
-function css (el, property) {
+function css(el, property) {
   // NOTE: Known bug, will return 'auto' if style value is 'auto'
-  const win = el.ownerDocument.defaultView
+  const win = el.ownerDocument.defaultView;
   // null means not to return pseudo styles
-  return win.getComputedStyle(el, null)[property]
+  return win.getComputedStyle(el, null)[property];
 }
 </script>
 

--- a/guides/advanced_guides/filtering.md
+++ b/guides/advanced_guides/filtering.md
@@ -1,0 +1,126 @@
+# Filtering
+
+When searching for documents, it is sometimes desired to filter through the results based on criteria, to provide the user with the most relevant response possible.
+
+Meilisearch allows you to define filters thanks to a **very simple query language**. Once defined, you can pass your filter to your search query, as a parameter.
+
+### The Query Language
+
+In itself the query language is very simple, and allows you to filter results on any document field. For now it only allows you to query on fields that are either `number`, `boolean`, or `string`
+
+### Conditions
+
+Conditions are the primitives of query filters. They are composed of three mandatory parameters `field OP value` where:
+
+- `field` refers to the document **attribute** to filter on. (_e.g_ id, title...). It is either a single alphanumeric word or a quoted string: `"movie title"`, and `release_date` are both valid `field`.
+- `OP` is the comparison operator, it can be one of `=`, `!=`, `>`, `>=`, `<`, or `<=`. `value` is the test condition for which the filter shall filter upon.
+
+The `=` and `!=` operators check for equality and difference. For strings, they are both **case insensitive**:
+
+```SQL
+title = "american ninja" // matches "American Ninja"
+```
+
+::: note
+`string` values are either double-quoted, single-quoted or a single unquoted word: `title = "Scream"`, `title = 'Scream'` and `title = Scream` are all valid syntaxes, `title = The Avengers` is not.
+:::
+
+The `>`, `>=`, `<`, and `<=` apply **only to numerical values**, and behave the standard way.
+
+::: warning
+As no specific schema is enforced at indexing, the filtering engine will try to coerce the type of `value`. This can lead to undefined behaviour when big floats are coerced into integers and reciprocally. For this reason, it is best to have homogeneous typing across fields, especially if numbers tend to become large.
+:::
+
+### Expressions
+
+The simplest form of expressions are conditions. New expressions are created either by connecting other expressions together with logical connectives, or by grouping expressions with parentheses, _e.g_:
+
+```SQL
+title = Scream // a condition is an expression
+title = Scream OR title = "The Avengers" // also an expression
+(title = Scream OR title = "The Avengers") // use parentheses to isolate an expression
+NOT (title = Scream OR title = "The Avengers") // negate the whole expression
+rating >= 3 AND (NOT (title = Scream OR title = "The Avengers")) // and so on...
+```
+
+### Logical Connectives
+
+An arbitrary number of expressions can be connected together thanks to logical connectives. These connectives are:
+
+- `NOT` negates the following expression, _e.g._ `NOT title = Scream`.
+- `OR` performs a logical 'or' between two expressions, _e.g._ `title = Scream OR title = "the avengers"`
+- `AND` performs a logical 'and' between two expressions, _e.g._ `title = Dumbo AND title = "Tim Burton"`
+
+::: note
+`NOT` has the highest precedence, this means that `NOT title = Scream OR title = "The Avengers"` is effectively evaluated `(NOT title = Scream) OR title = "The Avengers"`. `AND` precedence is lower than `NOT` and higher than `OR`.
+:::
+
+### A Note on Performance
+
+MeiliSearch is intended to be a flexible tool. For this reason, we decided not to put any restrictions on which fields the user can filter on, nor on how the queries are built. It is important to understand that it can lead to performance issues in some cases. We are currently working on new features to address this issue, such as [faceting](https://en.wikipedia.org/wiki/Faceted_search) to allow you to efficiently narrow down the number of candidates to a query, and thus improving performances of plain filters, even in worst cases.
+
+Also consider that `OR` and `AND` are left associative, meaning that the left-hand side is always evaluated first. If the left-hand side of an `OR` is `true` or the left-hand side of a `AND` is `false`, then the right-hand side won't be evaluated. You can sometimes get performance improvements by building your queries in such a way that the right-hand side of a connective is evaluated only when necessary.
+
+### Examples
+
+Suppose that you have a collection of movies, in the following JSON format:
+
+```json
+[
+	{
+		"id": "495925",
+		"title": "Doraemon the Movie:Nobita's Treasure Island",
+		"director": "Fujiko Fujio",
+		"poster": "https://image.tmdb.org/t/p/w1280/cmJ71gdZxCqkMUvGwWgSg3MK7pC.jpg",
+		"overview": "The story is based on Robert Louis Stevenson's Treasure Island novel.",
+		"release_date": 1520035200
+	},
+	{
+		"id": "329996",
+		"title": "Dumbo",
+		"director": "Tim Burton",
+		"poster": "https://image.tmdb.org/t/p/w1280/279PwJAcelI4VuBtdzrZASqDPQr.jpg",
+		"overview": "A young elephant, whose oversized ears enable him to fly, helps...",
+		"release_date": 1553644800
+	},
+	{
+		"id": "299536",
+		"title": "Avengers:Infinity War",
+		"director": "Joe Russo",
+		"poster": "https://image.tmdb.org/t/p/w1280/7WsyChQLEftFiDOVTGkv3hFpyyt.jpg",
+		"overview": "As the Avengers and their allies have continued to protect...",
+		"release_date": 1524618000
+	},
+	{
+		"id": "458723",
+		"title": "Us",
+		"director": "Jordan Peele",
+		"poster": "https://image.tmdb.org/t/p/w1280/ux2dU1jQ2ACIMShzB3yP93Udpzc.jpg",
+		"overview": "Husband and wife Gabe and Adelaide Wilson take their...",
+		"release_date": 1552521600
+	},
+	...
+]
+```
+
+Say you want to only show to your user movies that were released after a certain date, then you can use the following filter:
+
+```SQL
+release_date > 795484800 // march 18, 1995
+```
+
+Now imagine that we want only the movies released after the 18 of march 1995, and directed by either Jordan Peel or Tim Burton, then you would use this filter:
+
+```SQL
+release_date > 795484800 AND (director = "Tim Burton" OR director = "Jordan Peel")
+```
+
+Note that filtering on string is case insensitive. Here, the parentheses are mandatory, as `AND` has a higher precedence.
+
+Finally, imagine that you want to filter on "id". You would probably do this:
+
+```SQL
+id = "299536"
+```
+
+However, this would be a very bad idea. `id` uniquely identifies a movie. Therefore, only one document can match the user query. The filtering engine would have to search through all candidate documents to find the only possible match. This would be highly inefficient and should be avoided. We are currently working on a [faceted search](https://en.wikipedia.org/wiki/Faceted_search) feature, especially optimized for this kind of need. It is important to understand that filtering and querying don't have the same performances.

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -113,23 +113,7 @@ In the case a matched query word is found, the field's value will be cropped aro
 This is especially useful when you have to display content on the front-end in a specific way.
 :::
 
-## Crop length
-
-Set a length for the cropping around the matching query words (see attributesToCrop).
-
-`cropLength=<Integer>`
-
-- `<Integer>` (Optional, positive integer, defaults to `200`)
-
-  The length used to crop field values around the first matched query word if the field's attribute is in the `attributedToCrop` list.
-
-Cropping start at the **first occurrence of the matched query word**.
-
-If the value of the parameter `cropLength` is _n_, the returned field value will consist of **_n_ characters before the query word** and **_n_ characters from the first character of the query word**. Below is a simple representation:
-
-```json
-_n_ characters + _n_ characters including the query word
-```
+**Cropping start at the first occurrence of the search query**. It only keeps `cropLength` chars on each side of the first match, rounded to match word boundaries.
 
 #### Example
 
@@ -155,13 +139,17 @@ You will get the following response with the **cropped version in the \_formatte
     "id": "50393",
     "title": "Kung Fu Panda Holiday",
     "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-    "overview": "d his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade ",
+    "overview": "his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade",
     "release_date": 1290729600
   }
 }
 ```
 
-In the example above, the cropped version of `overview` is 200 characters longs. There are 100 characters before `shifu` (the first match) and 100 more characters starting at the first letter of `shifu`.
+## Crop length
+
+`cropLength=<Integer>`
+
+Number of characters to keep on each side of the start of the matching word. See [attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)
 
 ## Attributes to highlight
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -208,33 +208,17 @@ The Winter Feast is Po's favorite holiday. Every year he and his father hang dec
 
 ## Filters
 
-This setting allows to **filter queries by an attribute value**.
+`filters=<String>`
 
-Filters accept **only one** parameter.
-
-`filters=<Attribute>:<Value>`
-
-- `<Attribute>:<Value>` (Optional, string, defaults to empty)
-
-  Two strings separated by a colon.
-
-  - `<Attribute>`: The attribute name.
-
-  - `<Value>`: The value which will be used to filter documents.
-
-The attribute value used for filtering must be **equal to** the existing attribute value in the documents. The **comparison is done in a case-insensitive manner**.
-
-#### Example
-
-If you add this filter:
+Specify a filter to be used with the query. See our [dedicated guide](/guides/advanced_guides/filtering).
 
 ```bash
 $ curl -X GET -G 'http://localhost:7700/indexes/nzwlr302/search' \
-      -d q=n \
-      -d filters='title:Nightshift'
+        -d q=n \
+        -d filters='filters=title%3DNightshift'
 ```
 
-Only documents that contain the value `Nightshift` in their `title` attribute will be returned upon search.
+(`%3D` is URL-encoded for `=`)
 
 ```json
 {
@@ -246,12 +230,13 @@ Only documents that contain the value `Nightshift` in their `title` attribute wi
 }
 ```
 
-The parameter must be **URL-encoded**.
+The parameter should be **URL-encoded**.
 
 ```bash
-$ curl --request GET  -G 'http://localhost:7700/indexes/movies/search' \
-      -d q=shifu \
-      -d filters='title:Kung%20Fu%20Panda'
+$ curl --request GET  -G 'http://localhost:8080/indexes/nzwlr302/search' \
+        -d q=shifu \
+        -d filters='title%3D%22Kung%20Fu%20Panda%22' \
+        -i
 ```
 
 ## Matches

--- a/references/search.md
+++ b/references/search.md
@@ -26,7 +26,7 @@ Search for documents matching a specific query in the given index.
 | **filters**               | Filter queries by an attribute value                                                            |    `none`     |
 | **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
-> `filters` takes `key:value` as parameter, with the key to be the name of the field to filter, and the value the filter to be applied on this field, e.g.: `filters=first_name:John`. Only a single filter is supported in a query.
+> `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).
 
 ### Example
 

--- a/references/search.md
+++ b/references/search.md
@@ -23,11 +23,23 @@ Search for documents matching a specific query in the given index.
 | **attributesToCrop**      | Attributes whose values have to be cropped                                                      |    `none`     |
 | **cropLength**            | Length used to crop field values                                                                |     `200`     |
 | **attributesToHighlight** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
-| **filters**               | Filter queries by an attribute value                                                            |    `none`     |
+| **filters**               | Add fitler expression                                                                           |    `none`     |
 | **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).
 > `cropLength` is automatically rounded to match word boundaries.
+
+### Response
+
+| field                | Description                    |    type    |
+| -------------------- | ------------------------------ | :--------: |
+| **hits**             | results of the query           | `[result]` |
+| **offset**           | number of documents skipped    |  `number`  |
+| **limit**            | number of documents to take    |  `number`  |
+| **nbHits**           | total number of matches        |  `number`  |
+| **exhaustiveNbHits** | whether `nbHits` is exhaustive | `boolean`  |
+| **processingTimeMs** | processing time of the query   |  `number`  |
+| **query**            | query originating the response |  `string`  |
 
 ### Example
 
@@ -42,24 +54,31 @@ $ curl \
 {
   "hits": [
     {
-      "id": "25684",
-      "title": "American Ninja 5",
-      "poster": "https://image.tmdb.org/t/p/w1280/iuAQVI4mvjI83wnirpD8GVNRVuY.jpg",
-      "overview": "When a scientists daughter is kidnapped, American Ninja, attempts to find her, but this time he teams up with a youngster he has trained in the ways of the ninja.",
-      "release_date": "1993-01-01"
+      "id": "2770",
+      "title": "American Pie 2",
+      "poster": "https://image.tmdb.org/t/p/w1280/q4LNgUnRfltxzp3gf1MAGiK5LhV.jpg",
+      "overview": "The whole gang are back and as close as ever. They decide to
+      get even closer by spending the summer together at a beach house. They
+      decide to hold the biggest...",
+      "release_date": 997405200
     },
     {
-      "id": "25682",
-      "title": "American Ninja 3: Blood Hunt",
-      "poster": "https://image.tmdb.org/t/p/w1280/c7oNrk8bRg0BlmtvidhVD8ivPYT.jpg",
-      "overview": "Jackson is back, and now he has a new partner, karate champion Sean, as they must face a deadly terrorist known as 'The Cobra', who has infected Sean with a virus. Sean and Jackson have no choice but to fight the Cobra and his bands of ninjas.",
-      "release_date": "1989-02-24"
+      "id": "190859",
+      "title": "American Sniper",
+      "poster": "https://image.tmdb.org/t/p/w1280/svPHnYE7N5NAGO49dBmRhq0vDQ3.jpg",
+      "overview": "U.S. Navy SEAL Chris Kyle takes his sole mission—protect his
+      comrades—to heart and becomes one of the most lethal snipers in American
+      history. His pinpoint accuracy not only saves countless lives but also
+      makes him a prime...",
+      "release_date": 1418256000
     },
     ...
   ],
   "offset": 0,
   "limit": 20,
-  "processingTimeMs": 32,
-  "query": "american ninja 5"
+  "nbHits": 976,
+  "exhaustiveNbHits": false,
+  "processingTimeMs": 35,
+  "query": "american "
 }
 ```

--- a/references/search.md
+++ b/references/search.md
@@ -27,6 +27,7 @@ Search for documents matching a specific query in the given index.
 | **matches**               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering).
+> `cropLength` is automatically rounded to match word boundaries.
 
 ### Example
 


### PR DESCRIPTION
Prepare version for v0.10. 
MeiliSearch CHANGELOGS: 

- [x] Refined filtering (meilisearch/meilisearch#592)
- [x] Add the number of hits in search result (meilisearch/meilisearch#541)
- [x] Add support for aligned crop in search result (meilisearch/meilisearch#543)
- [x] ~Sanitize the content displayed in the web interface (meilisearch/meilisearch#539)~
- [x] ~Add support of nested null, boolean and seq values (meilisearch/meilisearch#571 and meilisearch/meilisearch#568, meilisearch/meilisearch#574)~
- [x] ~Fixed the core benchmark (meilisearch/meilisearch#576)~
- [x] ~Publish an ARMv7 and ARMv8 binaries on releases (meilisearch/meilisearch#540 and meilisearch/meilisearch#581)~
- [x] ~Fixed a bug where the result of the update status after the first update was empty (meilisearch/meilisearch#542)~
- [x] ~Fixed a bug where stop words were not handled correctly (meilisearch/meilisearch#594)~
- [x] ~Fix CORS issues (meilisearch/meilisearch#602)~
- [x] ~Support wildcard on attributes to retrieve, highlight, and crop (meilisearch/meilisearch#549, meilisearch/meilisearch#565, and meilisearch/meilisearch#598)~