### PR TITLE
Update update status

### DIFF
--- a/learn/advanced/asynchronous_updates.md
+++ b/learn/advanced/asynchronous_updates.md
@@ -95,8 +95,8 @@ Essentially, tasks are done in transactions. If the transaction fails or is kill
 You can use the `status` field returned by [the update route](/reference/api/updates.md) to determine if a process has been committed to MeiliSearch or not.
 
 - status: `enqueued` => Not yet begun. If MeiliSearch is killed and then restarted, the task will remain enqueued and be processed eventually.
-- status `processing` => In progress. If MeiliSearch is killed, there will be no consequences, since no part of the task has been committed to MeiliSearch. After restarting, Meilisearch will treat the task as `enqueued`.
-- status `done` => Completed. This action is done and is permanently added to your MeiliSearch instance. If you kill MeiliSearch, there will be no data loss; your database will remain exactly the same as before you killed MeiliSearch.
+- status `in_progress` => Processing. If MeiliSearch is killed, there will be no consequences, since no part of the task has been committed to MeiliSearch. After restarting, Meilisearch will treat the task as `enqueued`.
+- status `processed`/`done` => Completed. This action is done and is permanently added to your MeiliSearch instance. If you kill MeiliSearch, there will be no data loss; your database will remain exactly the same as before you killed MeiliSearch.
 
 ### Example
 


### PR DESCRIPTION
Some update status did not exist.

There are currently 2 actions that have status:
- dumps
- updates

But, they don't have similar behaviors.

Dumps status are:
- `in_progress`
- `done`
- `failed`

(cf in codebase: https://github.com/meilisearch/MeiliSearch/blob/c984fa1071fa6dc42344253490180b448314f729/meilisearch-http/src/dump.rs#L196-L200)

Update status are:
- `enqueued`
- `processed`
- `failed`

(cf in codebase: https://github.com/meilisearch/MeiliSearch/blob/c984fa1071fa6dc42344253490180b448314f729/meilisearch-core/src/update/mod.rs#L163-L176)