### PR TITLE
Add links to code-samples file for PHP, Go and Ruby

### DIFF
--- a/.vuepress/code-samples/sdks.json
+++ b/.vuepress/code-samples/sdks.json
@@ -13,5 +13,20 @@
     "language": "python",
     "label": "Python",
     "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-python/master/.code-samples.meilisearch.yaml"
+  },
+  {
+    "language": "php",
+    "label": "PHP",
+    "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-php/master/.code-samples.meilisearch.yaml"
+  },
+  {
+    "language": "ruby",
+    "label": "Ruby",
+    "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-ruby/master/.code-samples.meilisearch.yaml"
+  },
+  {
+    "language": "go",
+    "label": "Go",
+    "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-go/master/.code-samples.meilisearch.yaml"
   }
 ]


### PR DESCRIPTION
Should not be merged until the code-samples file is merge on:
- [x] [meilisearch-ruby](https://github.com/meilisearch/meilisearch-ruby/pull/61)
- [x] [meilisearch-php](https://github.com/meilisearch/meilisearch-php/pull/46)
- [x] [meilisearch-go](https://github.com/meilisearch/meilisearch-go/pull/52)