### PR TITLE
Remove axios vulnerability

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -1745,10 +1745,10 @@ autocomplete.js@0.36.0:
   dependencies:
     immediate "^3.2.3"
 
-autocomplete.js@0.37.1:
-  version "0.37.1"
-  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.37.1.tgz#a29a048d827e7d2bf8f7df8b831766e5cc97df01"
-  integrity sha512-PgSe9fHYhZEsm/9jggbjtVsGXJkPLvd+9mC7gZJ662vVL5CRWEtm/mIrrzCx0MrNxHVwxD5d00UOn6NsmL2LUQ==
+autocomplete.js@0.38.0:
+  version "0.38.0"
+  resolved "https://registry.yarnpkg.com/autocomplete.js/-/autocomplete.js-0.38.0.tgz#9d49c2f4788fa23960275a6422ca78b310c01ef8"
+  integrity sha512-xZlqbg0LN9D1cZd4TkPJmir/Bq0+xXnp35X6i87yU2dD2wYv9E7pVU1+QKu0PbBVV2dShppwlKGMsfCYQD9OtA==
   dependencies:
     immediate "^3.2.3"
 
@@ -1774,13 +1774,6 @@ aws4@^1.8.0:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.10.1.tgz#e1e82e4f3e999e2cfd61b161280d16a111f86428"
   integrity sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA==
-
-axios@^0.19.2:
-  version "0.19.2"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.2.tgz#3ea36c5d8818d0d5f8a8a97a6d36b86cdc00cb27"
-  integrity sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==
-  dependencies:
-    follow-redirects "1.5.10"
 
 babel-eslint@^10.1.0:
   version "10.1.0"
@@ -2750,6 +2743,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-fetch@^3.0.5:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
+  integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
+  dependencies:
+    node-fetch "2.6.1"
+
 cross-spawn@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-3.0.1.tgz#1256037ecb9f0c5f79e3d6ef135e30770184b982"
@@ -3285,13 +3285,6 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@=3.1.0, debug@~3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
 debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
@@ -3305,6 +3298,13 @@ debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
   dependencies:
     ms "2.1.2"
+
+debug@~3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
+  dependencies:
+    ms "2.0.0"
 
 decamelize@^1.1.2, decamelize@^1.2.0:
   version "1.2.0"
@@ -3492,15 +3492,15 @@ dns-txt@^2.0.2:
     buffer-indexof "^1.0.0"
 
 docs-searchbar.js@^1.1:
-  version "1.1.7"
-  resolved "https://registry.yarnpkg.com/docs-searchbar.js/-/docs-searchbar.js-1.1.7.tgz#bc2066d2d03242b05d1584e2220946539d7f2d86"
-  integrity sha512-DqNhqEmpWdmFGLl6SUffBsnuf05VpZHhM6LVyT4P6WkTEWg5K8lHfta2RDfbduvOm0xxGQxCfEVpd1m9JN32gw==
+  version "1.1.10"
+  resolved "https://registry.yarnpkg.com/docs-searchbar.js/-/docs-searchbar.js-1.1.10.tgz#29326f6fc2437440ce466072d38eda4cc4b07947"
+  integrity sha512-FZWdc11b+9spwL4vN70Wz3oUPnUJLPorS7v6dTcEamdV6IRn2EHHJ/UNrD/cfr5AO6hDrR87zMH6zPKNbmzwSg==
   dependencies:
-    autocomplete.js "0.37.1"
+    autocomplete.js "0.38.0"
     concurrently "^5.1.0"
     eslint-plugin-eslint-comments "^3.2.0"
     hogan.js "^3.0.2"
-    meilisearch "^0.12.0"
+    meilisearch "^0.17.0"
     request "^2.87.0"
     stack-utils "^2.0.2"
     to-factory "^1.0.0"
@@ -4358,13 +4358,6 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.3"
     readable-stream "^2.3.6"
-
-follow-redirects@1.5.10:
-  version "1.5.10"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.10.tgz#7b7a9f9aea2fdff36786a94ff643ed07f4ff5e2a"
-  integrity sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==
-  dependencies:
-    debug "=3.1.0"
 
 follow-redirects@^1.0.0:
   version "1.13.0"
