### PR TITLE
Errors documentation

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -138,11 +138,12 @@ module.exports = {
     ['check-md', { pattern: '**/*.md', strictExt: true }],
     ['sitemap', { hostname: 'https://docs.meilisearch.com' }],
     ['seo', {}],
+    'img-lazy',
     'vuepress-plugin-element-tabs',
     [require('./config-path-checker')],
     [require('./custom-markdown-rules')],
     [require('./code-samples')],
-    'img-lazy',
+    [require('./error-pages')],
     [
       'meilisearch',
       {

--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,8 +1,4 @@
 export default ({
   router,
 }) => {
-  router.addRoutes([
-    { path: '/errors', redirect: '/guides' },
-    { path: '/errors/*', redirect: '/guides' },
-  ])
 }

--- a/.vuepress/error-pages/index.js
+++ b/.vuepress/error-pages/index.js
@@ -22,10 +22,10 @@ module.exports = {
     const errors = sampleYamlToJs(errorYaml).errors
     const errorsPages = []
     errorsPages.push({
-      path: '/errors', // Cannot be errors. Works in development mode but not production
+      path: '/errors/', // Cannot be errors. Works in development mode but not production
       content: `## MeiliSearch Errors
 ${errors.map(err => `
-#### \`${err.code}\`
+## \`${err.code}\`
 ${err.description}
 `).join('')}`,
     })

--- a/.vuepress/error-pages/index.js
+++ b/.vuepress/error-pages/index.js
@@ -23,14 +23,12 @@ module.exports = {
     const errors = sampleYamlToJs(errorYaml).errors
     const errorsPages = []
     errorsPages.push({
-      path: '/errors-list/', // Cannot be errors. Works in development mode but not production
-      content: `## MeiliSearch Errors \n ${errors.map(err => `* [${err.code}](/errors/${err.code})\n`).join('')}`,
-    })
-    errors.map(err => {
-      errorsPages.push({
-        path: `/errors/${err.code}/`,
-        content: `## ${err.code} \n ${err.description}`,
-      })
+      path: '/errors', // Cannot be errors. Works in development mode but not production
+      content: `## MeiliSearch Errors
+${errors.map(err => `
+#### \`${err.code}\`
+${err.description}
+`).join('')}`,
     })
     return errorsPages
   },

--- a/.vuepress/error-pages/index.js
+++ b/.vuepress/error-pages/index.js
@@ -1,0 +1,37 @@
+const yamlToJs = require('js-yaml')
+const fs = require('fs')
+
+/*
+ * Convert YAML string to Js object
+ * Throw a precise error on parsing fail.
+ */
+function sampleYamlToJs(content) {
+  try {
+    return yamlToJs.safeLoad(content)
+  } catch (e) {
+    throw new Error(`Error file could not be parsed in JSON
+    ${e.message}
+
+    ${e.stack}`)
+  }
+}
+
+module.exports = {
+  async additionalPages() {
+    const errorYaml = fs.readFileSync(`${process.cwd()}/errors.yaml`, 'utf-8')
+    console.log(errorYaml)
+    const errors = sampleYamlToJs(errorYaml).errors
+    const errorsPages = []
+    errorsPages.push({
+      path: '/errors-list/', // Cannot be errors. Works in development mode but not production
+      content: `## MeiliSearch Errors \n ${errors.map(err => `* [${err.code}](/errors/${err.code})\n`).join('')}`,
+    })
+    errors.map(err => {
+      errorsPages.push({
+        path: `/errors/${err.code}/`,
+        content: `## ${err.code} \n ${err.description}`,
+      })
+    })
+    return errorsPages
+  },
+}

--- a/.vuepress/error-pages/index.js
+++ b/.vuepress/error-pages/index.js
@@ -19,7 +19,6 @@ function sampleYamlToJs(content) {
 module.exports = {
   async additionalPages() {
     const errorYaml = fs.readFileSync(`${process.cwd()}/errors.yaml`, 'utf-8')
-    console.log(errorYaml)
     const errors = sampleYamlToJs(errorYaml).errors
     const errorsPages = []
     errorsPages.push({


### PR DESCRIPTION
Two new links:

- `/errors-list`
- `/errors/:error_code`

I could not make `/errors` and `/errors/:error_code` because of vuepress buggy way to handle `additionalPages`.

`/errors-list` is not mandatory and can be removed.

Also `errors.yaml` is bound to be removed once #421 is merged.

