### PR TITLE
Remove reference to Crisp chatbox from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ $ yarn build
 Feel free to contact us about any questions you may have:
 
 - At [bonjour@meilisearch.com](mailto:bonjour@meilisearch.com): English or French is welcome! 🇬🇧 🇫🇷
-- Via the chat box available on every page of [our documentation](https://docs.meilisearch.com/) and on [our landing page](https://www.meilisearch.com/).
 - Join our [Slack community](https://slack.meilisearch.com/).
 - By opening an issue.
 


### PR DESCRIPTION
Crisp chatbox has been disabled on Documentation site (and also on homepage, I think). README should reflect that.