@@ -6082,12 +6075,12 @@ media-typer@0.3.0:
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
   integrity sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=
 
-meilisearch@^0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.12.0.tgz#051b728e2df07bdaf4321a98f6aa8dd7a89803e8"
-  integrity sha512-5bvw+zg8yh4ZXtXgz1VDAd0A/Ng1ZCagIiQyZKfyp7nyqOYafxIAU+wNigPcUdplyAunTXj2F6z/2GXeHge5VA==
+meilisearch@^0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/meilisearch/-/meilisearch-0.17.0.tgz#695914c929a57166a99e14549c22ab1216a62ed1"
+  integrity sha512-fKBNS1VtX8xl9WCK+3Uo60uLsJO6esoPXXOt6nq9lavWURmgRn7HC4em9S8N6P1kYCyb/BFMUOYZBm3rgq1zAw==
   dependencies:
-    axios "^0.19.2"
+    cross-fetch "^3.0.5"
 
 memory-fs@^0.4.1:
   version "0.4.1"
@@ -6413,6 +6406,11 @@ no-case@^2.2.0:
   integrity sha512-rmTZ9kz+f3rCvK2TD1Ue/oZlns7OGoIWP4fc3llxxRXlOkHKoWPPWJOfFYpITabSow43QJbRIoHQXtt10VldyQ==
   dependencies:
     lower-case "^1.1.1"
+
+node-fetch@2.6.1:
+  version "2.6.1"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
+  integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-forge@^0.10.0:
   version "0.10.0"
@@ -8503,9 +8501,9 @@ stack-utils@^1.0.1:
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
 stack-utils@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.2.tgz#5cf48b4557becb4638d0bc4f21d23f5d19586593"
-  integrity sha512-0H7QK2ECz3fyZMzQ8rH0j2ykpfbnd20BFtfg/SqVC2+sCTtcw0aDTGB7dk+de4U4uUeuz6nOtJcrkFFLG1B0Rg==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-2.0.3.tgz#cd5f030126ff116b78ccb3c027fe302713b61277"
+  integrity sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
   dependencies:
     escape-string-regexp "^2.0.0"
 


### PR DESCRIPTION
# Axios vulnerability

Oke! So this was a tricky one. 

## Problem analysiss

- `axios` is used by `meilisearch` < v0.14
- `docs-searchbar.js` uses `meilisearch`. 
    - Docs-searchbar >= v.1.1.8 [Upgraded to meilisearch](https://github.com/meilisearch/docs-searchbar.js/blob/v1.1.8/package.json) > v0.14
    - Before that version, because it uses meilisearch < v0.14, it had axios as a dependency of a dependency
- `vuepress-plugin-meilisearch` uses docs-searchbar.js. It uses the last version of docs-searchbar.js `v1.1.10`. Which uses meilisearch    `v0.17.0` which do NOT use `axios`.

So the 1 million question. Why with the latest version of `vuepress-plugin-meilisearch` do we still have `axios` as a dependency of dependencies?

## What is going on in yarn.lock
```
docs-searchbar.js@^1.1:
  version "1.1.7" // Why is it still 1.1.7 ?
  dependencies:
       meilisearch "^0.12.0" // Meilisearch that still uses axios

meilisearch@^0.12.0:
  version "0.12.0"
  dependencies:
    axios "^0.19.2"

vuepress-plugin-meilisearch@^0.10.6:
  version "0.10.6" // This version uses docs-searchbar@1.1.10 !
  dependencies:
    docs-searchbar.js "^1.1" // Here is the problem !
```

Because the version of docs-searchbar that changed from meilisearch v0.12 to v0.14 was a patch change `1.1.7` > `1.1.8`, and because we are giving as information `^1.1`, yarn.lock of documentation had no need to update the dependency.

## Solution

I removed and re-installed `vuepress-plugin-meilisearch` so that it would download the latests version of all dependency. 
This made the yarn.lock change to the following: 
```
docs-searchbar.js@^1.1:
  version "1.1.10"
  dependencies:
      meilisearch "^0.17.0" // Does not uses axios
```
