### PR TITLE
Clarify storage and memory requirements

### DIFF
--- a/resources/about_storage.md
+++ b/resources/about_storage.md
@@ -52,9 +52,11 @@ In this case, MeiliSearch will always ask for a memory map of 200Gb. This refers
 ## Measured disk usage
 
 We did some measurements on the default [movies.json](https://github.com/meilisearch/MeiliSearch/blob/master/datasets/movies/movies.json) dataset that you can find in the [getting started guide](/guides/introduction/quick_start_guide.md#add-documents).
-This dataset is a JSON file of 8.6 MB.
+This dataset is a JSON file of 8.6 MB and has 19,553 documents.
 When we index this file in MeiliSearch, the amount of disk space taken by LMDB is 122MB.
 
 | Raw JSON | MeiliSearch database size on disk | Real memory size | Private memory size     | Virtual memory size |
 | -------- | --------------------------------- | ---------------- | ----------------------- | ------------------- |
 | 8.6 MB   | 122 MB ( raw data **\* 14** )     | ≃ 6.3 MB         | 120 MB (≃ size on disk) | 204 Gb (memory map) |
+
+That means this dataset is using 6.3 MB of RAM and 122 MB of disk space.


### PR DESCRIPTION
The example on the [About Storate](https://docs.meilisearch.com/resources/about_storage.html#measured-disk-usage) page could be much clearer in my opinion about how much RAM and disk space MeiliSearch actually uses.

This PR uses the example and explicitly says how much RAM and disk space was used for that data set, just in case someone didn't understand the difference between virtual memory size, private memory size, real memory size, LMDB, etc.

**Before merging**, please double-check that I used the correct numbers for RAM and disk space. I think they're right, but I'm not 100% sure.

Fixes https://github.com/meilisearch/documentation/issues/694