### PR TITLE
Clarify Update fields

### DIFF
--- a/learn/advanced/asynchronous_updates.md
+++ b/learn/advanced/asynchronous_updates.md
@@ -4,7 +4,7 @@ MeiliSearch is an **asynchronous API**. It means that the API does not behave as
 
 Some operations are put in a queue and will be executed in turn (asynchronously). In this case, the server response contains the identifier to track the execution of the operation.
 
-### Async flow
+## Async flow
 
 - When making a write request (_create/update/delete_) against the search engine, it stores the operation received in a queue and returns an `updateId`. With this id, the operation update is trackable.
 - Each update received is treated following the order it has been received.
@@ -33,19 +33,23 @@ Every operation which could be compute-expensive is asynchronous. These include:
 - Update index settings
 - Add/update/delete documents
 
-### Understanding updates
+## Understanding updates
 
-All updates return the following information:
+All updates return the following fields:
 
-- **status**: The state of the operation (enqueued, processed, or failed).
-- **updateId**: The id of the update.
-- **type**: The type of the operation.
-- **enqueuedAt**: The date at which the operation has been added to the queue.
+- **`status`**: The state of the operation (enqueued, processed, or failed).
+- **`updateId`**: The id of the update.
+- **`type`**: The type of the operation, including its name and number.
+- **`enqueuedAt`**: The date at which the operation has been added to the queue.
 
-Updates which have already been processed may also return the following fields:
+Updates that have already been processed also return the following fields:
 
