### PR TITLE
Wait for Netlify

### DIFF
--- a/.github/workflows/gh-pages-scraping.yml
+++ b/.github/workflows/gh-pages-scraping.yml
@@ -12,18 +12,16 @@ jobs:
     steps:
     - uses: actions/checkout@master
 
-    - name: Publish
-      uses: netlify/actions/build@master
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        NETLIFY_CMD: vuepress build .
-        NETLIFY_DIR: .vuepress/dist
-
   scrape-docs:
     needs: build-deploy
     runs-on: ubuntu-18.04
     steps:
+    - name: Waiting for 200 from the Netlify Preview
+      uses: jakepartusch/wait-for-netlify-action@v1.2
+      id: waitFor200
+      with:
+        site_name: "dreamy-wiles-8fd85b"
+        max_timeout: 200
     - uses: actions/checkout@master
     - name: Run docs-scraper
       env:

--- a/reference/under_the_hood/README.md
+++ b/reference/under_the_hood/README.md
@@ -15,3 +15,5 @@ To better understand some of the algorithms behind our beloved search engine, ch
 [Storage](/reference/under_the_hood/storage.md)
 [Tokenization](/reference/under_the_hood/tokenization.md)
 [Typo Tolerance](/reference/under_the_hood/typotolerance.md)
+
+## This header is a test of our documentation scraper


### PR DESCRIPTION
Wait for 200 from Netlify site (or 200 second timeout) before running the docs scraper. Also adds a small scraper test in reference/under_the_hood/README.md. Attempting to solve netlify deploy pipeline problems (#551).

**Explanation of problem:** Each time there's a push to the production branch (Master), we run a scraper on our docs site to fill a MeiliSearch instance index (this powers the search bar). The problem is that the scraper is running before Netlify has finished deploying and publishing the new build, so it ends up scraping the old outdated content. This means that items that were just added in the most recent commit MAY NOT BE SEARCHABLE until the next time build is triggered (the next commit on Master).

**Explanation of solution:** This PR uses https://github.com/marketplace/actions/wait-for-netlify, a GitHub action that waits for an OK response from a Netlify preview (or a certain number of seconds) before continuing subsequent actions. Unclear if it will work for a Netlify site to build rather than a preview.