### PR TITLE
Update DigitalOcean how-to after v0.17

### DIFF
--- a/resources/howtos/digitalocean_droplet.md
+++ b/resources/howtos/digitalocean_droplet.md
@@ -105,6 +105,20 @@ A script will run automatically, asking for your settings and desired configurat
 
 ### 3. Enjoy your ready-to-use MeiliSearch droplet
 
-![Enjoy](/digitalocean/13.finish.png)
+Your MeiliSearch droplet is ready to be used in production.
+
+To check if everything is running smoothly, do an HTTP call to the health route:
+
+```bash
+curl -v https://<your-meilisearch-url>/health
+```
+
+The server should answer with a `204 No content` ststus code as shown in teh example below:
+
+```bash
+...
+< HTTP/1.1 204 No Content
+...
+```
 
 **Enjoy**!

--- a/resources/howtos/digitalocean_droplet.md
+++ b/resources/howtos/digitalocean_droplet.md
@@ -103,9 +103,9 @@ A script will run automatically, asking for your settings and desired configurat
 
 `sh /var/opt/meilisearch/scripts/first-login/000-set-meili-env.sh`
 
-### 3. Enjoy your ready-to-use MeiliSearch droplet
+### 3. Enjoy your ready-to-use MeiliSearch Droplet
 
-Your MeiliSearch droplet is ready to be used in production.
+Your MeiliSearch Droplet is ready to be used in production.
 
 To check if everything is running smoothly, do an HTTP call to the health route:
 

--- a/resources/howtos/digitalocean_droplet.md
+++ b/resources/howtos/digitalocean_droplet.md
@@ -110,10 +110,10 @@ Your MeiliSearch droplet is ready to be used in production.
 To check if everything is running smoothly, do an HTTP call to the health route:
 
 ```bash
-curl -v https://<your-meilisearch-url>/health
+$ curl -v https://<your-meilisearch-url>/health
 ```
 
-The server should answer with a `204 No content` ststus code as shown in teh example below:
+The server should answer with a `204 No content` status code as shown in the example below:
 
 ```bash
 ...


### PR DESCRIPTION
Since v0.17.0, MeiliSearch DigitalOcean droplet won't show the front-end interface if the environment is set to production. The screenshot in the `how-to` guide is replaced by an example on calling the `/health` route.