### PR TITLE
fix: error in distinct attribute example

### DIFF
--- a/guides/advanced_guides/distinct.md
+++ b/guides/advanced_guides/distinct.md
@@ -27,7 +27,7 @@ As shown below, you have 3 documents that contain information about the same jac
     "product_id": "123456"
   },
   {
-    "id": 2,
+    "id": 3,
     "description": "Leather jacket",
     "brand": "Lee jeans",
     "color": "blue",


### PR DESCRIPTION
Fixes an error in `distinct attribute` example in the documentation. Two documents have the same id. See #376 

Closes #376