### PR TITLE
Upgrade docs-scraper from v0.10.0 to v0.10.1

### DIFF
--- a/.github/workflows/gh-pages-scraping.yml
+++ b/.github/workflows/gh-pages-scraping.yml
@@ -46,4 +46,4 @@ jobs:
           -e MEILISEARCH_HOST_URL=$HOST_URL \
           -e MEILISEARCH_API_KEY=$API_KEY \
           -v $CONFIG_FILE_PATH:/docs-scraper/config.json \
-          getmeili/docs-scraper:v0.10.0 pipenv run ./docs_scraper config.json
+          getmeili/docs-scraper:v0.10.1 pipenv run ./docs_scraper config.json


### PR DESCRIPTION
The v0.10.1 is compatible with MeiliSearch v0.12.0 (the current Droplet version) and the v0.13.0 (upgrade coming after this PR is merged).