### PR TITLE
Updating the default max payload size from 10mb to 100mb

### DIFF
--- a/guides/advanced_guides/configuration.md
+++ b/guides/advanced_guides/configuration.md
@@ -133,7 +133,7 @@ In production mode, the [web interface](/guides/advanced_guides/web_interface.md
 
 The maximum size, in bytes, of accepted JSON payloads.
 
-**Default value**: `10485760` (+=10MB)
+**Default value**: `104857600` (+=100MB)
 
 ### SSL Authentication Path
 

--- a/guides/advanced_guides/known_limitations.md
+++ b/guides/advanced_guides/known_limitations.md
@@ -27,4 +27,4 @@ This limit is enforced for relevancy reasons. The more words there are in a give
 
 ### Payload size
 
-The default limit for the payload size is around __10MB__. [This limit can be modified](/guides/advanced_guides/configuration.md#payload-limit-size).
+The default limit for the payload size is around __100MB__. [This limit can be modified](/guides/advanced_guides/configuration.md#payload-limit-size).

--- a/guides/main_concepts/documents.md
+++ b/guides/main_concepts/documents.md
@@ -153,7 +153,7 @@ Take note that the document addition request in MeiliSearch is <!-- prettier-ign
 
 ## Upload
 
-By default, MeiliSearch limits the size of `JSON` payloads—and therefore document uploads—to 10MB.
+By default, MeiliSearch limits the size of `JSON` payloads—and therefore document uploads—to 100MB.
 
 To upload more documents in one go, it is possible to [change the payload size limit](/guides/advanced_guides/configuration.md#payload-limit-size) during the setup of your MeiliSearch instance using the `http-payload-size-limit` option.
 


### PR DESCRIPTION
References [Issue 1137](https://github.com/meilisearch/MeiliSearch/issues/1137) and [PR 1147](https://github.com/meilisearch/MeiliSearch/pull/1147)

Increasing the default payload size from 10mb to 100mb.