### PR TITLE
Rename meilisearch-digital-ocean into meilisearch-digitalocean

### DIFF
--- a/resources/sdks.md
+++ b/resources/sdks.md
@@ -28,7 +28,7 @@ You can use MeiliSearch API wrappers in your favorite language. These libraries 
 
 ## DevOps Tools
 
-- [meilisearch-digital-ocean](https://github.com/meilisearch/meilisearch-digital-ocean): how to deploy a MeiliSearch instance on DigitalOcean. See this [dedicated page](/resources/howtos/digitalocean_droplet.md) to use it.
+- [meilisearch-digitalocean](https://github.com/meilisearch/meilisearch-digitalocean): how to deploy a MeiliSearch instance on DigitalOcean. See this [dedicated page](/resources/howtos/digitalocean_droplet.md) to use it.
 - [meilisearch-kubernetes](https://github.com/meilisearch/meilisearch-kubernetes): how to deploy a MeiliSearch instance on Kubernetes.
 
 ## Other Tools


### PR DESCRIPTION
According to the @fharper request that I approved 👍 

(I know, renaming the URL is not mandatory but is consistent 😇)