### PR TITLE
hide copy button for response code box

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -14,3 +14,7 @@
     position: absolute;
     right: 0;
     bottom: 5px;
+.language-
+.language-json
+  div
+    visibility: hidden;


### PR DESCRIPTION
could have been done with JavaScript to remove the element, but I tricked it by rendering them invisible. It is working for code box without a language set or the JSON one since they are usually an example of return from the API