### PR TITLE
Update DigitalOcean how-to

### DIFF
--- a/create/how_to/digitalocean_droplet.md
+++ b/create/how_to/digitalocean_droplet.md
@@ -109,7 +109,7 @@ Open a terminal and start a new SSH connection with the IP you got from DigitalO
 Write in your terminal `ssh root@<your-ip-address>` and press Enter to establish connection:
 
 ```bash
-ssh meilisearch@42.42.42.42
+ssh root@42.42.42.42
 ```
 
 Write `yes` and press Enter to accept the authentication process.


### PR DESCRIPTION
[Not to merge until DO image is released]

When the DigitalOcean image for MeilISearch v0.20.0 is released, the user `meilisearch` for establishing an SSH connection is no longer available. This needs an update in the documentation. As ~long~ soon as this image is released, the docs need to be updated. This PR indicates the needed changes!