### PR TITLE
uid is not needed

### DIFF
--- a/guides/introduction/quick_start_guide.md
+++ b/guides/introduction/quick_start_guide.md
@@ -135,7 +135,7 @@ const MeiliSearch = require('meilisearch')
 
 var client = new MeiliSearch({ host: 'http://127.0.0.1:7700' })
 const index = client
-  .createIndex({ uid: 'movies' })
+  .createIndex('movies')
   .then((res) => console.log(res))
 ```
 


### PR DESCRIPTION
`uid` is not needed and adding uid will cause `UnhandledPromiseRejectionWarning`.

error detail

`UnhandledPromiseRejectionWarning: MeiliSearchApiError: Invalid JSON: invalid type: map, expected a string at line 1 column 7`