### PR TITLE
update faceting configuration curl example

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -179,7 +179,6 @@ get_attributes_for_faceting_1: |-
 update_attributes_for_faceting_1: |-
   $ curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting' \
-    --get \
     --data '[
         "genre",
         "director"


### PR DESCRIPTION
I get a bad request when I include `--get`, which seems like it'd conflict with `-X POST` anyway.

```
$ curl -H "x-meili-api-key: redacted" -X POST 'http://meilisearch.meilisearch.svc.cluster.local:7700/indexes/audionotes/settings/attributes-for-faceting' --get --data '["podcast_id"]'

*   Trying 10.20.15.209...
* TCP_NODELAY set
* Expire in 200 ms for 4 (transfer 0x562c2ede8f50)
* Connected to meilisearch.meilisearch.svc.cluster.local (10.20.15.209) port 7700 (#0)
> POST /indexes/audionotes/settings/attributes-for-faceting?["podcast_id"] HTTP/1.1
> Host: meilisearch.meilisearch.svc.cluster.local:7700
> User-Agent: curl/7.64.0
> Accept: */*
> x-meili-api-key: redacted
> 
< HTTP/1.1 400 Bad Request
< content-length: 0
< date: Sat, 11 Jul 2020 04:33:51 GMT
< x-envoy-upstream-service-time: 0
< server: envoy
< 
* Connection #0 to host meilisearch.meilisearch.svc.cluster.local left intact


$ curl -vvvH "x-meili-api-key: redacted" -X POST 'http://meilisearch.meilisearch.svc.cluster.local:7700/indexes/audionotes/settings/attributes-for-faceting' --data '["podcast_id"]'

*   Trying 10.20.15.209...
* TCP_NODELAY set
* Expire in 200 ms for 4 (transfer 0x5610b78eaf50)
* Connected to meilisearch.meilisearch.svc.cluster.local (10.20.15.209) port 7700 (#0)
> POST /indexes/audionotes/settings/attributes-for-faceting HTTP/1.1
> Host: meilisearch.meilisearch.svc.cluster.local:7700
> User-Agent: curl/7.64.0
> Accept: */*
> x-meili-api-key: redacted
> Content-Length: 14
> Content-Type: application/x-www-form-urlencoded
> 
* upload completely sent off: 14 out of 14 bytes
< HTTP/1.1 202 Accepted
< content-length: 15
< content-type: application/json
< date: Sat, 11 Jul 2020 04:41:14 GMT
< x-envoy-upstream-service-time: 17
< server: envoy
< 
* Connection #0 to host meilisearch.meilisearch.svc.cluster.local left intact
{"updateId":14}
```