### PR TITLE
Make code samples copy+paste friendly

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1,33 +1,33 @@
 get_one_index_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies'
 list_all_indexes_1: |1-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes'
 create_an_index_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes' \
     --data '{
       "uid": "movies",
       "primaryKey": "movie_id"
     }'
 update_an_index_1: |-
-  $ curl \
+  curl \
     -X PUT 'http://localhost:7700/indexes/movie_review' \
     --data '{
         "primaryKey" : "movie_review_id"
     }'
 delete_an_index_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies'
 get_one_document_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/documents/25684'
 get_documents_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/documents?limit=2'
 add_or_replace_documents_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/documents' \
     --data '[{
         "id": 287947,
@@ -37,7 +37,7 @@ add_or_replace_documents_1: |-
         "release_date": "2019-03-23"
     }]'
 add_or_update_documents_1: |-
-  $ curl \
+  curl \
     -X PUT 'http://localhost:7700/indexes/movies/documents' \
     --data '[{
         "id": 287947,
@@ -60,24 +60,24 @@ delete_documents_1: |-
         363869
     ]'
 search_1: |-
-  $ curl \
+  curl \
     'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "american ninja" }'
 get_update_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/updates/1'
 get_all_updates_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/updates'
 get_keys_1: |-
-  $ curl \
+  curl \
     -H "X-Meili-API-Key: 123"
     -X GET 'http://localhost:7700/keys'
 get_settings_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings'
 update_settings_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "rankingRules": [
@@ -113,13 +113,13 @@ update_settings_1: |-
         }
     }'
 reset_settings_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings'
 get_synonyms_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/synonyms'
 update_synonyms_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/synonyms' \
     --data '{
       "wolverine": ["xmen", "logan"],
@@ -127,23 +127,23 @@ update_synonyms_1: |-
       "wow": ["world of warcraft"]
     }'
 reset_synonyms_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/synonyms'
 get_stop_words_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/stop-words'
 update_stop_words_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/stop-words' \
     --data '["the", "of", "to"]'
 reset_stop_words_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/stop-words'
 get_ranking_rules_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/ranking-rules'
 update_ranking_rules_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/ranking-rules' \
     --data '[
         "typo",
@@ -156,36 +156,36 @@ update_ranking_rules_1: |-
         "desc(rank)"
     ]'
 reset_ranking_rules_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/ranking-rules'
 get_distinct_attribute_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/distinct-attribute'
 update_distinct_attribute_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/distinct-attribute' \
     --data '"movie_id"'
 reset_distinct_attribute_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/distinct-attribute'
 get_attributes_for_faceting_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting'
 update_attributes_for_faceting_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting' \
     --data '[
         "genres",
         "director"
     ]'
 reset_attributes_for_faceting_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/attributes-for-faceting'
 get_searchable_attributes_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/searchable-attributes'
 update_searchable_attributes_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/searchable-attributes' \
     --data '[
         "title",
@@ -193,13 +193,13 @@ update_searchable_attributes_1: |-
         "genre"
     ]'
 reset_searchable_attributes_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/searchable-attributes'
 get_displayed_attributes_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/settings/displayed-attributes'
 update_displayed_attributes_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/displayed-attributes' \
     --data '[
         "title",
@@ -208,27 +208,27 @@ update_displayed_attributes_1: |-
         "release_date"
     ]'
 reset_displayed_attributes_1: |-
-  $ curl \
+  curl \
     -X DELETE 'http://localhost:7700/indexes/movies/settings/displayed-attributes'
 
 get_index_stats_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/indexes/movies/stats'
 get_indexes_stats_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/stats'
 get_health_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/health'
 get_version_1: |-
-  $ curl \
+  curl \
     -X GET 'http://localhost:7700/version'
 distinct_attribute_guide_1: |-
