### PR TITLE
Add comment at the top of the code-samples file

### DIFF
--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -1,3 +1,8 @@
+# This code-samples file is used by the MeiliSearch documentation
+# Every example written here will be automatically fetched by
+# the documentation on build
+# You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
+---
 get_one_index_1: |-
 list_all_indexes_1: |-
 create_an_index_1: |-


### PR DESCRIPTION
This comment is already added in the code-samples file in the Ruby, PHP and Go packages according to @tpayet and @eskombro reviews

see: https://github.com/meilisearch/meilisearch-ruby/pull/61#discussion_r447045529