### PR TITLE
Update "genre" field into "genres"

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -42,7 +42,7 @@ add_or_update_documents_1: |-
     --data '[{
         "id": 287947,
         "title": "Shazam ⚡️",
-        "genre": "comedy"
+        "genres": "comedy"
     }]'
 delete_all_documents_1: |-
   curl \
@@ -180,7 +180,7 @@ update_attributes_for_faceting_1: |-
   $ curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting' \
     --data '[
-        "genre",
+        "genres",
         "director"
     ]'
 reset_attributes_for_faceting_1: |-

--- a/guides/advanced_guides/faceted_search.md
+++ b/guides/advanced_guides/faceted_search.md
@@ -90,32 +90,32 @@ The following are correct:
 good ✅
 
 ```javascript
-"genre:horror"
+"genres:horror"
 ```
 
 good ✅
 
 ```javascript
-["genre:horror", "genre:thriller"]
+["genres:horror", "genres:thriller"]
 ```
 
 good ✅
 
 ```javascript
-["genre:comedy", ["genre:horror", "genre:thiller"]]
+["genres:comedy", ["genres:horror", "genres:thiller"]]
 ```
 
 If the maximum array depth is exceeded, errors will be raised:
 error ❌
 
 ```javascript
-["genre:comedy", ["genre:horror", ["genre:romance"]]]
+["genres:comedy", ["genres:horror", ["genres:romance"]]]
 ```
 
 error ❌
 
 ```javascript
-[[["genre:romance"]]]
+[[["genres:romance"]]]
 ```
 
 Facet filters can have a **maximum array deepness of two**.
@@ -125,32 +125,32 @@ The following are correct:
 good ✅
 
 ```javascript
-"genre:horror"
+"genres:horror"
 ```
 
 good ✅
 
 ```javascript
-["genre:horror", "genre:thriller"]
+["genres:horror", "genres:thriller"]
 ```
 
 good ✅
 
 ```javascript
-["genre:comedy", ["genre:horror", "genre:thiller"]]
+["genres:comedy", ["genres:horror", "genres:thiller"]]
 ```
 
 When you add one more array deepness, it will raise errors:
 error ❌
 
 ```javascript
-["genre:comedy", ["genre:horror", ["genre:romance"]]]
+["genres:comedy", ["genres:horror", ["genres:romance"]]]
 ```
 
 error ❌
 
 ```javascript
-[[["genre:romance"]]]
+[[["genres:romance"]]]
 ```
 
 #### Logical Connectives

--- a/guides/advanced_guides/search_parameters.md
+++ b/guides/advanced_guides/search_parameters.md
@@ -104,9 +104,9 @@ or a mix of both `facetFilters=["facetName1:facetValue1", ["facetName2:facetValu
 - `["facetName1:facetValue1", ["facetName2:facetValue2"]]` (Array of array of strings or single strings, defaults to `null`)
 
   Both types of array contain the facet names and values to filter on.
-  A valid array must be an array that contains either a list of strings or arrays of strings and can mix both (e.g. `["director:Mati Diop", ["genre:Comedy", "genre:Romance"]]`).
+  A valid array must be an array that contains either a list of strings or arrays of strings and can mix both (e.g. `["director:Mati Diop", ["genres:Comedy", "genres:Romance"]]`).
 
-  - `facetName`: The name (the attribute) of a field used as a facet (e.g. `director`, `genre`).
+  - `facetName`: The name (the attribute) of a field used as a facet (e.g. `director`, `genres`).
   - `facetValue`: The value of this facet to filter results on (e.g. `Tim Burton`, `Mati Diop`, `Comedy`, `Romance`).
 
 Facet filters also support logical connectives by using [inner and outer array elements](/guides/advanced_guides/faceted_search.md#using-facets).
@@ -115,10 +115,10 @@ Facet filters also support logical connectives by using [inner and outer array e
 
 #### Example
 
-Suppose you have declared `director` and `genre` as [faceted attributes](/guides/advanced_guides/settings.md#attributes-for-faceting), and you want to get movies matching "thriller" classified as either horror **or** mystery **and** directed by Jordan Peele.
+Suppose you have declared `director` and `genres` as [faceted attributes](/guides/advanced_guides/settings.md#attributes-for-faceting), and you want to get movies matching "thriller" classified as either horror **or** mystery **and** directed by Jordan Peele.
 
 ```SQL
-("genre:Horror" OR "genre:Mystery") AND "director:Jordan Peele"
+("genres:Horror" OR "genres:Mystery") AND "director:Jordan Peele"
 ```
 
 Querying on "thriller", the above example results in the following CURL command:

--- a/guides/advanced_guides/settings.md
+++ b/guides/advanced_guides/settings.md
@@ -73,7 +73,7 @@ Faceted <clientGlossary word="attribute" label="attributes"/> are the attributes
 
 #### Example
 
-To be able to facet search on `director` and `genre` in a movie database, you would declare faceted attributes as follows:
+To be able to facet search on `director` and `genres` in a movie database, you would declare faceted attributes as follows:
 
 <code-samples id="faceted_search_update_settings_1" />
 

--- a/references/attributes_for_faceting.md
+++ b/references/attributes_for_faceting.md
@@ -29,7 +29,7 @@ Get the [attributes for faceting](/guides/advanced_guides/faceted_search.md) of 
 List the settings.
 
 ```json
-["genre", "director"]
+["genres", "director"]
 ```
 
 ## Update Attributes for Faceting

--- a/references/documents.md
+++ b/references/documents.md
@@ -180,7 +180,7 @@ The body is composed of a **JSON array** of documents.
 
 <code-samples id="add_or_update_documents_1" />
 This document is an update of the document found in [add or replace document](/references/documents.md#add-or-replace-documents).
-The documents are matched because they have the same `primaryKey` value `id: 287947`. This route will update the `title` field as it changed from `Shazam` to `Shazam ⚡️` and add the new `genre` field to that document. The rest of the document will remain unchanged.
+The documents are matched because they have the same `primaryKey` value `id: 287947`. This route will update the `title` field as it changed from `Shazam` to `Shazam ⚡️` and add the new `genres` field to that document. The rest of the document will remain unchanged.
 
 #### Response: `202 Accepted`
 

--- a/references/settings.md
+++ b/references/settings.md
@@ -67,7 +67,7 @@ List the settings.
     "exactness",
     "desc(release_date)"
   ],
-  "attributesForFaceting": ["genre"],
+  "attributesForFaceting": ["genres"],
   "distinctAttribute": null,
   "searchableAttributes": ["title", "description", "uid"],
   "displayedAttributes": [


### PR DESCRIPTION
## Field update

Every occurrence of the "genre" field inside the documentation has been replaced with `genres` (expect for some precise case where `genre` was specifically chosen). 

### Code-samples update

Code-samples had some example containing `"genre"` instead of `"genres"` this has been changed as well and should be changed in every code-sample out there. 