### PR TITLE
Attributes for faceting sub route

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -173,6 +173,19 @@ update_distinct_attribute_1: |-
 reset_distinct_attribute_1: |-
   $ curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/distinct-attribute'
+get_attributes_for_faceting_1: |-
+  $ curl \
+    -X GET 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting'
+update_attributes_for_faceting_1: |-
+  $ curl \
+    -X GET 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting' \
+    --data '[
+        "genre",
+        "director"
+    ]'
+reset_attributes_for_faceting_1: |-
+  $ curl \
+    -X DELETE 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting'
 get_searchable_attributes_1: |-
   $ curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/searchable-attributes'

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -88,6 +88,7 @@ module.exports = {
                 '/references/synonyms',
                 '/references/stop_words',
                 '/references/ranking_rules',
+                '/references/attributes_for_faceting',
                 '/references/distinct_attribute',
                 '/references/searchable_attributes',
                 '/references/displayed_attributes',

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -32,6 +32,9 @@ reset_distinct_attribute_1: |-
 get_searchable_attributes_1: |-
 update_searchable_attributes_1: |-
 reset_searchable_attributes_1: |-
+get_attributes_for_faceting_1: |-
+update_attributes_for_faceting_1: |-
+reset_attributes_for_faceting_1: |-
 get_displayed_attributes_1: |-
 update_displayed_attributes_1: |-
 reset_displayed_attributes_1: |-

--- a/guides/advanced_guides/settings.md
+++ b/guides/advanced_guides/settings.md
@@ -1,4 +1,4 @@
-# Settings Configuration
+# Settings
 
 This page describes all the **settings** available in MeiliSearch and how to **configure** them.
 

--- a/references/accept_new_fields.md
+++ b/references/accept_new_fields.md
@@ -14,7 +14,7 @@ When `accept-new-fields` is set to **false**, the fields are still stored. This 
 
 :::
 
-The `accept-new-fields` value can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+The `accept-new-fields` value can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 ::: note
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.

--- a/references/attributes_for_faceting.md
+++ b/references/attributes_for_faceting.md
@@ -1,0 +1,95 @@
+# Attributes for Faceting
+
+_Child route of the [settings route](/references/settings.md)._
+
+The attributes that can be used as [facets for faceted search](/guides/advanced_guides/faceted_search.md).
+
+Attributes for faceting can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+
+[Learn more about faceted search](/guides/advanced_guides/faceted_search.md).
+
+## Get Attributes for Faceting
+
+<RouteHighlighter method="GET" route="/indexes/:index_uid/settings/attributes-for-faceting" />
+
+Get the [attributes for faceting](/guides/advanced_guides/faceted_search.md) of an index.
+
+#### Path Variables
+
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
+
+### Example
+
+<code-samples id="get_attributes_for_faceting_1" />
+
+#### Response: `200 Ok`
+
+List the settings.
+
+```json
+["genre", "director"]
+```
+
+## Update Attributes for Faceting
+
+<RouteHighlighter method="POST" route="/indexes/:index_uid/settings/attributes-for-faceting" />
+
+Update the [attributes for faceting](/guides/advanced_guides/faceted_search.md) of an index.
+
+#### Path Variables
+
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
+
+#### Body
+
+An array of strings that contains the attributes to use as facets.
+
+[More information about the body](/guides/advanced_guides/settings.md#attributes-for-faceting).
+
+### Example
+
+<code-samples id="update_attributes_for_faceting_1" />
+
+#### Response: `202 Accepted`
+
+```json
+{
+  "updateId": 1
+}
+```
+
+This `updateId` allows you to [track the current update](/references/updates.md).
+
+## Reset Attributes for Faceting
+
+<RouteHighlighter method="DELETE" route="/indexes/:index_uid/settings/attributes-for-faceting"/>
+
+Reset the [attributes for faceting](/guides/advanced_guides/faceted_search.md) of the index to the default value.
+
+#### Default value
+
+Empty array
+
+#### Path Variables
+
+| Variable      | Description   |
+| ------------- | ------------- |
+| **index_uid** | The index UID |
+
+#### Example
+
+<code-samples id="reset_attributes_for_faceting_1" />
+
+#### Response: `202 Accepted`
+
+```json
+{
+  "updateId": 1
+}
+```
+
+This `updateId` allows you to [track the current update](/references/updates.md).

--- a/references/attributes_for_faceting.md
+++ b/references/attributes_for_faceting.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 The attributes that can be used as [facets for faceted search](/guides/advanced_guides/faceted_search.md).
 
-Attributes for faceting can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Attributes for faceting can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 [Learn more about faceted search](/guides/advanced_guides/faceted_search.md).
 

--- a/references/attributes_for_faceting.md
+++ b/references/attributes_for_faceting.md
@@ -72,7 +72,7 @@ Reset the [attributes for faceting](/guides/advanced_guides/faceted_search.md) o
 
 #### Default value
 
-Empty array
+An empty array (`[]`).
 
 #### Path Variables
 

--- a/references/displayed_attributes.md
+++ b/references/displayed_attributes.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 The fields whose attributes are added to the displayed-attributes list are **displayed in each matching document**.
 
-Displayed attributes can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Displayed attributes can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 ::: note
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.

--- a/references/distinct_attribute.md
+++ b/references/distinct_attribute.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 [Distinct attribute](/guides/advanced_guides/distinct.md) is a field whose value will always be **unique** in the returned documents.
 
-Distinct attribute can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Distinct attribute can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 ::: note
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.

--- a/references/ranking_rules.md
+++ b/references/ranking_rules.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 Ranking rules are built-in rules that **ensure relevancy in search results**. Ranking rules are applied in a default order which can be changed in the settings. You can add or remove rules and change their order of importance.
 
-Ranking rules can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Ranking rules can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 [Learn more about ranking rules and their relevancy](/guides/main_concepts/relevancy.md).
 

--- a/references/searchable_attributes.md
+++ b/references/searchable_attributes.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 The values of the fields whose attributes are added to the searchable-attributes list are **searched for matching query words**.
 
-Searchable attributes can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Searchable attributes can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 ::: note
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.

--- a/references/stop_words.md
+++ b/references/stop_words.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 The stop-words route lets you add a list of words that will be ignored in search queries. So if you add `the` as a stop word and you make a search on `the mask` you will only have matching documents with `mask`.
 
-Stop-words can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Stop-words can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 [Learn more about stop words](/guides/advanced_guides/stop_words.md)
 

--- a/references/synonyms.md
+++ b/references/synonyms.md
@@ -4,7 +4,7 @@ _Child route of the [settings route](/references/settings.md)._
 
 `Synonyms` is an object containing words and their respective synonyms. A synonym in Meilisearch is considered equal to its associated word in a search query.
 
-Synonyms can also be updated directly through the [global settings route](/references/settings.md#update-settings) at the same time than the other settings.
+Synonyms can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 
 ::: note
 Updating the settings means overwriting the default settings of MeiliSearch. You can reset to default values using the `DELETE` routes.


### PR DESCRIPTION
- `Settings Configuration` guide is now called `Settings` to avoid confusion with configuration guide
- Added information about attributes for faceting in the settings references (This has been added in the main branch `prepare-new-version` not on purpose)
- Created dedicated reference for attributes for faceting
- Added 3 new code samples in the curl sample file and the template file