### PR TITLE
Clarify partial update of settings via POST request

### DIFF
--- a/references/settings.md
+++ b/references/settings.md
@@ -96,7 +96,6 @@ Update the settings of an index.
 | **displayedAttributes**  | [Strings] | Fields displayed in the returned documents                                       | All attributes found in the documents                                                             |
 | **acceptNewFields**      | Boolean   | Defines whether new fields should be searchable and displayed or not             | `true`                                                                                            |
 
-
 ### Examples
 
 #### Add settings

--- a/references/settings.md
+++ b/references/settings.md
@@ -18,6 +18,8 @@ These are the reference pages for the dedicated routes:
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.
 :::
 
+It is also possible to partially update your settings using a POST request to `Settings`, containing only the parameters that you want to modify. Parameters that are not present in the request body will keep their current configuration and WONT be modified.
+
 ## Get settings
 
 <RouteHighlighter method="GET" route="/indexes/:index_uid/settings" />
@@ -94,7 +96,6 @@ Update the settings of an index.
 | **displayedAttributes**  | [Strings] | Fields displayed in the returned documents                                       | All attributes found in the documents                                                             |
 | **acceptNewFields**      | Boolean   | Defines whether new fields should be searchable and displayed or not             | `true`                                                                                            |
 
-Any parameters not provided will be left unchanged.
 
 ### Examples
 

--- a/references/settings.md
+++ b/references/settings.md
@@ -76,6 +76,8 @@ List the settings.
 
 Update the settings of an index.
 
+Updates in the settings route are **partial**. This means that any parameters not provided in the body will be left unchanged.
+
 #### Path Variables
 
 | Variable      | Description   |
@@ -93,10 +95,6 @@ Update the settings of an index.
 | **searchableAttributes** | [Strings] | Fields in which to search for matching query words sorted by order of importance | All attributes found in the documents                                                             |
 | **displayedAttributes**  | [Strings] | Fields displayed in the returned documents                                       | All attributes found in the documents                                                             |
 | **acceptNewFields**      | Boolean   | Defines whether new fields should be searchable and displayed or not             | `true`                                                                                            |
-
-::: warning
-Updates in the settings route are **partial**. This means that any parameters not provided in the body will be left unchanged.
-:::
 
 ### Examples
 

--- a/references/settings.md
+++ b/references/settings.md
@@ -2,7 +2,7 @@
 
 `Settings` is a list of all the **customization** possible for an index.
 
-It is possible to update all the settings in one go or individually with the dedicated routes.
+It is possible to update all the settings in one go or individually with the dedicated routes. Updates in the settings route are **partial**. This means that any parameters not provided in the body will be left unchanged.
 
 These are the reference pages for the dedicated routes:
 
@@ -17,8 +17,6 @@ These are the reference pages for the dedicated routes:
 ::: note
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.
 :::
-
-It is also possible to partially update your settings using a POST request to `Settings`, containing only the parameters that you want to modify. Parameters that are not present in the request body will keep their current configuration and WONT be modified.
 
 ## Get settings
 
@@ -95,6 +93,10 @@ Update the settings of an index.
 | **searchableAttributes** | [Strings] | Fields in which to search for matching query words sorted by order of importance | All attributes found in the documents                                                             |
 | **displayedAttributes**  | [Strings] | Fields displayed in the returned documents                                       | All attributes found in the documents                                                             |
 | **acceptNewFields**      | Boolean   | Defines whether new fields should be searchable and displayed or not             | `true`                                                                                            |
+
+::: warning
+Updates in the settings route are **partial**. This means that any parameters not provided in the body will be left unchanged.
+:::
 
 ### Examples
 


### PR DESCRIPTION
It doesn't seem clear enough in the documentation that a `POST` request on `/indexes/:index_id/settings` lets the user **partially** update an index settings 

This paragraph proposes an alternative to using specific routes, which seems to be an architectural choice of MeiliSearch and should be documented :) Let me know what you think!

[to my understanding, usually a POST request requires the whole body and won't accept just a few parameters]