### PR TITLE
should fix getting started

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -143,7 +143,6 @@ module.exports = {
     [require('./config-path-checker')],
     [require('./custom-markdown-rules')],
     [require('./code-samples')],
-    'img-lazy',
     [
       'meilisearch',
       {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "vue-eslint-parser": "^7.1.0",
     "vuepress": "^1.5.2",
     "vuepress-plugin-element-tabs": "^0.2.8",
-    "vuepress-plugin-img-lazy": "^1.0.3",
     "vuepress-plugin-meilisearch": "^0.10.1",
     "vuepress-plugin-seo": "^0.1.3",
     "vuepress-plugin-sitemap": "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5792,11 +5792,6 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lozad@^1.9.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/lozad/-/lozad-1.15.0.tgz#cdab34e0e00eaecd3972129880560f5885a1a7bf"
-  integrity sha512-P60iyIiud4XSH5SXxrgPCXoebEaT6SYAvRBgeMBZPYmWVRSfOhQks8ZmyZ/WFgDgwvrHnWffXw9HMg8G0gvt0w==
-
 lru-cache@^4.0.1, lru-cache@^4.1.2:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
@@ -5865,16 +5860,6 @@ markdown-it-emoji@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/markdown-it-emoji/-/markdown-it-emoji-1.4.0.tgz#9bee0e9a990a963ba96df6980c4fddb05dfb4dcc"
   integrity sha1-m+4OmpkKljupbfaYDE/dsF37Tcw=
-
-markdown-it-img-lazy@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-it-img-lazy/-/markdown-it-img-lazy-1.0.1.tgz#b9ec7f1da6566f498eb723d5cec3f7a4514b9337"
-  integrity sha512-qxQr1LJjwTS8GGQWEKsbgjTQYulKPZtxIyoVK4fjJh6eZcLKz8vcT1hkz/f68Yr4KI5jmw7+ViGK+nLnUEqxeg==
-
-markdown-it-imsize@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/markdown-it-imsize/-/markdown-it-imsize-2.0.1.tgz#cca0427905d05338a247cb9ca9d968c5cddd5170"
-  integrity sha1-zKBCeQXQUziiR8ucqdloxc3dUXA=
 
 markdown-it-table-of-contents@^0.4.0:
   version "0.4.4"
@@ -9357,15 +9342,6 @@ vuepress-plugin-element-tabs@^0.2.8:
     node-sass "^4.11.0"
     resize-observer-polyfill "^1.5.1"
     sass-loader "^7.1.0"
-
-vuepress-plugin-img-lazy@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/vuepress-plugin-img-lazy/-/vuepress-plugin-img-lazy-1.0.3.tgz#957e3df9a340030744f20e5969ce0e006e35e345"
-  integrity sha512-gsr29hzmuX1yiDxER9pd4rjwd2lQFxcYbLAAdBGwRtma1UuITPLPrQAycAA40Zzu57JPL2ww1w3QFh76uTba8Q==
-  dependencies:
-    lozad "^1.9.0"
-    markdown-it-img-lazy "^1.0.0"
-    markdown-it-imsize "^2.0.1"
 
 vuepress-plugin-meilisearch@^0.10.1:
   version "0.10.1"


### PR DESCRIPTION
A bug only present on master crashes when going directly to the getting_started guide.
-> [https://docs.meilisearch.com/guides/introduction/quick_start_guide.html](https://docs.meilisearch.com/guides/introduction/quick_start_guide.html)

I could not reproduce this neither on local neither on netlify. I suppose it comes from the latest plugin which is the `lazy load`.

Only indication I have is `warning An error was encountered in plugin "img-lazy"` on build. 
I suppose this is at the origin of the bug. I will investigate more later but fixing the doc is the most important.
