### PR TITLE
Update AWS how-to v0.20.0: health check 200

### DIFF
--- a/create/how_to/aws.md
+++ b/create/how_to/aws.md
@@ -125,11 +125,11 @@ Your domain name should now be linked to your MeiliSearch instance. Run a health
 curl -v http://<your-domain-name>/health
 ```
 
-The server should answer with a `204 No content` status code as shown in the example below:
+The server should answer with a `200 OK` status code as shown in the example below:
 
 ```bash
 ...
-< HTTP/1.1 204 No Content
+< HTTP/1.1 200 OK
 ...
 ```
 
@@ -196,11 +196,11 @@ curl -v https://<your-domain-name>/health
 
 > Note that this time, we're using HTTPS.
 
-The server should answer with a `204 No content` status code as shown in the example below:
+The server should answer with a `200 OK` status code as shown in the example below:
 
 ```bash
 ...
-< HTTP/1.1 204 No Content
+< HTTP/1.1 200 OK
 ...
 ```
 


### PR DESCRIPTION
Since v0.20.0 health check response from `/health` route sends a `200 OK` response instead of `204 No content`