### PR TITLE
Redirection of errors links to docs landing

### DIFF
--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -2,7 +2,7 @@ export default ({
   router,
 }) => {
   router.addRoutes([
-    { path: '/errors', redirect: '/' },
-    { path: '/errors/*', redirect: '/' },
+    { path: '/errors', redirect: '/guides' },
+    { path: '/errors/*', redirect: '/guides' },
   ])
 }

--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,0 +1,8 @@
+export default ({
+  router,
+}) => {
+  router.addRoutes([
+    { path: '/errors', redirect: '/' },
+    { path: '/errors/*', redirect: '/' },
+  ])
+}


### PR DESCRIPTION
## Error redirection

All links `docs.meilisearch.com/errors` and `docs.meilisearch.com/errors/*` (`*` being every possible value) are redirected to the documentation landing page.

![errorredirection](https://user-images.githubusercontent.com/33010418/83249009-3be92680-a1a6-11ea-90a8-8225cc3e69e4.gif)

