### PR TITLE
Simplify config file for docs-scraper by removing useless fields

### DIFF
--- a/.vuepress/docs-scraper/docs-scraper.config.json
+++ b/.vuepress/docs-scraper/docs-scraper.config.json
@@ -2,7 +2,6 @@
   "index_uid": "docs",
   "sitemap_urls": ["https://docs.meilisearch.com/sitemap.xml"],
   "start_urls": ["https://docs.meilisearch.com"],
-  "stop_urls": [],
   "selectors": {
     "lvl0": {
       "selector": ".sidebar-heading.open",
@@ -14,15 +13,8 @@
     "lvl3": ".theme-default-content h3",
     "lvl4": ".theme-default-content h4",
     "lvl5": ".theme-default-content h5",
-    "text": ".theme-default-content p, .theme-default-content li",
-    "lang": {
-      "selector": "/html/@lang",
-      "type": "xpath",
-      "global": true
-    }
+    "text": ".theme-default-content p, .theme-default-content li"
   },
-  "selectors_exclude": [".table-of-contents"],
   "strip_chars": " .,;:#",
-  "scrap_start_urls": true,
-  "nb_hits": 1185
+  "scrap_start_urls": true
 }


### PR DESCRIPTION
Goal: providing a simple file for the users who want to imitate our config or to try understanding the config file.