### PR TITLE
Fields not in displayed attribute are never in returned documents

### DIFF
--- a/guides/advanced_guides/field_properties.md
+++ b/guides/advanced_guides/field_properties.md
@@ -26,7 +26,7 @@ Documents returned upon search contain only displayed fields.
 
 **By default, all field attributes are added to the displayed-attributes list**. If a new document is ingested and one of its fields was never present in any other document, the latter will be automatically added to the displayed-attributes list. [This behavior can be changed](/references/accept_new_fields.md).
 
-Therefore, if a field attribute is not in the displayed-attribute list, the field won't be added to the documents returned upon search. Nevertheless, the documents fetched using the `GET /documents` route will have those fields, this setting only affects the document hits upon search.
+Therefore, if a field attribute is not in the displayed-attribute list, the field won't be added to the returned documents.
 
 This list can be restricted to a selected set of attributes in the settings.
 


### PR DESCRIPTION
Error in the documentation that said:

```
Therefore, if a field attribute is not in the displayed-attribute list, the field won't be added to the documents returned upon search. Nevertheless, the documents fetched using the GET /documents route will have those fields, this setting only affects the document hits upon search.
```

Which is not true. Changed to: 

```
Therefore, if a field attribute is not in the displayed-attribute list, the field won't be added to the returned documents.
```

Discussed in: meilisearch/MeiliSearch#717