### PR TITLE
Add information about ranking rules

### DIFF
--- a/reference/features/settings.md
+++ b/reference/features/settings.md
@@ -99,6 +99,13 @@ Default value (the ranking rules in the default order):
 
 You can add a custom ranking rule anywhere in the list of ranking rules. A custom ranking rule is composed of an attribute and an ascending or descending order. The attribute **must have a numeric value** in the documents.
 
+::: warning
+
+If some documents do not contain the attribute defined in a custom ranking rule, the application of the ranking rule is undefined and the search results might not be sorted as you expected.
+We recommend providing documents that all contain the attribute filled in the ranking rule.
+
+:::
+
 #### Example
 
 To add your ranking rules to the settings, send:

--- a/reference/features/settings.md
+++ b/reference/features/settings.md
@@ -102,7 +102,8 @@ You can add a custom ranking rule anywhere in the list of ranking rules. A custo
 ::: warning
 
 If some documents do not contain the attribute defined in a custom ranking rule, the application of the ranking rule is undefined and the search results might not be sorted as you expected.
-We recommend providing documents that all contain the attribute filled in the ranking rule.
+
+We recommend that all your documents contain any attribute used in a custom ranking rule. For example, if you set the custom ranking rule `desc(year)`, make sure that all your documents contain the attribute `year`.
 
 :::
 


### PR DESCRIPTION
Hello @react-learner, here is a behavior we've found out with the core team about ranking rule. No user complained for the moment, but I think the documentation should be transparent about it 🙂

Sorry for my English, I hope this is understandable.
In other words: because of the bucket sort, if the users don't provide documents with the attribute that they filled in the ranking rules, the search engine cannot behave in a "logical" way. This can lead to some undefined behavior (from the user POV), that's why we recommend having documents containing the fields in the ranking rules.