### PR TITLE
Fix version of mermaid to non breaking one

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "@popperjs/core": "^2.3.3",
     "docs-searchbar.js": "^1.1.1",
-    "mermaid": "^8.4.8",
+    "mermaid": "8.4.8",
     "vue-eslint-parser": "^7.0.0",
     "vuepress": "^1.3.1",
     "vuepress-plugin-element-tabs": "^0.2.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5887,10 +5887,10 @@ merge2@^1.2.3, merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.3.0.tgz#5b366ee83b2f1582c48f87e47cf1a9352103ca81"
   integrity sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==
 
-mermaid@^8.4.8:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-8.5.0.tgz#8ab141359e0ab2d20d00ff887f45648982b56158"
-  integrity sha512-fZf4GAzkqWuSwo5L+BmzaBwWPudHkxL3M/t1RmS9Dvc2mcnv6hdhMaeC7poARpHaSGwkpb74LL81qXj+vAsVBg==
+mermaid@8.4.8:
+  version "8.4.8"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-8.4.8.tgz#8adcfdbc505d6bca52df167cff690427c9727b60"
+  integrity sha512-sumTNBFwMX7oMQgogdr3NhgTeQOiwcEsm23rQ4KHGW7tpmvMwER1S+1gjCSSnqlmM/zw7Ga7oesYCYicKboRwQ==
   dependencies:
     "@braintree/sanitize-url" "^3.1.0"
     crypto-random-string "^3.0.1"


### PR DESCRIPTION
In an upgrade, [mermaid](https://mermaidjs.github.io/#/) went from version 8.4 to 8.5. The changes in this new release breaks ore implementation of our mermaid schema. 

This should be addressed at some point #314 