### PR TITLE
Fix endpoint of delete-batch example

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -52,7 +52,7 @@ delete_one_document_1: |-
     -X DELETE 'http://localhost:7700/indexes/movies/documents/25684'
 delete_documents_1: |-
   curl \
-    -X POST 'http://localhost:7700/indexes/movies/delete-batch' \
+    -X POST 'http://localhost:7700/indexes/movies/documents/delete-batch' \
     --data '[
         23488,
         153738,


### PR DESCRIPTION
The documentation shows the invalid path (404)`http://localhost:7700/indexes/movies/delete-batch` as example endpoint for the `delete-batch` operation. 

The correct endpoint should be `http://localhost:7700/indexes/movies/documents/delete-batch`