-  $ curl
+  curl
     -X POST 'http://localhost:7700/indexes/jackets/settings' \
     --data '{ "distinctAttribute": "product_id" }'
 field_properties_guide_searchable_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "searchableAttributes": [
@@ -238,7 +238,7 @@ field_properties_guide_searchable_1: |-
         ]
     }'
 field_properties_guide_displayed_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "displayedAttributes": [
@@ -249,46 +249,46 @@ field_properties_guide_displayed_1: |-
         ]
     }'
 filtering_guide_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "Avengers", "filters": "release_date > 795484800" }'
 filtering_guide_2: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q":"Batman",  "filters": "release_date > 795484800 AND (director = \"Tim Burton\" OR director = \"Christopher Nolan\")" }'
 filtering_guide_3: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "horror", "filters": "director = \"Jordan Peele\"" }'
 filtering_guide_4: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "Planet of the Apes", "filters": "rating >= 3 AND (NOT director = \"Tim Burton\")" }' \
 search_parameter_guide_query_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
     --data { "q": "shifu" }
 search_parameter_guide_offset_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "shifu", "offset": 1 }'
 search_parameter_guide_limit_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "shifu", "limit": 2 }'
 search_parameter_guide_retrieve_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "shifu", "attributesToRetrieve": ["overview", "title"] }'
 search_parameter_guide_crop_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "shifu", "attributesToCrop": ["overview"], "cropLength": 10 }'
 search_parameter_guide_highlight_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "shifu", "attributesToHighlight": ["overview"] }'
 search_parameter_guide_filter_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "n", "filters": "title = Nightshift" }'
 search_parameter_guide_filter_2: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "shifu", "filters": "title=\"Kung Fu Panda\"" }'
 search_parameter_guide_matches_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "shifu", "attributesToHighlight": ["overview"], "matches": true }'
 settings_guide_synonyms_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/tops/settings' \
     --data '{
         "synonyms": {
@@ -297,7 +297,7 @@ settings_guide_synonyms_1: |-
         }
     }'
 settings_guide_stop_words_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "stopWords": [
@@ -307,7 +307,7 @@ settings_guide_stop_words_1: |-
         ]
     }'
 settings_guide_ranking_rules_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "rankingRules": [
@@ -322,13 +322,13 @@ settings_guide_ranking_rules_1: |-
         ]
     }'
 settings_guide_distinct_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/jackets/settings' \
     --data '{
         "distinctAttribute": "product_id"
     }
 settings_guide_searchable_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "searchableAttributes": [
@@ -338,7 +338,7 @@ settings_guide_searchable_1: |-
         ]
     }'
 settings_guide_displayed_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "displayedAttributes": [
@@ -349,10 +349,10 @@ settings_guide_displayed_1: |-
         ]
     }'
 add_movies_json_1: |-
-  $ curl -X POST 'http://127.0.0.1:7700/indexes/movies/documents'\
+  curl -X POST 'http://127.0.0.1:7700/indexes/movies/documents'\
     --data @movies.json
 documents_guide_add_movie_1: |-
-  $ curl -X POST `http://localhost:7700/indexes/movies/documents` \
+  curl -X POST `http://localhost:7700/indexes/movies/documents` \
     --data '[
       {
         "movie_id": "123sq178",
@@ -360,24 +360,24 @@ documents_guide_add_movie_1: |-
       }
     ]'
 search_guide_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "shifu", "limit": 5, "offset": 10 }'
 search_guide_2: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "Avengers", "filters": "release_date > 795484800" }'
 getting_started_add_documents_md: |-
   ```bash
-  $ curl \
+  curl \
     -X POST 'http://127.0.0.1:7700/indexes/movies/documents' \
     --data @movies.json
   ```
 getting_started_search_md: |-
   ```bash
-  $ curl 'http://127.0.0.1:7700/indexes/movies/search' \
+  curl 'http://127.0.0.1:7700/indexes/movies/search' \
   --data '{ "q": "botman" }'
   ```
 faceted_search_update_settings_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "attributesForFaceting": [
@@ -386,13 +386,13 @@ faceted_search_update_settings_1: |-
         ]
     }'
 faceted_search_facet_filters_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "thriller", "facetFilters": [["genres:Horror", "genres:Mystery"], "director:Jordan Peele"] }'
 faceted_search_facets_distribution_1: |-
-  $ curl --get 'http://localhost:7700/indexes/movies/search' \
+  curl --get 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "Batman", "facetsDistribution": ["genres"] }'
 faceted_search_walkthrough_attributes_for_faceting_1: |-
-  $ curl \
+  curl \
     -X POST 'http://localhost:7700/indexes/movies/settings' \
     --data '{
         "attributesForFaceting": [
@@ -403,12 +403,12 @@ faceted_search_walkthrough_attributes_for_faceting_1: |-
         ]
     }'
 faceted_search_walkthrough_facet_filters_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{ "q": "thriller", "facetFilters": [["genres:Horror", "genres:Mystery"], "director:Jordan Peele"] }'
 faceted_search_walkthrough_facets_distribution_1: |-
-  $ curl 'http://localhost:7700/indexes/movies/search' \
+  curl 'http://localhost:7700/indexes/movies/search' \
   --data '{  "q": "Batman", "facetsDistribution": ["genres"] }'
 post_dump_1: |-
-  $ curl -X POST 'http://localhost:7700/dumps'
+  curl -X POST 'http://localhost:7700/dumps'
 get_dump_status_1: |-
-  $ curl -X GET 'http://localhost:7700/dumps/20201101-110357260/status'
+  curl -X GET 'http://localhost:7700/dumps/20201101-110357260/status'

