### PR TITLE
fix the code samples for the search

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -59,10 +59,13 @@ delete_documents_1: |-
         437035,
         363869
     ]'
-search_1: |-
+search_post_1: |-
   curl \
-    'http://localhost:7700/indexes/movies/search' \
+    -X POST 'http://localhost:7700/indexes/movies/search' \
     --data '{ "q": "american ninja" }'
+search_get_1: |-
+  curl \
+    -X GET 'http://localhost:7700/indexes/movies/search?q=american%20ninja'
 get_update_1: |-
   curl \
     -X GET 'http://localhost:7700/indexes/movies/updates/1'

--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -57,7 +57,7 @@ This is the preferred route to perform search when an API key is required, as it
 
 ### Example
 
-<CodeSamples id="search_1" />
+<CodeSamples id="search_post_1" />
 
 #### Response: `200 Ok`
 
@@ -149,7 +149,7 @@ When the `q` parameter is not specified, a [placeholder](/reference/features/sea
 
 ### Example
 
-<CodeSamples id="search_1" />
+<CodeSamples id="search_get_1" />
 
 #### Response: `200 Ok`
 


### PR DESCRIPTION
I noticed we were using the same code samples for the GET search and the POST search. Because of that, the GET search was broken.