### PR TITLE
Remove code-sample in template file

### DIFF
--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -72,7 +72,6 @@ settings_guide_displayed_1: |-
 documents_guide_add_movie_1: |-
 search_guide_1: |-
 search_guide_2: |-
-getting_started_create_index_md: |-
 getting_started_add_documents_md: |-
 getting_started_search_md: |-
 faceted_search_update_settings_1: |-


### PR DESCRIPTION
The template file is used on the build to determine if samples are missing in the different SDK's. As this one is not needed anymore it should be removed!