### PR TITLE
Update authentication documentation regarding public key routes

### DIFF
--- a/guides/advanced_guides/authentication.md
+++ b/guides/advanced_guides/authentication.md
@@ -6,6 +6,7 @@ MeiliSearch uses a key-based authentication. There are three types of keys:
 - The **Private** key grants access to all routes except the `/keys` routes.
 - The **Public** key only grants access to the following routes:
   - `GET /indexes/:index_uid/search`
+  - `POST /indexes/:index_uid/search`
   - `GET /indexes/:index_uid/documents`
   - `GET /indexes/:index_uid/documents/:doc_id`
   - `GET /health`


### PR DESCRIPTION
I didn't test this, but I am guessing the public key also allows access to `POST /indexes/:index_uid/search`