-- **duration**: The number of seconds taken to complete the operation.
-- **processedAt**: The date at which the operation has been processed.
+- **`duration`**: The number of seconds taken to complete the operation.
+- **`processedAt`**: The date at which the operation has been processed.
+
+Finally, failed updates return an additional field:
+
+- **`error`**: A string describing [the error that occurred](https://docs.meilisearch.com/errors/).
 
 ### Examples
 
@@ -82,7 +86,7 @@ Failing to upload document:
 }
 ```
 
-### Killing MeiliSearch While a Task is Processing
+## Killing MeiliSearch While a Task is Processing
 
 Since in MeiliSearch asynchronous tasks are <clientGlossary word="atomic"/>, killing MeiliSearch in the middle of a process does not corrupt or alter the database.
 
@@ -94,7 +98,7 @@ You can use the `status` field returned by [the update route](/reference/api/upd
 - status `processing` => In progress. If MeiliSearch is killed, there will be no consequences, since no part of the task has been committed to MeiliSearch. After restarting, Meilisearch will treat the task as `enqueued`.
 - status `done` => Completed. This action is done and is permanently added to your MeiliSearch instance. If you kill MeiliSearch, there will be no data loss; your database will remain exactly the same as before you killed MeiliSearch.
 
-#### Example
+### Example
 
 Imagine that you're adding 100 documents in one batch to MeiliSearch. If you kill the process after 99 documents have successfully been added, then none of the 100 documents will be present in the dataset when you restart MeiliSearch. The same is true if the 100th document raises an error. Either all documents are added, or none are.
 

--- a/learn/advanced/asynchronous_updates.md
+++ b/learn/advanced/asynchronous_updates.md
@@ -35,13 +35,17 @@ Every operation which could be compute-expensive is asynchronous. These include:
 
 ### Understanding updates
 
-Updates returns the following information:
+All updates return the following information:
 
 - **status**: The state of the operation (enqueued, processed, or failed).
 - **updateId**: The id of the update.
 - **type**: The type of the operation.
 - **enqueuedAt**: The date at which the operation has been added to the queue.
-- **processedAt**: The date at which the operation has been processed.
+
+Updates which have already been processed may also return the following fields:
+
+- **duration**: The number of seconds taken to complete the operation.
+- **processedAt**: The date at which the operation has been processed (only if operation has already completed).
 
 ### Examples
 

--- a/learn/advanced/asynchronous_updates.md
+++ b/learn/advanced/asynchronous_updates.md
@@ -45,7 +45,7 @@ All updates return the following information:
 Updates which have already been processed may also return the following fields:
 
 - **duration**: The number of seconds taken to complete the operation.
-- **processedAt**: The date at which the operation has been processed (only if operation has already completed).
+- **processedAt**: The date at which the operation has been processed.
 
 ### Examples
 

--- a/learn/advanced/snapshots_vs_dumps.md
+++ b/learn/advanced/snapshots_vs_dumps.md
@@ -2,7 +2,7 @@
 
 MeiliSearch has two ways to backup its data: `snapshots` and `dumps`.
 
-## Snapshots
+### Snapshots
 
 **Snapshots** make it possible to schedule the creation of hard copies of your database.
 
@@ -10,13 +10,13 @@ This feature is **intended mainly as a safeguard**: ensuring that if some failur
 
 The documents in a snapshot are already "indexed" and ready to go, greatly increasing import speed. However, as a result, **snapshots are not compatible between different versions of MeiliSearch**.
 
-## Dumps
+### Dumps
 
 **Dumps**, on the other hand, export MeiliSearch data in a way that is not bound to a specific MeiliSearch version.
 
 As a result, importing a dump requires MeiliSearch to re-index all of your documents. This process requires an amount of time and memory corresponding to the size of the database (the number of documents, their size, and the complexity of any index settings).
 
-## Conclusion
+### Conclusion
 
 To summarize:
 

--- a/reference/api/updates.md
+++ b/reference/api/updates.md
@@ -21,7 +21,7 @@ Get the status of an [update](/learn/advanced/asynchronous_updates.md) in a give
 
 #### Response: `200 Ok`
 
-Here is an example response of [an update that has been processed](/learn/advanced/asynchronous_updates.md#understanding-updates).
+Here is an example response representing [an update that has already been processed](/learn/advanced/asynchronous_updates.md#understanding-updates).
 
 ```json
 {
@@ -55,7 +55,7 @@ Get the status of all [updates](/learn/advanced/asynchronous_updates.md) in a gi
 
 #### Response: `200 Ok`
 
-Here is an example of an [enqueued update](/learn/advanced/asynchronous_updates.md#understanding-updates) response.
+Here is an example response representing an [enqueued update](/learn/advanced/asynchronous_updates.md#understanding-updates).
 
 ```json
 [

--- a/reference/api/updates.md
+++ b/reference/api/updates.md
@@ -21,7 +21,7 @@ Get the status of an [update](/learn/advanced/asynchronous_updates.md) in a give
 
 #### Response: `200 Ok`
 
-Here is an example response of an update that has been processed.
+Here is an example response of [an update that has been processed](/learn/advanced/asynchronous_updates.md#understanding-updates).
 
 ```json
 {
@@ -55,20 +55,18 @@ Get the status of all [updates](/learn/advanced/asynchronous_updates.md) in a gi
 
 #### Response: `200 Ok`
 
-Here is an example response of updates that have been processed.
+Here is an example of an [enqueued update](/learn/advanced/asynchronous_updates.md#understanding-updates) response.
 
 ```json
 [
-  {
-    "status": "processed",
-    "updateId": 1,
-    "type": {
-      "name": "DocumentsAddition",
-      "number": 4
-    },
-    "duration": 0.076980613,
-    "enqueuedAt": "2019-12-07T21:16:09.623944Z",
-    "processedAt": "2019-12-07T21:16:09.703509Z"
-  }
+    {
+        "status": "enqueued",
+        "updateId": 0,
+        "type": {
+            "name": "DocumentsAddition",
+            "number": 30
+        },
+        "enqueuedAt": "2021-02-14T14:07:09.364505700Z"
+    }
 ]
 ```


### PR DESCRIPTION
As stated in #765 , the current documentation is unclear on updates, particularly which fields may be contained in the response body when you make a call to GET updates. This PR attempts to improve that situation.

Fixes #765 