### PR TITLE
Fix the copy code button

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -18,9 +18,8 @@ body
     background-color #f3f5f7
     border-color #1e90ff
 .code-copy
-    position: absolute;
-    right: 0;
-    bottom: 5px;
+    position: sticky;
+    left: 0px;
 
 {$contentClass} a code
   color $accentColor


### PR DESCRIPTION
I noticed a small “bug” when reading the documentation on my smol screen.

When you scroll to the right, the code copy button also scrolls:
![image](https://user-images.githubusercontent.com/7032172/119815642-104d6900-beec-11eb-9461-c5fd17cc71a5.png)

It's ugly. With this fix the position of the button stays “fixed” to the bottom right of the screen:

![image](https://user-images.githubusercontent.com/7032172/119815563-fad83f00-beeb-11eb-8f97-fb8f8b6e080f.png)

---------------

This fix was made thanks to @lordteka