### PR TITLE
Prepare documentation for MeiliSearch 10/2020 release

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -438,3 +438,7 @@ faceted_search_walkthrough_facet_filters_1: |-
 faceted_search_walkthrough_facets_distribution_1: |-
   $ curl 'http://localhost:7700/indexes/movies/search' \
   --data '{  "q": "Batman", "facetsDistribution": ["genres"] }'
+post_dump_1: |- 
+  $ curl -X POST 'http://localhost:7700/dumps'
+get_dump_status_1: |- 
+  $ curl -X GET 'http://localhost:7700/dumps/:dump_uid/status'

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,37 +5,37 @@ module.exports = {
     node: true,
   },
   extends: [
-    "eslint:recommended",
-    "eslint-config-standard",
-    "plugin:vue/recommended",
+    'eslint:recommended',
+    'eslint-config-standard',
+    'plugin:vue/recommended',
   ],
   globals: {
-    Atomics: "readonly",
-    SharedArrayBuffer: "readonly",
-    CODE_SAMPLES: "readonly"
+    Atomics: 'readonly',
+    SharedArrayBuffer: 'readonly',
+    CODE_SAMPLES: 'readonly',
   },
   parserOptions: {
-    parser: "babel-eslint",
+    parser: 'babel-eslint',
     allowImportExportEverywhere: true,
     ecmaVersion: 2018,
-    sourceType: "module",
+    sourceType: 'module',
   },
