### PR TITLE
Payload limit and configuration guide

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -45,6 +45,7 @@ module.exports = {
           collapsable: false,
           children: [
             '/guides/advanced_guides/installation',
+            '/guides/advanced_guides/configuration',
             '/guides/advanced_guides/search_parameters',
             '/guides/advanced_guides/filtering',
             '/guides/advanced_guides/faceted_search',

--- a/faq/faq.md
+++ b/faq/faq.md
@@ -159,7 +159,7 @@ Yes, a web interface is available on the default address and port of your MeiliS
 
 All you need to do is open your web browser and enter MeiliSearch’s address to visit it. This leads you to a web page with a search bar that allows you to search in a selected index.
 
-Since the production environment requires an API-key for searching, the web interface is only available in [development mode](/guides/advanced_guides/installation.md#environments).
+Since the production environment requires an API-key for searching, the web interface is only available in [development mode](/guides/advanced_guides/configuration.md#environment).
 
 Here is more information about the [MeiliSearch web interface](/guides/advanced_guides/web_interface.md).
 

--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -49,7 +49,7 @@ Defines the location for the database files
 **Environment Variable**: `MEILI_HTTP_ADDR`
 **CLI option**: `--http-addr`
 
-he address on which the http server will listen.
+The address the HTTP server will listen on.
 
 **Default value**: `"127.0.0.1:7700"`
 

--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -40,7 +40,7 @@ List of options:
 **Environment Variable**: `MEILI_DB_PATH`
 **CLI option**: `--db-path`
 
-Defines the location for the database files
+Defines the location for the database files.
 
 **Default value**: `"./data.ms"`
 
@@ -58,7 +58,9 @@ The address the HTTP server will listen on.
 **Environment Variable**: `MEILI_MASTER_KEY`
 **CLI option**: `--master-key`
 
-The master key allowing you to do everything on the server. If no master key is provided
+The master key allowing you to do everything on the server. If no master key is provided all routes will be accessible without keys. This is only possible if your are in `developement` environment. An error is thrown if you try to start MeiliSearch without master key when the environment is set to `production`.
+
+[Learn more about the permission and authentication in this guide.](/guides/advanced_guides/authentication.md)
 
 **Default Value**: `None`
 
@@ -82,7 +84,7 @@ By default, MeiliSearch runs in `development` mode.
 - `Development`: the [master key](/guides/advanced_guides/authentication.md) is **optional**, and logs are output in "info" mode (_console output_).
 
 If the server is running in development mode more logs will be displayed, and the master key can be avoided which implies that there is no security on the updates routes.
-This is useful to debug when integrating the engine with another service
+This is useful to debug when integrating the engine with another service.
 
 **Default value**: `development`
 

--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -1,0 +1,96 @@
+# Configuration
+
+Many options are available to configure a MeiliSearch Instance. Each of these options are added on MeiliSearch Instance launch.
+
+Options can be either communicated through **environment variables** or **command line options**.
+
+## Passing arguments via the command line
+
+Options are added on launch.
+
+```bash
+$ ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
+Server is listening on: http://127.0.0.1:7700
+```
+
+## Passing arguments via the environment variables
+
+The format of the environment variables are the same as the command line options with the exception that it is uppercased and `MEILI_` is added at the start.
+
+```
+$ export MEILI_DB_PATH=./meilifiles
+$ export MEILI_HTTP_ADDR=127.0.0.1:7700
+$ ./meilisearch
+Server is listening on: http://127.0.0.1:7700
+```
+
+## Options
+
+List of options:
+
+- [Path to database](/guides/advanced_guides/configuration.md#path-to-database)
+- [HTTP address](/guides/advanced_guides/configuration.md#http-address)
+- [Master Key](/guides/advanced_guides/configuration.md#master-key)
+- [No Analytics](/guides/advanced_guides/configuration.md#no-analytics)
+- [Environment](/guides/advanced_guides/configuration.md#environment)
+- [Payload size limit](/guides/advanced_guides/configuration.md#payload-size-limit)
+
+### Path to database
+
+**Environment Variable**: `MEILI_DB_PATH`
+**CLI option**: `--db-path`
+
+Defines the location for the database files
+
+**Default value**: `"./data.ms"`
+
+### HTTP Address
+
+**Environment Variable**: `MEILI_HTTP_ADDR`
+**CLI option**: `--http-addr`
+
+he address on which the http server will listen.
+
+**Default value**: `"127.0.0.1:7700"`
+
+### Master Key
+
+**Environment Variable**: `MEILI_MASTER_KEY`
+**CLI option**: `--master-key`
+
+The master key allowing you to do everything on the server. If no master key is provided
+
+**Default Value**: `None`
+
+### No Analytics
+
+**Environment Variable**: `MEILI_NO_ANALYTICS`
+**CLI option**: `--no-analytics`
+
+Deactivates analytics. Analytics allow us to know how many users are using MeiliSearch, which versions and which platforms are used. This process is entirely anonymous.
+
+**Default value**: `false`
+
+### Environment
+
+**Environment Variable**: `MEILI_ENV`
+**CLI option**: `--env`
+
+By default, MeiliSearch runs in `development` mode.
+
+- `Production`: the [master key](/guides/advanced_guides/authentication.md) is **mandatory**.
+- `Development`: the [master key](/guides/advanced_guides/authentication.md) is **optional**, and logs are output in "info" mode (_console output_).
+
+If the server is running in development mode more logs will be displayed, and the master key can be avoided which implies that there is no security on the updates routes.
+This is useful to debug when integrating the engine with another service
+
+**Default value**: `development`
+
+### Payload Size Limit
+
+**Environment Variable**: `MEILI_HTTP_PAYLOAD_SIZE_LIMIT`
+**CLI option**: --http-payload-size-limit
+
+The maximum size, in bytes, of accepted JSON payloads.
+
+**Default value**: `10485760` (+=10Mb)

--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -15,7 +15,7 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Passing arguments via the environment variables
 
-The format of the environment variables are the same as the command line options with the exception that it is uppercased and `MEILI_` is added at the start.
+The format of the environment variables is identical to the command line options with the exception that it is uppercased and `MEILI_` is added at the beginning.
 
 ```
 $ export MEILI_DB_PATH=./meilifiles

--- a/guides/advanced_guides/installation.md
+++ b/guides/advanced_guides/installation.md
@@ -90,56 +90,13 @@ $ ./target/release/meilisearch
 
 ::::
 
-## Usage
+## Environment variables and Options
 
-```
-$ ./meilisearch --help
-meilisearch-http 0.10.0
-
-USAGE:
-    meilisearch [OPTIONS]
-
-FLAGS:
-    -h, --help       Prints help information
-    -V, --version    Prints version information
-
-OPTIONS:
-        --db-path <db-path>              The destination where the database must be created. [env: MEILI_DB_PATH=]
-                                         [default: ./data.ms]
-        --env <env>                      This environment variable must be set to `production` if your are running in
-                                         production. Could be `production` or `development` - `production`: Force api
-                                         keys - `development`: Show logs in "info" mode + not mendatory to specify the
-                                         api keys [env: MEILI_ENV=]  [default: development]  [possible values:
-                                         development, production]
-        --http-addr <http-addr>          The address on which the http server will listen. [env: MEILI_HTTP_ADDR=]
-                                         [default: 127.0.0.1:7700]
-        --master-key <master-key>        The master key allowing you to do everything on the server. [env:
-                                         MEILI_MASTER_KEY=]
-        --no-analytics <no-analytics>    Do not send analytics to Meili. [env: MEILI_NO_ANALYTICS=]
-```
-
-## Environment variables and Flags
-
-Flags can be added on launch.
+Options are added on launch.
 
 ```bash
 $ ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
 Server is listening on: http://127.0.0.1:7700
 ```
 
-Here is the list of **all Environment variables and Flags** (CLI options).
-
-| Environment Variable | CLI option     | Description                                                                                                                                                              | Default value    |
-| -------------------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | ---------------- |
-| `MEILI_DB_PATH`      | --db-path      | Defines the location for the database files                                                                                                                              | "./data.ms"      |
-| `MEILI_HTTP_ADDR`    | --http-addr    | Address and port to listen to                                                                                                                                            | "127.0.0.1:7700" |
-| `MEILI_MASTER_KEY`   | --master-key   | Default admin API key                                                                                                                                                    |                  |
-| `MEILI_NO_ANALYTICS` | --no-analytics | Deactivates analytics. Analytics allow us to know how many users are using MeiliSearch, which versions and which platforms are used. This process is entirely anonymous. |                  |
-| `MEILI_ENV`          | --env          | Defines the running environment of MeiliSearch. Can be set to `production` or `development`.                                                                             | "development"    |
-
-### Environments
-
-By default, MeiliSearch runs in `development` mode.
-
-- `Production`: the [master key](/guides/advanced_guides/authentication.md) is **mandatory**.
-- `Development`: the [master key](/guides/advanced_guides/authentication.md) is **optional**, and logs are output in "info" mode (_console output_).
+Here is the list of [all Environment variables and options](/guides/advanced_guides/configuration.md).

--- a/guides/advanced_guides/web_interface.md
+++ b/guides/advanced_guides/web_interface.md
@@ -2,10 +2,10 @@
 
 After adding documents to your MeiliSearch, it is possible to try out the search engine with the integrated web interface.
 
-The web interface is served on the address and port specified in the command line argument `--listen`. If not specified, [the default address and port is used](/guides/advanced_guides/installation.md#environment-variables-and-flags).
+The web interface is served on the address and port specified in the command line argument `--listen`. If not specified, [the default address and port is used](/guides/advanced_guides/configuration.md#http-address).
 
 ::: warning
-Since the production environment requires an API-key for searching, the web interface is only available in [development mode](/guides/advanced_guides/installation.md#environments).
+Since the production environment requires an API-key for searching, the web interface is only available in [development mode](/guides/advanced_guides/configuration.md#environment).
 :::
 
 ### Example

--- a/guides/introduction/quick_start_guide.md
+++ b/guides/introduction/quick_start_guide.md
@@ -93,7 +93,7 @@ $ ./target/release/meilisearch
 
 ::::
 
-[Environment variables and flags](/guides/advanced_guides/installation.md#environment-variables-and-flags) can be set before and on launch. Amongst all the flags, you can use the **master key** and the **port** flags.
+[Environment variables and options](/guides/advanced_guides/configuration.md) can be set before and on launch to configure MeiliSearch. Amongst all the options, you can use the **master key** and the **port** options.
 
 ### Communicate with MeiliSearch
 
@@ -444,5 +444,5 @@ This will lead you to a web page with a search bar that will allow you to search
 ![movies demo gif](/movies-web-demo.gif)
 
 ::: warning
-Since the production environment requires an API-key for searching, the web interface is only available in [development mode](/guides/advanced_guides/installation.md#environments).
+Since the production environment requires an API-key for searching, the web interface is only available in [development mode](/guides/advanced_guides/configuration.md#environment).
 :::

--- a/guides/main_concepts/documents.md
+++ b/guides/main_concepts/documents.md
@@ -28,6 +28,19 @@ When using the [route to add new documents](/references/documents.md#add-or-upda
 
 In order to be indexed, each **document must contain** [the primary key field](/guides/main_concepts/documents.md#primary-key).
 
+## Upload
+
+By default, MeiliSearch limits the size of `JSON` payload to 10Mb. This affects the upload of documents.
+To upload more document in one go, it is possible to [change the payload size](/guides/advanced_guides/configuration.md#payload-size-limit) limit during the setup of the MeiliSearch instance using the `http-payload-size-limit` option.
+
+```
+./meilisearch http-payload-size-limit=100000000
+```
+
+> The payload limit is now +-100MB instead of 10MB
+
+**MeiliSearch uses a lot of RAM when indexing documents**, be aware of your RAM availability as you increase the size of your batch as this could result in a MeiliSearch crash.
+
 ## Fields
 
 - **[Data type](/guides/advanced_guides/datatypes.md)**: A field's data type determines what kind of data can be stored in that field.


### PR DESCRIPTION
### Checks the following changelog in the main branch
- Enable max payload size override (meilisearch/MeiliSearch#684)
- Breaking on max payload size

### Configuration guide

Moves the command line options and environment variables to a dedicated `configuration` page instead of in the `installation` page.

### Payload limit
Introduces the limit of 10 MB in the document guide

### Payload size limit
Introduces the command line option to change the limit of the upload payload size



