### PR TITLE
Env needs to be lowercase

### DIFF
--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -116,8 +116,8 @@ Analytics allow us to know how many users are using MeiliSearch and the followin
 
 By default, MeiliSearch runs in `development` mode.
 
-- `Production`: the [master key](/guides/advanced_guides/authentication.md) is **mandatory**.
-- `Development`: the [master key](/guides/advanced_guides/authentication.md) is **optional**, and logs are output in "info" mode (_console output_).
+- `production`: the [master key](/guides/advanced_guides/authentication.md) is **mandatory**.
+- `development`: the [master key](/guides/advanced_guides/authentication.md) is **optional**, and logs are output in "info" mode (_console output_).
 
 If the server is running in development mode more logs will be displayed, and the master key can be avoided which implies that there is no security on the updates routes.
 This is useful to debug when integrating the engine with another service.


### PR DESCRIPTION
I typed the wrong value `Production` from this place in the documentation and got the following error message:

```
error: 'Production' isn't a valid value for '--env <env>'

[possible values: development, production]

Did you mean 'production'?

USAGE:

meilisearch --db-path <db-path> --dump-batch-size <dump-batch-size> --dumps-dir <dumps-dir> --env <env> --http-addr <http-addr> --http-payload-size-limit <http-payload-size-limit> --master-key <master-key> --max-mdb-size <max-mdb-size> --max-udb-size <max-udb-size> --no-analytics <no-analytics> --sentry-dsn <sentry-dsn> --snapshot-dir <snapshot-dir>


For more information try --help
```