-  plugins: ["vue", "prettier"],
+  plugins: ['vue', 'prettier'],
   rules: {
-    "vue/no-v-html": "off", //used in cases where HTML is needed
-    "space-before-function-paren": ["error", {
-      "anonymous": "always",
-      "named": "never",
-      "asyncArrow": "always"
+    'vue/no-v-html': 'off', // used in cases where HTML is needed
+    'space-before-function-paren': ['error', {
+      anonymous: 'always',
+      named: 'never',
+      asyncArrow: 'always',
     }],
-    "comma-dangle": ["error", {
-      "arrays": "always-multiline",
-      "objects": "always-multiline",
-      "imports": "always-multiline",
-      "exports": "always-multiline",
-      "functions": "never"
+    'comma-dangle': ['error', {
+      arrays: 'always-multiline',
+      objects: 'always-multiline',
+      imports: 'always-multiline',
+      exports: 'always-multiline',
+      functions: 'never',
     }],
-    "vue/max-attributes-per-line": [
+    'vue/max-attributes-per-line': [
       2,
       {
         singleline: 20,
@@ -44,6 +44,6 @@ module.exports = {
           allowFirstLine: false,
         },
       },
-    ]
+    ],
   },
-};
+}

--- a/.vuepress/components/glossary.vue
+++ b/.vuepress/components/glossary.vue
@@ -16,18 +16,25 @@ import { createPopper } from '@popperjs/core'
 
 const glossary = {
   field:
-    "A field, or a key-value pair, is a set of two data items linked together: an <b>attribute</b> and its associated <b>value</b>. <br><br> Ex: <code>attribute: 'value'</code>",
+    'A field, or a key-value pair, is a set of two data items linked together: an <b>attribute</b> and its associated <b>value</b>. <br><br> Ex: <code>"attribute": "value"</code>',
   attribute:
-    "An attribute is the name of a field, like a key. <br><br> Ex:  <code>title: 'Batman'</code> <br> In the example above, title is the attribute.",
+    'An attribute is the name of a field, like a key. <br><br> Ex:  <code>"title": "Batman"</code> <br> In the example above, "title" is the attribute.',
+  value:
+    'A piece of data linked to an attribute. One half of a field. <br><br> Ex:  <code>"title": "Batman"</code> <br> In the example above, "Batman" is the value.',
   'ranking rules':
     'A set of consecutive rules applied to ensure relevancy in search results. <br><br> For example, to sort results by number of typos or number of matched query terms in each matching document.',
+  'primary field':
+    'A special field containing the primary key and a unique document id. <br><br> Every document must possess a correctly formatted primary field in order to be indexed.',
   'primary key':
-    'The attribute of the field which contains the unique identifier of the documents. <br><br> It is used by MeiliSearch to store the document. <br><br> Example: <code>movie_id</code> is the primary key of a movie document.',
+    'The attribute of the primary field. The primary key\'s associated value is a unique document id. An index possesses only one primary key, which is shared among all its documents. <br><br> Example: in a document with the primary field <code>"movie_id": "Abc_012"</code>, "movie_id" is the primary key.',
+  'document id':
+    'The value of the primary field. The document id acts as a unique identifier for storing documents. <br><br> Example: in a document with the primary field <code>"movie_id": "Abc_012"</code>, "Abc_012" is the document id.',
   schemaless:
-    "This means data can be indexed without providing a fixed data structure. <br><br> For example, SQL's tables require schema definition whereas MongoDB's collections don't.",
+    'This means data can be indexed without providing a fixed data structure. <br><br> For example, SQL\'s tables require schema definition whereas MongoDB\'s collections don\'t.',
   searchable:
     'The data is used to determine the relevancy of a document when doing a search query.',
-  displayed: 'The field is present in the documents returned upon search.',
+  displayed:
+    'The field is present in the documents returned upon search.',
 }
 
 export default {

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -1,6 +1,6 @@
 const ogprefix = 'og: http://ogp.me/ns#'
 module.exports = {
-  title: 'MeiliSearch Documentation v0.14',
+  title: 'MeiliSearch Documentation v0.15',
   description: 'Open source Instant Search Engine',
   themeConfig: {
     repo: 'meilisearch/MeiliSearch',
@@ -99,6 +99,7 @@ module.exports = {
             '/references/stats',
             '/references/health',
             '/references/version',
+            '/references/dump',
           ],
         },
       ],

--- a/.vuepress/public/postman/meilisearch-collection.json
+++ b/.vuepress/public/postman/meilisearch-collection.json
@@ -1,12 +1,12 @@
 {
 	"info": {
-		"_postman_id": "b112fb40-a555-40f7-882e-370237b53693",
-		"name": "MeiliSearch v0.14",
+		"_postman_id": "0ff31625-5c59-4167-baa9-b14dadb2d721",
+		"name": "MeiliSearch v0.15",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
 		{
-			"name": "Index",
+			"name": "Indexes",
 			"item": [
 				{
 					"name": "List all indexes",
@@ -224,7 +224,9 @@
 							"mode": "raw",
 							"raw": "[\n  { \"id\": 2,    \"title\": \"Pride and Prejudice\",                    \"author\": \"Jane Austin\",              \"genre\": \"romance\" },\n  { \"id\": 456,  \"title\": \"Le Petit Prince\",                        \"author\": \"Antoine de Saint-Exupéry\", \"genre\": \"adventure\" },\n  { \"id\": 1,    \"title\": \"Alice In Wonderland\",                    \"author\": \"Lewis Carroll\",            \"genre\": \"fantasy\" },\n  { \"id\": 1344, \"title\": \"The Hobbit\",                             \"author\": \"J. R. R. Tolkien\",         \"genre\": \"fantasy\" },\n  { \"id\": 4,    \"title\": \"Harry Potter and the Half-Blood Prince\", \"author\": \"J. K. Rowling\",            \"genre\": \"fantasy\" },\n  { \"id\": 42,   \"title\": \"The Hitchhiker's Guide to the Galaxy\",   \"author\": \"Douglas Adams\" }\n]",
 							"options": {
-								"raw": {}
+								"raw": {
+									"language": "json"
+								}
 							}
 						},
 						"url": {
@@ -257,7 +259,9 @@
 							"mode": "raw",
 							"raw": "[\n  {\n\t\"id\": 2,\n\t\"author\": \"J. Austen\",\n\t\"date\": \"1813\"\n  }\n]",
 							"options": {
-								"raw": {}
+								"raw": {
+									"language": "json"
+								}
 							}
 						},
 						"url": {
@@ -1252,6 +1256,82 @@
 				}
 			],
 			"protocolProfileBehavior": {}
+		},
+		{
+			"name": "Dumps",
+			"item": [
+				{
+					"name": "Get a dump status",
+					"request": {
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{url}}/dumps/20201001-110357260/status",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"dumps",
+								"20201001-110357260",
+								"status"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create a dump",
+					"protocolProfileBehavior": {
+						"disabledSystemHeaders": {}
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n\t\"uid\": \"{{indexUID}}\"\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{url}}/dumps",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"dumps"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "0265ea3d-b8e6-489d-82b5-330e5c5faa4c",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "197a673a-9a4b-4cae-bb55-d815399a54dc",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
 		}
 	],
 	"auth": {
@@ -1273,7 +1353,7 @@
 		{
 			"listen": "prerequest",
 			"script": {
-				"id": "3d558ac3-706e-4762-ba8e-949359fb6479",
+				"id": "82b5ff41-9cc7-41bc-9623-88410c73da63",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -1283,7 +1363,7 @@
 		{
 			"listen": "test",
 			"script": {
-				"id": "35ce4f87-4f5e-4807-b938-b08ddee9d7fd",
+				"id": "10a519ec-0201-4e5d-8a0f-83c5d37e6a4b",
 				"type": "text/javascript",
 				"exec": [
 					""
@@ -1293,12 +1373,12 @@
 	],
 	"variable": [
 		{
-			"id": "1653a290-d7d8-43a1-b8bc-ab0cdad1ac5f",
+			"id": "f6184d92-9c0c-4521-9a76-1f84d37e974e",
 			"key": "url",
 			"value": "http://0.0.0.0:7700"
 		},
 		{
-			"id": "ac601bd6-d4a3-47f7-b024-77f9942a46e9",
+			"id": "d88ba4a1-c490-49a4-b3cf-3af96c889145",
 			"key": "indexUID",
 			"value": "indexUID"
 		}

--- a/errors.yaml
+++ b/errors.yaml
@@ -48,4 +48,8 @@ errors:
     description: "There was an error in the search."
   - code: unsupported_media_type
     description: "The payload content type is not supported by MeiliSearch. Currently, MeiliSearch supports only JSON payloads."
+  - code: dump_already_in_progress
+    description: "A dump creation is already in progress and a new one can't be triggered until the previous dump creation is not finished."
+  - code: dump_process_failed
+    description: "An error occured during dump creation process, task aborted."
 ...

--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -37,6 +37,10 @@ Server is listening on: http://127.0.0.1:7700
 
 - [Analytics](/guides/advanced_guides/configuration.md#analytics)
 - [Payload Limit Size](/guides/advanced_guides/configuration.md#payload-limit-size)
+- [Dumps](/guides/advanced_guides/configuration.md#dumps-folder)
+  - [Dumps folder](/guides/advanced_guides/configuration.md#dumps-folder)
+  - [Import dump](/guides/advanced_guides/configuration.md#import-dump)
+  - [Dump batch size](/guides/advanced_guides/configuration.md#dump-batch-size)
 - [Max MDB Size](/guides/advanced_guides/configuration.md#max-mdb-size)
 - [Max UDB Size](/guides/advanced_guides/configuration.md#max-udb-size)
 - [SSL Configuration](/guides/advanced_guides/configuration.md#ssl-authentication-path):
@@ -296,3 +300,37 @@ The engine ignores missing snapshots and does not throw an error in this case.
 **CLI option**: `--ignore-snapshot-if-db-exists`
 
 The engine skips snapshot importation if a database already exists. No error is thrown in this case.
+
+### Dumps folder
+
+**Environment variable**: `MEILI_DUMPS_FOLDER`
+**CLI option**: `--dumps-folder`
+
+Path of the folder where dumps will be created if the [dump route](/references/dump.md#trigger-a-dump-creation) is called.
+
+**Default value**: `dumps/`
+
+### Import dump
+
+**Environment variable**: `MEILI_IMPORT_DUMP`
+**CLI option**: `--import-dump`
+
+Import a dump from the specified path. Must be a `.tar.gz` file.
+
+As the data contained in the dump needs to be indexed, the process will take an amount of time corresponding to the size of the dump. Only when the import is complete and successful will the MeiliSearch server start.
+
+### Dump batch size
+
+**Environment variable**: `MEILI_DUMP_BATCH_SIZE`
+**CLI option**: `--dump-batch-size`
+
+Sets the batch size used in the dump importation process. This number corresponds to the maximum number of documents indexed in each batch. A larger value will take less time but use more memory.
+
+**Example**
+Imagine you set `--dump-batch-size 1000` and your dump contains 2600 documents. Instead of indexing all 2600 docs in one go, the engine will :
+
+1. Index documents 0 -> 999 (1000 docs)
+2. Index documents 1000 -> 1999 (1000 docs)
+3. Index documents 2000 -> 2599 (600 docs)
+
+**Default value**: `1024`

--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -306,7 +306,7 @@ The engine skips snapshot importation if a database already exists. No error is 
 **Environment variable**: `MEILI_DUMPS_FOLDER`
 **CLI option**: `--dumps-folder`
 
-Path of the folder where dumps will be created if the [dump route](/references/dump.md#trigger-a-dump-creation) is called.
+Path of the folder where dumps will be created if the [dump route](/references/dump.md#create-a-dump) is called.
 
 **Default value**: `dumps/`
 

--- a/guides/advanced_guides/known_limitations.md
+++ b/guides/advanced_guides/known_limitations.md
@@ -11,7 +11,7 @@ Some of these limitations have been made by MeiliSearch developers for relevacy 
 MeiliSearch uses two databases: the first one for storage and the second one for updates.
 On launch LMDB needs to know the size that it can allocate on disk. This space will be reserved on disk for LMDB, thus MeiliSearch. This space will also be allocated as virtual memory.
 
-The maximum database size is by default __100GiB__ for each databases. This size can me modified using the options `--max-mdb-size` & `--max-udb-size` as described in the [configuration guide](/guides/advanced_guides/configuration.md#max-mdb-size).
+The maxime database size is by default __100GiB__ for each databases. This size can me modified using the options `--max-mdb-size` & `--max-udb-size` as described in the [configuration guide](/guides/advanced_guides/configuration.md#max-mdb-size).
 
 ### Number of indexes
 

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -4,13 +4,13 @@ Search parameters let the user customize their search request.
 
 | Query Parameter                                                                                   | Description                                                                                     | Default Value |
 | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
-| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string                                                                                    |               |
+| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string                                                                                    |     `""`     |
 | **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                                                                     |      `0`      |
 | **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Maximum number of documents returned                                                            |     `20`      |
 | **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                                                            |    `null`     |
 | **[facetFilters](/guides/advanced_guides/search_parameters.md#facet-filters)** | Facet names and values to filter on                                  |    `null`     |
 | **[facetsDistribution](/guides/advanced_guides/search_parameters.md#the-facets-distribution)** | Facets for which to retrieve the matching count                                 |    `null`     |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                                                 |      `*`      |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                                                 |      `["*"]`      |
 | **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                                                      |    `null`     |
 | **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Length used to crop field values                                                                |     `200`     |
 | **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms                                 |    `null`     |

--- a/guides/main_concepts/documents.md
+++ b/guides/main_concepts/documents.md
@@ -1,108 +1,141 @@
 # Documents
 
-**Documents** are objects composed of fields which can store any type of data.</br>
-Each **field** contains an **attribute** and its associated **value**.
+A **document** is an object composed of one or more **<clientGlossary word="field" label="fields"/>**. Each field consists of an **<clientGlossary word="attribute" />** and its associated **<clientGlossary word="value" />**.
 
-![document structure](/document_structure.svg =573x400)
-
-#### Wording
-
-- **Document**: A document is an object which contains a list of fields in curly brackets.
-- **[Field](/guides/main_concepts/documents.md#fields)**: A field, or a key-value pair, is a set of two data items linked together: an attribute and its corresponding value.
-- **Attribute**: An attribute is the name of a field, like a key.
-- **[Primary key](/guides/main_concepts/documents.md#primary-key)**: The attribute of the field which contains the unique identifier of the documents.
-- **[Document id](/guides/main_concepts/documents.md#document-id)**: A document id is the value associated to the primary key attribute. Values in that field must always be **unique**.
-
-#### Example
-
-Given an **index** that contains information about movies. There would be **documents** with the following **attributes**:`"id"`, `"title"`, `"description"` and `"type"`, a **field** is the association of an attribute and its **value**: `"title": "Kung fu Panda"`.
-
-Each document contains at least the **primary key** attribute : `id` with its associated value, the **document id**: `"id": "123456"`
+Documents function as **containers for organizing data**, and are the basic building blocks of a MeiliSearch database. To search for a document, it must first be added to an [index][indexes].
 
 ## Structure
 
-Documents are sent to MeiliSearch in `JSON format`.
-When using the [route to add new documents](/references/documents.md#add-or-update-documents), all documents must be sent in an array **even if there is only one document**.
+![document structure](/document_structure.svg =573x400)
 
-<code-samples id="documents_guide_add_movie_1" />
+### Important Terms
 
-In order to be indexed, each **document must contain** [the primary key field](/guides/main_concepts/documents.md#primary-key).
+- **Document**: an object which contains data in the form of one or more fields.
+- **[Field][fields]**: a set of two data items that are linked together: an **attribute** and a **value**.
+- **Attribute**: the first part of a field. Acts as a name or description for its associated value.
+- **Value**: the second part of a field, consisting of data of any valid `JSON` type.
+- **[Primary Field][primary-field]**: A special field that is mandatory in all documents. It contains the primary key and document identifier.
+- **[Primary Key][primary-key]**: the attribute of the primary field. **All documents in the same index must possess the same primary key.** Its associated value is the document identifier.
+- **[Document Identifier][document-id]**: the value of the primary field. **Every document in a given index must have a unique identifier**.
 
-## Upload
+### Formatting
 
-By default, MeiliSearch limits the size of `JSON` payload to 10MB. This affects the upload of documents.
+Documents are represented as `JSON objects`: key-value pairs enclosed by curly brackets. As such, [any rule that applies to formatting `JSON objects`](https://www.w3schools.com/js/js_json_objects.asp) also applies to formatting MeiliSearch documents. For example, **an attribute must be a string**, while **a value must be a valid [`JSON` data type](https://www.w3schools.com/js/js_json_datatypes.asp)**.
 
-To upload more document in one go, it is possible to [change the payload size limit](/guides/advanced_guides/configuration.md#payload-limit-size) during the setup of the MeiliSearch instance using the `http-payload-size-limit` option.
+As an example, let's say you are making an **[index][indexes]** that contains information about movies. A sample document might look like this:
 
-```bash
-$ ./meilisearch --http-payload-size-limit=100000000
+```json
+{
+  "id": "1564saqw12ss",
+  "title": "Kung Fu Panda",
+  "genre": "Children's Animation",
+  "release-year": 2008,
+  "cast": [ {"Jack Black": "Po"}, {"Jackie Chan": "Monkey"} ]
+}
 ```
 
-> The payload limit is now +-100MB instead of 10MB
+In the above example, `"id"`, `"title"`, `"genre"`, `"release-year"`, and `"cast"` are **attributes**.
+Each attribute must be associated with a **value**, e.g. `"Kung Fu Panda"` is the value of `"title"`.
+At minimum, the document must contain one field with the **[primary key][primary-key]** attribute and a unique **[document id][document-id]** as its value. Above, that's: `"id": "1564saqw12ss"`.
 
-**MeiliSearch uses a lot of RAM when indexing documents**, be aware of your RAM availability as you increase the size of your batch as this could result in a MeiliSearch crash.
+### Limitations and Requirements
+
+Documents have a **soft maximum of 1000 fields**; beyond that the [<clientGlossary word="ranking rules" />](/guides/main_concepts/relevancy.md#ranking-rules) may no longer be effective, leading to undefined behavior.
+
+Additionally, every document must have at minimum one field containing the **[<clientGlossary word="primary key" />][primary-key]** and a **[unique id][document-id]**.
+
+If you try to [index a document](/guides/introduction/quick_start_guide.md#add-documents) that's incorrectly formatted, missing a primary key, or possessing the [wrong primary key for a given index](/guides/main_concepts/indexes.md#primary-key), it will cause an error and no documents will be added.
 
 ## Fields
 
-- **[Data type](/guides/advanced_guides/datatypes.md)**: A field's data type determines what kind of data can be stored in that field.
-- **[Field properties](/guides/advanced_guides/field_properties.md)**: Field properties determines the characteristics and behavior of the data added to that field.
+A <clientGlossary word="field" /> is a set of two data items linked together: an <clientGlossary word="attribute" /> and a value. Documents are made up of fields.
 
-By default, all fields included in a document are <clientGlossary word="searchable" /> and <clientGlossary word="displayed" />.
-You can adjust how a field get handled by MeiliSearch in the settings. It can either be searchable or displayed, both, or none of both. In the latter case, the field will be completely ignored when a document is sent.
+An attribute functions a bit like a variable in most programming languages, i.e. it is a name that allows you to store, access, and describe some data. That data is the attribute's **value**.
 
-You can also apply <clientGlossary word="ranking rules" /> to some fields. For example, you may decide recent movies should be more relevant than older ones.
+Every field has a [data type](/guides/advanced_guides/datatypes.md) dictated by its value. Every value must be a valid [`JSON` data type](https://www.w3schools.com/js/js_json_datatypes.asp).
 
-## Primary key
+Take note that in the case of strings, the value **[can contain at most 1000 words](/guides/advanced_guides/known_limitations.md#maximum-words-per-attribute)**. If it contains more than 1000 words, only the first 1000 will be indexed.
 
-A primary key is an <clientGlossary word="attribute" /> which contains a unique value. It uniquely identifies each of the documents of a given index in order to store them. Therefore, values in that field must always be **unique**.
+You can also apply [<clientGlossary word="ranking rules" />](/guides/main_concepts/relevancy.md#ranking-rules) to some fields. For example, you may decide recent movies should be more relevant than older ones.
 
-Each index recognizes **only one** primary key attribute. Once a [primary key has been set for an index](/guides/main_concepts/documents.md#setting-the-primary-key), it **cannot be changed anymore**.
+If you would like to adjust how a field gets handled by MeiliSearch, you can do so in the [settings](/guides/advanced_guides/settings.md#settings).
 
-If no **primary key** is found in a document, the document will not be stored.
+### Field properties
 
-**Example:**
+A field may also possess **[field properties](/guides/advanced_guides/field_properties.md)**. Field properties determine the characteristics and behavior of the data added to that field.
 
-Suppose we have an index of 200k `documents` called `movie`. Each document is identified by a primary key named `movie_id` whose value is unique as shown below.
+At this time, there are two field properties: [<clientGlossary word="searchable" />](/guides/advanced_guides/field_properties.md#searchable-fields) and [<clientGlossary word="displayed" />](/guides/advanced_guides/field_properties.md#displayed-fields). A field can have one, both, or neither of these properties. **By default, all fields in a document are both displayed and searchable.**
+
+To clarify, a field may be:
+
+- searchable but not displayed
+- displayed but not searchable
+- both displayed and searchable (default)
+- neither displayed nor searchable
+
+In the latter case, the field will be completely ignored when a search is performed. However, it will still be [stored](/guides/advanced_guides/field_properties.md#data-storing) in the document.
+
+## Primary Field
+
+The <clientGlossary word="primary field" /> is a special <clientGlossary word="field" /> that must be present in all documents. Its attribute is the [<clientGlossary word="primary key" />][primary-key] and its value is the [<clientGlossary word="document id" />][document-id].
+
+The primary field serves the important role of uniquely identifying each document stored in an index, ensuring that **it is impossible to have two exactly identical documents** present in the same index.
+
+Therefore, every document in the same index **must possess the exact same primary key** associated with a unique **document id** as value.
+
+#### Example:
+
+Suppose we have an index called `movie` that contains 200,000 documents. As shown below, each document is identified by a **primary field** containing the **primary key** `movie_id` and a **unique value** (the document id).
+Aside from the primary key, **documents in the same index are not required to share attributes**, e.g. you could have a document in this index without the "title" attribute.
 
 ```json
 [
   {
     "movie_id": "1564saqw12ss",
-    "title": "Kung fu Panda"
+    "title": "Kung fu Panda",
+    "runtime": 95
   },
   {
     "movie_id": "15k1j2kkw223s",
-    "title": "Batman"
+    "title": "Batman Begins",
+    "gritty reboot": true
   }
 ]
 ```
 
-### Setting the primary key
+### Primary Key
 
-There are several ways for MeiliSearch to know which field is the `primary key` in several ways.
+The <clientGlossary word="primary key" />  is a **mandatory <clientGlossary word="attribute" /> linked to a unique <clientGlossary word="value" />:** the [<clientGlossary word="document id" />][document-id]. It is part of the [<clientGlossary word="primary field" />][primary-field].
 
-- MeiliSearch [automatically infers the primary key](/guides/main_concepts/documents.md#meilisearch-infers-your-primary-key) based on your first document.
-- Set it [on index creation](/references/indexes.md#create-an-index)
-- Set it [on document addition](/references/documents.md#add-or-replace-documents)
+Each index recognizes **only one** primary key attribute. Once a primary key has been set for an index, it **cannot be changed anymore**. If no primary key is found in a document, **the document will not be stored.**
+
+#### Setting the primary key
+
+There are several ways for MeiliSearch to know which field is the primary key.
+
+- You can set it manually [on index creation](/references/indexes.md#create-an-index)
+- You can set it manually [on document addition](/references/documents.md#add-or-replace-documents)
+- MeiliSearch can [automatically infer the primary key](/guides/main_concepts/documents.md#meilisearch-infers-your-primary-key) based on your first document.
 
 #### MeiliSearch infers your primary key
 
-If no primary key has been given either when the index was created or as a parameter of the add documents route, the primary key will be searched in the first document sent.
-
-MeiliSearch will search for an attribute that contains the string `id` in a case-insensitive manner (i.e, `uid`, `MovieId`, `ID`, `123id123`).
-If no corresponding attribute has been found, the index will have no known primary key, and therefore, no documents will be added.
+If the primary key has neither been set at index creation nor as a parameter of the add documents route, MeiliSearch will search your first document for an attribute that contains the string `id` in a case-insensitive manner (e.g., `uid`, `MovieId`, `ID`, `123id123`) and set it as that index's primary key.
+If no corresponding attribute is found, the index will have no known primary key, and therefore, **no documents will be added**.
 
 #### Missing primary key error
 
-❗️ If you get the `Could not infer a primary key` error, the primary key was not recognized. This means your primary key is wrongly formatted. Sending the [primary key's name as a query parameter](/references/documents.md#add-or-replace-documents) or [updating your index to add the primary key's name](/references/indexes.md#create-an-index) as explained in [setting the primary key](/guides/main_concepts/documents.md#primary-key) should solve this issue.
+❗️ If you get the `Could not infer a primary key` error, the primary key was not recognized. This means **your primary key is wrongly formatted or absent**.
+Manually adding the primary key can be accomplished by using its name as a parameter for [the add document route](/references/documents.md#add-or-replace-documents) or [the update index route](/references/indexes.md#create-an-index).
 
 ### Document Id
 
-The document id is the **value** associated to the <clientGlossary word="primary key"/>.
+The <clientGlossary word="document id" /> is the <clientGlossary word="value" /> associated to the <clientGlossary word="primary key"/>. It is part of the <clientGlossary word="primary field" />, and acts as a unique identifier for each of the documents of a given index.
+
+This unique value ensures that two documents in the same index cannot be exactly alike. If two documents in the same index have the same id, then they are treated as the same document and the more recent one will replace the older.
 
 The document id must contain only `A-Z a-z 0-9` and `-_` characters.
 
-#### Examples
+#### Example:
 
 Good:
 
@@ -116,4 +149,28 @@ Bad:
 "id": "@BI+* ^5h2%"
 ```
 
-The document addition request in MeiliSearch is <!-- prettier-ignore -->[atomic](https://en.wikipedia.org/wiki/Atomicity_(database_systems)). Thus, for example, if you submit 200 documents in one go and it happens one of them contains a wrongly formatted document id, an error will occur and result in no additions.
+Take note that the document addition request in MeiliSearch is <!-- prettier-ignore -->[atomic](https://en.wikipedia.org/wiki/Atomicity_(database_systems)). This means that **if even a single document id is incorrectly formatted, an error will occur and none of your documents will be added**.
+
+## Upload
+
+By default, MeiliSearch limits the size of `JSON` payloads—and therefore document uploads—to 10MB.
+
+To upload more documents in one go, it is possible to [change the payload size limit](/guides/advanced_guides/configuration.md#payload-limit-size) during the setup of your MeiliSearch instance using the `http-payload-size-limit` option.
+
+```bash
+$ ./meilisearch --http-payload-size-limit=100000000
+```
+
+> The payload limit is now +-100MB instead of 10MB
+
+**MeiliSearch uses a lot of RAM when indexing documents**. Be aware of your RAM availability as you increase the size of your batch as this could result in a MeiliSearch crash.
+
+When using the [route to add new documents](/references/documents.md#add-or-update-documents), all documents must be sent in an array **even if there is only one document**.
+
+<code-samples id="documents_guide_add_movie_1" />
+
+[primary-field]: /guides/main_concepts/documents.md#primary-field
+[primary-key]: /guides/main_concepts/documents.md#primary-key
+[document-id]: /guides/main_concepts/documents.md#document-id
+[fields]: /guides/main_concepts/documents.md#fields
+[indexes]: /guides/main_concepts/indexes.md

--- a/references/dump.md
+++ b/references/dump.md
@@ -1,0 +1,54 @@
+# Dumps
+
+The `dumps` route allows the creation of database dumps. Dumps are `.tar.gz` files that can be used to launch MeiliSearch. Dumps are compatible between MeiliSearch versions.
+
+Creating a dump is also referred to as exporting it, whereas launching MeiliSearch with a dump is referred to as importing it. 
+
+During a [dump export](/references/dump.md#create-a-dump), all indexes of the current instance are exported—together with their documents and settings—and saved as a single `.tar.gz` file.
+
+During a dump import, all indexes contained in the indicated `.tar.gz` file are imported along with their associated documents and settings. Any existing index with the same uid as an index in the dump file will be overwritten.
+
+Dump imports are [performed at launch](/guides/advanced_guides/configuration.md#import-dump) using an option. [Batch size](/guides/advanced_guides/configuration.md#dump-batch-size) can also be set at this time.
+
+## Create a Dump
+
+<RouteHighlighter method="POST" route="/dumps"/>
+
+Triggers a dump creation process. Once the process is complete, a dump is created in the [dumps folder](/guides/advanced_guides/configuration.md#dumps-folder). If the dumps folder does not exist yet, it will be created.
+
+### Example
+
+<code-samples id="post_dump_1" />
+
+#### Response: `202 Accepted`
+
+```json
+{
+  "uid": "20200929-114144097",
+  "status": "processing"
+}
+```
+
+## Get dump status
+
+<RouteHighlighter method="GET" route="/dumps/:dump_uid/status"/>
+
+Get the status of a dump creation process using the uid returned after calling the [dump creation route](/references/dump.md#create-a-dump).
+The returned status could be:
+
+- `processing`: Dump creation is in progress.
+- `dump_process_failed`: An error occured during dump process, and the task was aborted.
+- `done`: Dump creation is finished and was successful.
+
+### Example
+
+<code-samples id="get_dump_status_1" />
+
+#### Response: `200 Ok`
+
+```json
+{
+  "uid": "20200929-114144097",
+  "status": "done"
+}
+```

--- a/references/dump.md
+++ b/references/dump.md
@@ -2,7 +2,7 @@
 
 The `dumps` route allows the creation of database dumps. Dumps are `.tar.gz` files that can be used to launch MeiliSearch. Dumps are compatible between MeiliSearch versions.
 
-Creating a dump is also referred to as exporting it, whereas launching MeiliSearch with a dump is referred to as importing it. 
+Creating a dump is also referred to as exporting it, whereas launching MeiliSearch with a dump is referred to as importing it.
 
 During a [dump export](/references/dump.md#create-a-dump), all indexes of the current instance are exported—together with their documents and settings—and saved as a single `.tar.gz` file.
 

--- a/references/search.md
+++ b/references/search.md
@@ -23,6 +23,7 @@ This is the preferred route to perform search when an API key is required, as it
 
 #### Body
 
+<<<<<<< HEAD
 | Variable                  | Type                 | Description                                                                                       | Default value                                                                                   |
 | ------------------------- | -------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | **q**                     | `String`               | Query string \_(mandatory)                                                                      | `""`                                                                                          |
@@ -36,6 +37,21 @@ This is the preferred route to perform search when an API key is required, as it
 | **cropLength**            | `Integer`              | Length used to crop field values                                                                | `200`                                                                                           |
 | **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `null`                                                                                          |
 | **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `false`                                                                                         |
+=======
+| Variable                  | Type                 | Description                                                                                     | Default value                                                                                     |
+| ------------------------- | -------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| **q**                     | `String`               | Query string                                                                      | `{}`                                                                                              |
+| **offset**                | `Integer`              | Number of documents to skip                                                                     | `[]`                                                                                              |
+| **limit**                 | `Integer`              | Maximum number of documents returned                                                            | [A list of ordered built-in ranking rules](/guides/main_concepts/relevancy.md#order-of-the-rules) |
+| **filters**               | `String`               | Filter queries by an attribute value                                                            | `[]`                                                                                              |
+| **facetFilters**          | `[Strings | [Strings]]` | Facet names and values to filter on                                                             | `null`                                                                                            |
+| **facetsDistribution**    | `[Strings]`            | Facets for which to retrieve the matching count                                                 | All attributes found in the documents                                                             |
+| **attributesToRetrieve**  | `[Strings]`            | Attributes to display in the returned documents                                                 | All attributes found in the documents                                                             |
+| **attributesToCrop**     | `[Strings]`            | Attributes whose values have to be cropped                                                      | `true`                                                                                            |
+| **cropLength**            | `Integer`              | Length used to crop field values                                                                | `true`                                                                                            |
+| **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `true`                                                                                            |
+| **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `true`                                                                                            |
+>>>>>>> fda35c79... Prepare documentation for MeiliSearch 10/2020 release
 
 > `filters` accept a query string. You can find more about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering.md).
 > `cropLength` is automatically rounded to match word boundaries.

--- a/references/search.md
+++ b/references/search.md
@@ -23,7 +23,6 @@ This is the preferred route to perform search when an API key is required, as it
 
 #### Body
 
-<<<<<<< HEAD
 | Variable                  | Type                 | Description                                                                                       | Default value                                                                                   |
 | ------------------------- | -------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | **q**                     | `String`               | Query string \_(mandatory)                                                                      | `""`                                                                                          |
@@ -37,22 +36,6 @@ This is the preferred route to perform search when an API key is required, as it
 | **cropLength**            | `Integer`              | Length used to crop field values                                                                | `200`                                                                                           |
 | **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `null`                                                                                          |
 | **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `false`                                                                                         |
-=======
-| Variable                  | Type                 | Description                                                                                     | Default value                                                                                     |
-| ------------------------- | -------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **q**                     | `String`               | Query string                                                                      | `{}`                                                                                              |
-| **offset**                | `Integer`              | Number of documents to skip                                                                     | `[]`                                                                                              |
-| **limit**                 | `Integer`              | Maximum number of documents returned                                                            | [A list of ordered built-in ranking rules](/guides/main_concepts/relevancy.md#order-of-the-rules) |
-| **filters**               | `String`               | Filter queries by an attribute value                                                            | `[]`                                                                                              |
-| **facetFilters**          | `[Strings | [Strings]]` | Facet names and values to filter on                                                             | `null`                                                                                            |
-| **facetsDistribution**    | `[Strings]`            | Facets for which to retrieve the matching count                                                 | All attributes found in the documents                                                             |
-| **attributesToRetrieve**  | `[Strings]`            | Attributes to display in the returned documents                                                 | All attributes found in the documents                                                             |
-| **attributesToCrop**     | `[Strings]`            | Attributes whose values have to be cropped                                                      | `true`                                                                                            |
-| **cropLength**            | `Integer`              | Length used to crop field values                                                                | `true`                                                                                            |
-| **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `true`                                                                                            |
-| **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `true`                                                                                            |
->>>>>>> fda35c79... Prepare documentation for MeiliSearch 10/2020 release
-
 > `filters` accept a query string. You can find more about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering.md).
 > `cropLength` is automatically rounded to match word boundaries.
 

--- a/references/search.md
+++ b/references/search.md
@@ -23,19 +23,19 @@ This is the preferred route to perform search when an API key is required, as it
 
 #### Body
 
-| Variable                  | Type                 | Description                                                                                     | Default value                                                                                     |
-| ------------------------- | -------------------- | ----------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
-| **q**                     | `String`               | Query string \_(mandatory)                                                                      | `{}`                                                                                              |
-| **offset**                | `Integer`              | Number of documents to skip                                                                     | `[]`                                                                                              |
-| **limit**                 | `Integer`              | Maximum number of documents returned                                                            | [A list of ordered built-in ranking rules](/guides/main_concepts/relevancy.md#order-of-the-rules) |
-| **filters**               | `String`               | Filter queries by an attribute value                                                            | `[]`                                                                                              |
-| **facetFilters**          | `[Strings | [Strings]]` | Facet names and values to filter on                                                             | `null`                                                                                            |
-| **facetsDistribution**    | `[Strings]`            | Facets for which to retrieve the matching count                                                 | All attributes found in the documents                                                             |
-| **attributesToRetrieve**  | `[Strings]`            | Attributes to display in the returned documents                                                 | All attributes found in the documents                                                             |
-| **attributesToCrop**     | `[Strings]`            | Attributes whose values have to be cropped                                                      | `true`                                                                                            |
-| **cropLength**            | `Integer`              | Length used to crop field values                                                                | `true`                                                                                            |
-| **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `true`                                                                                            |
-| **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `true`                                                                                            |
+| Variable                  | Type                 | Description                                                                                       | Default value                                                                                   |
+| ------------------------- | -------------------- | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| **q**                     | `String`               | Query string \_(mandatory)                                                                      | `""`                                                                                          |
+| **offset**                | `Integer`              | Number of documents to skip                                                                     | `0`                                                                                             |
+| **limit**                 | `Integer`              | Maximum number of documents returned                                                            | `20`                                                                                            |
+| **filters**               | `String`               | Filter queries by an attribute value                                                            | `null`                                                                                          |
+| **facetFilters**          | `[Strings OR [Strings]]` | Facet names and values to filter on                                                            | `null`                                                                                          |
+| **facetsDistribution**    | `[Strings]`            | Facets for which to retrieve the matching count                                                 | `null`                                                                                          |
+| **attributesToRetrieve**  | `[Strings]`            | Attributes to display in the returned documents                                                 | `["*"]`                                                                                           |
+| **attributesToCrop**     | `[Strings]`            | Attributes whose values have to be cropped                                                       | `null`                                                                                          |
+| **cropLength**            | `Integer`              | Length used to crop field values                                                                | `200`                                                                                           |
+| **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `null`                                                                                          |
+| **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `false`                                                                                         |
 
 > `filters` accept a query string. You can find more about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering.md).
 > `cropLength` is automatically rounded to match word boundaries.
@@ -115,17 +115,17 @@ This route should only be used when no API key is required. If an API key is req
 
 | Query Parameter                                                                                   | Description                                                                                     | Default Value |
 | ------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- | :-----------: |
-| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string                                                                                   |               |
-| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                                                                     |      `0`      |
+| **[q](/guides/advanced_guides/search_parameters.md#query-q)**                                     | Query string                                                                                    |    `""`     |
+| **[offset](/guides/advanced_guides/search_parameters.md#offset)**                                 | Number of documents to skip                                                                     |     `0`       |
 | **[limit](/guides/advanced_guides/search_parameters.md#limit)**                                   | Maximum number of documents returned                                                            |     `20`      |
-| **[facetFilters](/guides/advanced_guides/search_parameters.md#facet-filters)** | Facet names and values to filter on                                  |    `null`     |
-| **[facetsDistribution](/guides/advanced_guides/search_parameters.md#the-facets-distribution)** | Facets for which to retrieve the matching count                                 |    `null`     |
-| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                                                 |      `*`      |
-| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                                                      |    `none`     |
-| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Length used to crop field values                                                                |     `200`     |
-| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms                                 |    `none`     |
-| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                                                            |    `none`     |
-| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Defines whether an object that contains information about the matches should be returned or not |    `false`    |
+| **[filters](/guides/advanced_guides/search_parameters.md#filters)**                               | Filter queries by an attribute value                                                            |    `null`     |
+| **[facetFilters](/guides/advanced_guides/search_parameters.md#facet-filters)** | Facet names and values to filter on                                                                                |    `null`     |
+| **[facetsDistribution](/guides/advanced_guides/search_parameters.md#the-facets-distribution)** | Facets for which to retrieve the matching count                                                    |    `null`     |
+| **[attributesToRetrieve](/guides/advanced_guides/search_parameters.md#attributes-to-retrieve)**   | Attributes to display in the returned documents                                                 |    `["*"]`      |
+| **[attributesToCrop](/guides/advanced_guides/search_parameters.md#attributes-to-crop)**           | Attributes whose values have to be cropped                                                      |    `null`     |
+| **[cropLength](/guides/advanced_guides/search_parameters.md#crop-length)**                        | Length used to crop field values                                                                |    `200`      |
+| **[attributesToHighlight](/guides/advanced_guides/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms                                 |    `null`     |
+| **[matches](/guides/advanced_guides/search_parameters.md#matches)**                               | Defines whether an object that contains information about the matches should be returned or not |   `false`     |
 
 > `filters` accept a query string. You can find about the filter syntax on [our dedicated page](/guides/advanced_guides/filtering.md).
 > `cropLength` is automatically rounded to match word boundaries.

--- a/references/searchable_attributes.md
+++ b/references/searchable_attributes.md
@@ -3,7 +3,7 @@
 _Child route of the [settings route](/references/settings.md)._
 
 The values of the fields whose attributes are added to the searchable-attributes list are **searched for matching query words**.
-By default, all fields are considered to be `searchableAttributes`. This behavior is represented by the `[*]` in the settings. Setting `searchableAttributes` to an empty array `[]` will reset the setting to its default value.
+By default, all fields are considered to be `searchableAttributes`. This behavior is represented by the `["*"]` in the settings. Setting `searchableAttributes` to an empty array `[]` will reset the setting to its default value.
 
 Searchable attributes can also be updated directly through the [global settings route](/references/settings.md#update-settings) along with the other settings.
 


### PR DESCRIPTION
What is new in the 10/2020 release and where is doc needed: 
- [x] Backup Meilisearch DataBase triggering an HTTP route meilisearch/meilisearch#840 & backup meilisearch/meilisearch#887 
   - All routes in [API references](https://docs.meilisearch.com/references/)
   - All CLI options in [configuration](https://docs.meilisearch.com/guides/advanced_guides/configuration.html)
   - [2 new error codes](https://github.com/meilisearch/MeiliSearch/pull/887#discussion_r493656064) must be added to the [error yaml](https://github.com/meilisearch/documentation/blob/master/errors.yaml)
- [x] Considere an empty query search as a placeholder search meilisearch/meilisearch#916
  - Change information in [Api references](https://docs.meilisearch.com/references/search.html#search-in-an-index-with-post-route)
  - Change information in [Search parameters](https://docs.meilisearch.com/guides/advanced_guides/search_parameters.html)

