### PR TITLE
Fixes code copy position

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -10,3 +10,7 @@
   &.note
     background-color #f3f5f7
     border-color #1e90ff
+.code-copy
+    position: absolute;
+    right: 0;
+    bottom: 5px;


### PR DESCRIPTION
Copy icons should not increase the size of the code blocks with this style :) 

Preview: 
<img width="781" alt="Screenshot 2021-02-10 at 20 20 17" src="https://user-images.githubusercontent.com/33010418/107560261-6e746b80-6bdd-11eb-8fe9-e2452d215d1c.png">