--- a/create/faq.md
+++ b/create/faq.md
@@ -111,7 +111,7 @@ Good:
 The [jq](https://github.com/stedolan/jq) command line tool can greatly help you check the format of your data.
 
 ```bash
-$ cat your_file.json | jq
+cat your_file.json | jq
 ```
 
 :::

--- a/create/how_to/digitalocean_droplet.md
+++ b/create/how_to/digitalocean_droplet.md
@@ -84,7 +84,7 @@ If you want to use your own domain name (or sub-domain), add `A record` in your 
 This should work out of the box. Your domain name should now be linked to your MeiliSearch instance. You can now do a health check to verify that your instance is running and your DNS is well configured:
 
 ```bash
-$ curl -v http://<your-domain-name>/health
+curl -v http://<your-domain-name>/health
 ```
 
 The server should answer with a `204 No content` status code as shown in the example below:
@@ -109,7 +109,7 @@ Open a terminal and start a new SSH connection with the IP you got from DigitalO
 Write in your terminal `ssh root@<your-ip-address>` and press Enter to establish connection:
 
 ```bash
-$ ssh meilisearch@42.42.42.42
+ssh meilisearch@42.42.42.42
 ```
 
 Write `yes` and press Enter to accept the authentication process.
@@ -117,7 +117,7 @@ Write `yes` and press Enter to accept the authentication process.
 A script will run automatically, asking for your settings and desired configuration. If you want to run this script again anytime, you can do so by using the following command:
 
 ```bash
-$ meilisearch-setup
+meilisearch-setup
 ```
 
 ### 3. Enjoy your ready-to-use MeiliSearch Droplet
@@ -127,7 +127,7 @@ Your MeiliSearch Droplet is ready to be used in **production**.
 To check if everything is running smoothly, do an HTTP call to the `/health` route:
 
 ```bash
-$ curl -v https://<your-domain-name>/health
+curl -v https://<your-domain-name>/health
 ```
 
 The server should answer with a `204 No content` status code as shown in the example below:

--- a/create/how_to/http2_ssl.md
+++ b/create/how_to/http2_ssl.md
@@ -18,19 +18,19 @@ Then, use `curl` to do requests. It is a simple way to specify that you want to 
 
 Start by running the binary.
 
-```
+```bash
 ./meilisearch
 ```
 
 And then, send a request.
 
-```
+```bash
 curl -kvs --http2 --request GET 'http://localhost:7700/indexes'
 ```
 
 You will get the following answer from the server:
 
-```
+```bash
 *   Trying ::1...
 * TCP_NODELAY set
 * Connection failed
@@ -62,25 +62,25 @@ The answer `< HTTP/1.1 200 OK` indicates that the server still uses HTTP/1.
 
 This time, start by generating the SSL certificates. mkcert creates two files: `127.0.0.1.pem` and `127.0.0.1-key.pem`.
 
-```
+```bash
 mkcert '127.0.0.1'
 ```
 
 Then, use the certificate and the key to configure MeiliSearch with SSL.
 
-```
+```bash
 ./meilisearch --ssl-cert-path ./127.0.0.1.pem --ssl-key-path ./127.0.0.1-key.pem
 ```
 
 Next, make the same request as above but change `http://` to `https://`.
 
-```
+```bash
 curl -kvs --http2 --request GET 'https://localhost:7700/indexes'
 ```
 
 You will get the following answer from the server:
 
-```
+```bash
 *   Trying ::1...
 * TCP_NODELAY set
 * Connection failed
@@ -132,13 +132,13 @@ You will get the following answer from the server:
 
 You can see that the server now supports HTTP/2.
 
-```
+```bash
 * Using HTTP2, server supports multi-use
 * Connection state changed (HTTP/2 confirmed)
 ```
 
 The server successfully receives HTTP/2 requests.
 
-```
+```bash
 < HTTP/2 200
 ```

--- a/create/how_to/meilisearch_react.md
+++ b/create/how_to/meilisearch_react.md
@@ -247,16 +247,20 @@ Install the MeiliSearch SDK:
 :::: tabs
 
 ::: tab npm
+
 ```bash
 # if you use npm
 npm install meilisearch
 ```
+
 :::
 ::: tab yarn
+
 ```bash
 # if you use yarn
 yarn add meilisearch
 ```
+
 :::
 ::::
 

--- a/create/how_to/meilisearch_react.md
+++ b/create/how_to/meilisearch_react.md
@@ -244,12 +244,21 @@ Connecting to MeiliSearch from React using the MeiliSearch Javascript SDK is a s
 
 Install the MeiliSearch SDK:
 
+:::: tabs
+
+::: tab npm
 ```bash
 # if you use npm
 npm install meilisearch
+```
+:::
+::: tab yarn
+```bash
 # if you use yarn
 yarn add meilisearch
 ```
+:::
+::::
 
 Set up the MeiliSearch Client with the server URL. In our case, it was the localhost Docker machine. Finally, load the right Index from the backend.
 

--- a/create/how_to/running_production.md
+++ b/create/how_to/running_production.md
@@ -67,11 +67,15 @@ MeiliSearch is finally installed and ready to use. To make it accessible from ev
 mv ./meilisearch /usr/bin/
 ```
 
-You can now start using MeiliSearch! In your terminal, run `meilisearch`. Expected output:
+You can now start using MeiliSearch! In your terminal, run the following command to launch meilisearch.
+
+```bash
+meilisearch
+```
+
+You should see the following successful response:
 
 ```
-$ meilisearch
-
 888b     d888          d8b 888 d8b  .d8888b.                                    888
 8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
 88888b.d88888              888     Y88b.                                        888
@@ -100,7 +104,7 @@ Service files are text files that tell your operating system how to run your pro
 To run MeiliSearch in a production environment, use the `--env` flag. To generate a master key that will let MeiliSearch create reading and writing keys, use the `--master-key` flag. With those keys, you can easily control who can access or create new documents, indexes, or change the configuration. You can change the `Master Key` to any value in the following command. However, for security concerns, it's better to choose a safe and random key, never share it and, just, **keep it safe**.
 
 ```bash
-cat << EOF >/etc/systemd/system/meilisearch.service
+cat << EOF > /etc/systemd/system/meilisearch.service
 [Unit]
 Description=MeiliSearch
 After=systemd-user-sessions.service

--- a/create/how_to/running_production.md
+++ b/create/how_to/running_production.md
@@ -46,11 +46,11 @@ Once you are logged in into your machine via SSH, ensure your system and its dep
 
 ```bash
 # Update the list of available packages and their versions
-$ apt update
+apt update
 # Install curl which is required to install MeiliSearch in the next step
-$ apt install curl -y
+apt install curl -y
 # Install MeiliSearch latest version from the script
-$ curl -L https://install.meilisearch.com | sh
+curl -L https://install.meilisearch.com | sh
 ```
 
 > The different options to achieve a MeiliSearch installation are detailed in **[this guide](/reference/features/installation.md#download-and-launch)**.
@@ -64,15 +64,14 @@ MeiliSearch is finally installed and ready to use. To make it accessible from ev
 
 ```bash
 # Move the MeiliSearch binary to your system binaries
-$ mv ./meilisearch /usr/bin/
+mv ./meilisearch /usr/bin/
 ```
 
-You can now start using MeiliSearch! In your terminal, run:
+You can now start using MeiliSearch! In your terminal, run `meilisearch`. Expected output:
 
-```bash
+```
 $ meilisearch
 
-# --- Expected output for v0.11.1 ---
 888b     d888          d8b 888 d8b  .d8888b.                                    888
 8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
 88888b.d88888              888     Y88b.                                        888
@@ -82,8 +81,8 @@ $ meilisearch
 888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
 888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888
 
-[2020-05-04T11:47:13Z INFO  meilisearch] Database path: "./data.ms"
-[2020-05-04T11:47:13Z INFO  meilisearch] Server listening on: "127.0.0.1:7700"
+Database path: "./data.ms"
+Server listening on: "127.0.0.1:7700"
 ```
 
 ## Step 2: Run MeiliSearch as a service
@@ -101,7 +100,7 @@ Service files are text files that tell your operating system how to run your pro
 To run MeiliSearch in a production environment, use the `--env` flag. To generate a master key that will let MeiliSearch create reading and writing keys, use the `--master-key` flag. With those keys, you can easily control who can access or create new documents, indexes, or change the configuration. You can change the `Master Key` to any value in the following command. However, for security concerns, it's better to choose a safe and random key, never share it and, just, **keep it safe**.
 
 ```bash
-$ cat << EOF >/etc/systemd/system/meilisearch.service
+cat << EOF >/etc/systemd/system/meilisearch.service
 [Unit]
 Description=MeiliSearch
 After=systemd-user-sessions.service
@@ -125,14 +124,16 @@ The service file you just built is all you need for creating your service. Now y
 
 ```bash
 # Set the service meilisearch
-$ systemctl enable meilisearch
+systemctl enable meilisearch
 
 # Start the meilisearch service
-$ systemctl start meilisearch
+systemctl start meilisearch
 
 # Verify that the service is actually running
-$ systemctl status meilisearch
+systemctl status meilisearch
+```
 
+```bash
 -# --- Expected output ---
 ● meilisearch.service - MeiliSearch
    Loaded: loaded (/etc/systemd/system/meilisearch.service; enabled; vendor preset: enabled)
@@ -158,17 +159,17 @@ Configuring Nginx as a proxy server is really simple. First of all, install it o
 
 ```bash
 # Install Nginx on Debian
-$ apt-get install nginx -y
+apt-get install nginx -y
 ```
 
 First, deleting the default configuration file is important as the default port for HTTP, the `port 80`, is used by Nginx by default. Thus, trying to use it for MeiliSearch will create a conflict. Replace the default file by your own configuration file. You can also make MeiliSearch listen to another port by specifying it in the Nginx configuration file, but we will not cover this option in this tutorial.
 
 ```bash
 # Delete the default configuration file for Nginx
-$ rm -f /etc/nginx/sites-enabled/default
+rm -f /etc/nginx/sites-enabled/default
 
 # Add your configuration file specifying the Reverse Proxy settings
-$ cat << EOF > /etc/nginx/sites-enabled/meilisearch
+cat << EOF > /etc/nginx/sites-enabled/meilisearch
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
@@ -184,11 +185,11 @@ Finally, enable and start the Nginx service again to make sure it is still avail
 
 ```bash
 # Reload the operating system daemons / services
-$ systemctl daemon-reload
+systemctl daemon-reload
 
 # Enable and start Nginx service
-$ systemctl enable nginx
-$ systemctl restart nginx
+systemctl enable nginx
+systemctl restart nginx
 ```
 
 MeiliSearch is now up, deployed in a production environment, using a safe API key, and being served by a Reverse Proxy Nginx. You should now be able to send requests to your server from the outside world. Open your web browser and visit: (<http://your-ip-address>). The IP address is the same you used to connect to your machine via SSH in Step 1.
@@ -215,7 +216,7 @@ Using certbot in your Linux server is very easy and straightforward. This tool w
 First of all, install the packages on your system:
 
 ```bash
-$ sudo apt-get install certbot python-certbot-nginx -y
+sudo apt-get install certbot python-certbot-nginx -y
 ```
 
 Let's run the Certbot script to be guided through the installation process:
@@ -252,13 +253,13 @@ First, let's copy your certificate files in their conventional directory so the 
 
 ```bash
 # Create a directory /etc/ssl/example to store the certificate files
-$ mkdir -p /etc/ssl/example
+mkdir -p /etc/ssl/example
 
 # Move your files to /etc/ssl/example. We will suppose that your
 # files are called example.pem and example.key
 
-$ mv path-to-your-files/example.pem /etc/ssl/example/
-$ mv path-to-your-files/example.key /etc/ssl/example/
+mv path-to-your-files/example.pem /etc/ssl/example/
+mv path-to-your-files/example.key /etc/ssl/example/
 ```
 
 Finally, we create a new Nginx configuration file, and restart the daemons and Nginx service
@@ -269,7 +270,7 @@ Finally, we create a new Nginx configuration file, and restart the daemons and N
 
 # Replace example.com in both `server_name` fields with your own domain name
 
-$ cat << EOF > /etc/nginx/sites-enabled/meilisearch
+cat << EOF > /etc/nginx/sites-enabled/meilisearch
 server {
       listen 80 default_server;
       listen [::]:80 default_server;
@@ -295,7 +296,7 @@ server {
 }
 EOF
 
-$ systemctl restart nginx
+systemctl restart nginx
 ```
 
 Your SSL certificates should be working and Nginx should be able to find them. Every request to `http://example.com` will now be redirected to `https://example.com`

--- a/create/how_to/search_bar_for_docs.md
+++ b/create/how_to/search_bar_for_docs.md
@@ -19,8 +19,8 @@ First of all, you need your documentation content to be scraped and pushed into 
 You can install and run MeiliSearch on your machine using `curl`.
 
 ```bash
-$ curl -L https://install.meilisearch.com | sh
-$ ./meilisearch --master-key=myMasterKey
+curl -L https://install.meilisearch.com | sh
+./meilisearch --master-key=myMasterKey
 ```
 
 There are [other ways to install MeiliSearch](/learn/tutorials/getting_started.md#download-and-launch).
@@ -93,12 +93,12 @@ More [optional fields are available](https://github.com/meilisearch/docs-scraper
 You can run the scraper with Docker. With our local MeiliSearch instance set up at [the first step](#run-a-meilisearch-instance), we run:
 
 ```bash
-$ docker run -t --rm \
-    --network=host \
-    -e MEILISEARCH_HOST_URL='http://localhost:7700' \
-    -e MEILISEARCH_API_KEY='myMasterKey' \
-    -v <absolute-path-to-your-config-file>:/docs-scraper/config.json \
-    getmeili/docs-scraper:latest pipenv run ./docs_scraper config.json
+docker run -t --rm \
+  --network=host \
+  -e MEILISEARCH_HOST_URL='http://localhost:7700' \
+  -e MEILISEARCH_API_KEY='myMasterKey' \
+  -v <absolute-path-to-your-config-file>:/docs-scraper/config.json \
+  getmeili/docs-scraper:latest pipenv run ./docs_scraper config.json
 ```
 
 ::: note
@@ -130,11 +130,21 @@ If you use VuePress for your documentation, we provide a [Vuepress plugin](https
 
 In your VuePress project:
 
+:::: tabs
+
+::: tab yarn
 ```bash
-$ yarn add vuepress-plugin-meilisearch
-# or
-$ npm install vuepress-plugin-meilisearch
+yarn add vuepress-plugin-meilisearch
 ```
+:::
+
+::: tab npm
+```bash
+npm install vuepress-plugin-meilisearch
+```
+:::
+
+::::
 
 In your `config.js` file:
 

--- a/create/how_to/search_bar_for_docs.md
+++ b/create/how_to/search_bar_for_docs.md
@@ -133,15 +133,19 @@ In your VuePress project:
 :::: tabs
 
 ::: tab yarn
+
 ```bash
 yarn add vuepress-plugin-meilisearch
 ```
+
 :::
 
 ::: tab npm
+
 ```bash
 npm install vuepress-plugin-meilisearch
 ```
+
 :::
 
 ::::

--- a/learn/core_concepts/documents.md
+++ b/learn/core_concepts/documents.md
@@ -158,7 +158,7 @@ By default, MeiliSearch limits the size of `JSON` payloads—and therefore docum
 To upload more documents in one go, it is possible to [change the payload size limit](/reference/features/configuration.md#payload-limit-size) during the setup of your MeiliSearch instance using the `http-payload-size-limit` option. The new limit must be given in bytes.
 
 ```bash
-$ ./meilisearch --http-payload-size-limit= 1048576000
+./meilisearch --http-payload-size-limit=1048576000
 ```
 
 > The above code sets the payload limit to 1GB, instead of the 100MB default.

--- a/learn/tutorials/getting_started.md
+++ b/learn/tutorials/getting_started.md
@@ -7,9 +7,24 @@ This quick tour will help you get started with MeiliSearch in only a few steps.
 First of all, let's download and run MeiliSearch.
 
 ```bash
-$ curl -L https://install.meilisearch.com | sh
-$ ./meilisearch
-Server is listening on: http://127.0.0.1:7700
+curl -L https://install.meilisearch.com | sh
+./meilisearch
+```
+
+You should see the following response:
+
+```
+888b     d888          d8b 888 d8b  .d8888b.                                    888
+8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
+88888b.d88888              888     Y88b.                                        888
+888Y88888P888  .d88b.  888 888 888  "Y888b.    .d88b.   8888b.  888d888 .d8888b 88888b.
+888 Y888P 888 d8P  Y8b 888 888 888     "Y88b. d8P  Y8b     "88b 888P"  d88P"    888 "88b
+888  Y8P  888 88888888 888 888 888       "888 88888888 .d888888 888    888      888  888
+888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
+888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888
+
+Database path:		"./data.ms"
+Server listening on:	"127.0.0.1:7700"
 ```
 
 You can download & run MeiliSearch [in many different ways (i.e: docker, apt, homebrew, ...)](/reference/features/installation.md).

--- a/learn/tutorials/getting_started.md
+++ b/learn/tutorials/getting_started.md
@@ -23,8 +23,8 @@ You should see the following response:
 888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
 888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888
 
-Database path:		"./data.ms"
-Server listening on:	"127.0.0.1:7700"
+Database path:       "./data.ms"
+Server listening on: "127.0.0.1:7700"
 ```
 
 You can download & run MeiliSearch [in many different ways (i.e: docker, apt, homebrew, ...)](/reference/features/installation.md).

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -9,7 +9,9 @@ Options can be either communicated through **environment variables** or **comman
 Options are added at launch.
 
 ```bash
-$ ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
+./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
+```
+```bash
 Server is listening on: http://127.0.0.1:7700
 ```
 
@@ -18,9 +20,11 @@ Server is listening on: http://127.0.0.1:7700
 The format of the environment variables is identical to the command line options with the exception that it is uppercased and `MEILI_` is prepended.
 
 ```bash
-$ export MEILI_DB_PATH=./meilifiles
-$ export MEILI_HTTP_ADDR=127.0.0.1:7700
-$ ./meilisearch
+export MEILI_DB_PATH=./meilifiles
+export MEILI_HTTP_ADDR=127.0.0.1:7700
+./meilisearch
+```
+```bash
 Server is listening on: http://127.0.0.1:7700
 ```
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -11,6 +11,7 @@ Options are added at launch.
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
 ```
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
 ```
@@ -24,6 +25,7 @@ export MEILI_DB_PATH=./meilifiles
 export MEILI_HTTP_ADDR=127.0.0.1:7700
 ./meilisearch
 ```
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
 ```

--- a/reference/features/installation.md
+++ b/reference/features/installation.md
@@ -10,8 +10,10 @@ Download the **latest stable release** of MeiliSearch with **curl**.
 Launch MeiliSearch to start the server.
 
 ```bash
-$ curl -L https://install.meilisearch.com | sh
-$ ./meilisearch
+curl -L https://install.meilisearch.com | sh
+./meilisearch
+```
+```bash
 Server is listening on: http://127.0.0.1:7700
 ```
 
@@ -23,8 +25,10 @@ Download the **latest stable release** of MeiliSearch with **Homebrew**.
 Launch MeiliSearch to start the server.
 
 ```bash
-$ brew update && brew install meilisearch
-$ meilisearch
+brew update && brew install meilisearch
+meilisearch
+```
+```bash
 Server is listening on: http://127.0.0.1:7700
 ```
 
@@ -36,10 +40,12 @@ Using **Docker** you can choose to run [any available tags](https://hub.docker.c
 This command starts the **latest stable release** of MeiliSearch.
 
 ```bash
-$ docker run -it --rm \
+docker run -it --rm \
     -p 7700:7700 \
     -v $(pwd)/data.ms:/data.ms \
     getmeili/meilisearch
+```
+```bash
 Server is listening on: http://0.0.0.0:7700
 ```
 
@@ -53,9 +59,11 @@ Download the **latest stable release** of MeiliSearch with **APT**.
 Launch MeiliSearch to start the server.
 
 ```bash
-$ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
-$ apt update && apt install meilisearch-http
-$ meilisearch
+echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
+apt update && apt install meilisearch-http
+meilisearch
+```
+```bash
 Server is listening on: http://127.0.0.1:7700
 ```
 
@@ -68,21 +76,21 @@ MeiliSearch is written in `Rust`. To compile it, [installing the Rust toolchain]
 If the Rust toolchain is already installed, clone the repository on your local system and change it to your working directory.
 
 ```bash
-$ git clone https://github.com/meilisearch/MeiliSearch
-$ cd MeiliSearch
+git clone https://github.com/meilisearch/MeiliSearch
+cd MeiliSearch
 ```
 
 In the cloned repository, compile MeiliSearch.
 
 ```bash
 # Update the rust toolchain to the latest version
-$ rustup update
+rustup update
 
 # Compile the project
-$ cargo build --release
+cargo build --release
 
 # Execute the server binary
-$ ./target/release/meilisearch
+./target/release/meilisearch
 ```
 
 :::
@@ -96,7 +104,9 @@ Options are added at launch. Either through command line options or through envi
 This is an example using the command line options.
 
 ```bash
-$ ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
+./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
+```
+```bash
 Server is listening on: http://127.0.0.1:7700
 ```
 

--- a/reference/features/installation.md
+++ b/reference/features/installation.md
@@ -108,8 +108,8 @@ After launching MeiliSearch, you should see the following response:
 888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
 888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888
 
-Database path:		"./data.ms"
-Server listening on:	"127.0.0.1:7700"
+Database path:       "./data.ms"
+Server listening on: "127.0.0.1:7700"
 ```
 
 ## Configuration Options

--- a/reference/features/installation.md
+++ b/reference/features/installation.md
@@ -13,6 +13,7 @@ Launch MeiliSearch to start the server.
 curl -L https://install.meilisearch.com | sh
 ./meilisearch
 ```
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
 ```
@@ -28,6 +29,7 @@ Launch MeiliSearch to start the server.
 brew update && brew install meilisearch
 meilisearch
 ```
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
 ```
@@ -45,6 +47,7 @@ docker run -it --rm \
     -v $(pwd)/data.ms:/data.ms \
     getmeili/meilisearch
 ```
+
 ```bash
 Server is listening on: http://0.0.0.0:7700
 ```
@@ -63,6 +66,7 @@ echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.l
 apt update && apt install meilisearch-http
 meilisearch
 ```
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
 ```
@@ -106,6 +110,7 @@ This is an example using the command line options.
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
 ```
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
 ```

--- a/reference/features/installation.md
+++ b/reference/features/installation.md
@@ -10,12 +10,11 @@ Download the **latest stable release** of MeiliSearch with **curl**.
 Launch MeiliSearch to start the server.
 
 ```bash
+# Install MeiliSearch
 curl -L https://install.meilisearch.com | sh
-./meilisearch
-```
 
-```bash
-Server is listening on: http://127.0.0.1:7700
+# Launch MeiliSearch
+./meilisearch
 ```
 
 :::
@@ -26,12 +25,11 @@ Download the **latest stable release** of MeiliSearch with **Homebrew**.
 Launch MeiliSearch to start the server.
 
 ```bash
+# Update brew and install MeiliSearch
 brew update && brew install meilisearch
-meilisearch
-```
 
-```bash
-Server is listening on: http://127.0.0.1:7700
+# Launch MeiliSearch
+meilisearch
 ```
 
 :::
@@ -48,10 +46,6 @@ docker run -it --rm \
     getmeili/meilisearch
 ```
 
-```bash
-Server is listening on: http://0.0.0.0:7700
-```
-
 Data written to a **Docker container is not persistent** and is deleted along with the container when the latter is stopped. Docker volumes are not deleted when containers are removed. It is then recommended to share volumes between your containers and your host machine to provide persistent storage. MeiliSearch writes data to `/data.ms`
 :::
 
@@ -62,13 +56,14 @@ Download the **latest stable release** of MeiliSearch with **APT**.
 Launch MeiliSearch to start the server.
 
 ```bash
+# Add MeiliSearch package
 echo "deb [trusted=yes] https://apt.fury.io/meilisearch/ /" > /etc/apt/sources.list.d/fury.list
-apt update && apt install meilisearch-http
-meilisearch
-```
 
-```bash
-Server is listening on: http://127.0.0.1:7700
+# Update APT and install MeiliSearch
+apt update && apt install meilisearch-http
+
+# Launch MeiliSearch
+meilisearch
 ```
 
 :::
@@ -100,6 +95,22 @@ cargo build --release
 :::
 
 ::::
+
+After launching MeiliSearch, you should see the following response:
+
+```
+888b     d888          d8b 888 d8b  .d8888b.                                    888
+8888b   d8888          Y8P 888 Y8P d88P  Y88b                                   888
+88888b.d88888              888     Y88b.                                        888
+888Y88888P888  .d88b.  888 888 888  "Y888b.    .d88b.   8888b.  888d888 .d8888b 88888b.
+888 Y888P 888 d8P  Y8b 888 888 888     "Y88b. d8P  Y8b     "88b 888P"  d88P"    888 "88b
+888  Y8P  888 88888888 888 888 888       "888 88888888 .d888888 888    888      888  888
+888   "   888 Y8b.     888 888 888 Y88b  d88P Y8b.     888  888 888    Y88b.    888  888
+888       888  "Y8888  888 888 888  "Y8888P"   "Y8888  "Y888888 888     "Y8888P 888  888
+
+Database path:		"./data.ms"
+Server listening on:	"127.0.0.1:7700"
+```
 
 ## Configuration Options
 

--- a/reference/features/snapshots.md
+++ b/reference/features/snapshots.md
@@ -9,7 +9,7 @@ Using this feature, it is possible to schedule snapshot creation at custom inter
 For MeiliSearch to create snapshots, the feature must be enabled by adding the following flag:
 
 ```bash
-$ meilisearch --schedule-snapshot=true
+meilisearch --schedule-snapshot=true
 ```
 
 By default, MeiliSearch creates snapshots in a directory called `snapshots/` at the root of your MeiliSearch.
@@ -17,7 +17,7 @@ By default, MeiliSearch creates snapshots in a directory called `snapshots/` at 
 The destination can be modified with the `--snapshot-dir` flag.
 
 ```bash
-$ meilisearch --schedule-snapshot=true --snapshot-dir mySnapShots/
+meilisearch --schedule-snapshot=true --snapshot-dir mySnapShots/
 ```
 
 Now snapshots are created in `mySnapShots/` directory.
@@ -27,7 +27,7 @@ The first snapshot is created on launching MeiliSearch. After that, snapshots ar
 The amount of time between each new snapshot can be modified with the `--snapshot-interval-sec` flag.
 
 ```bash
-$ meilisearch --schedule-snapshot=true --snapshot-interval-sec 3600
+meilisearch --schedule-snapshot=true --snapshot-interval-sec 3600
 ```
 
 After running the above code, a snapshot is created every hour (3600 seconds).
@@ -43,7 +43,7 @@ Because snapshots are exact copies of your database that haven't gone through an
 Using the global environment `MEILI_IMPORT_SNAPSHOT` or the CLI flag `--import-snapshot` , MeiliSearch will start the server using the provided snapshot.
 
 ```bash
-$ meilisearch --import-snapshot mySnapShots/data.ms.snapshot
+meilisearch --import-snapshot mySnapShots/data.ms.snapshot
 ```
 
 ## Common Problems


### PR DESCRIPTION
Remove command prompt from bash code samples, separate input from server response.
Fixes #731 , fixes #723 