### PR TITLE
Add 'Resources' dropdown menu to navbar

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -14,6 +14,27 @@ module.exports = {
       { text: 'Learn', link: '/learn/' },
       { text: 'Create', link: '/create/' },
       { text: 'Reference', link: '/reference/' },
+      {
+        text: 'Resources',
+        items: [
+          { text: 'FAQ', link: '/resources/faq' },
+          { text: 'Open API', link: '/resources/open-api-readme' },
+          {
+            text: 'SDKs',
+            items: [
+              { text: '.Net', link: 'https://github.com/meilisearch/meilisearch-dotnet' },
+              { text: 'Golang', link: 'https://github.com/meilisearch/meilisearch-go' },
+              { text: 'Java', link: 'https://github.com/meilisearch/meilisearch-java' },
+              { text: 'JavaScript', link: 'https://github.com/meilisearch/meilisearch-js' },
+              { text: 'PHP', link: 'https://github.com/meilisearch/meilisearch-php' },
+              { text: 'Python', link: 'https://github.com/meilisearch/meilisearch-python' },
+              { text: 'Ruby', link: 'https://github.com/meilisearch/meilisearch-ruby' },
+              { text: 'Rust', link: 'https://github.com/meilisearch/meilisearch-rust' },
+              { text: 'Swift', link: 'https://github.com/meilisearch/meilisearch-swift' },
+            ],
+          },
+        ],
+      },
       { text: 'Slack', link: 'https://slack.meilisearch.com' },
     ],
     sidebar: {
@@ -134,10 +155,6 @@ module.exports = {
           ],
         },
         {
-          title: '📇 OpenAPI',
-          path: '/reference/open-api/',
-        },
-        {
           title: '🛠️ Under the Hood',
           path: '/reference/under_the_hood/',
           collapsable: true,
@@ -154,7 +171,7 @@ module.exports = {
       ],
       '/create/': [
         {
-          title: '📜 How To',
+          title: '📕 How To',
           path: '/create/how_to/',
           collapsable: false,
           children: [
@@ -227,11 +244,6 @@ module.exports = {
               ],
             },
           ],
-        },
-        {
-          title: '❓ FAQ',
-          path: '/create/faq',
-          collapsable: false,
         },
       ],
     },

--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -71,3 +71,6 @@
 /learn/tutorials                                    /learn/getting_started
 /learn/tutorials/getting_started.html               /learn/getting_started/quick_start.html
 /learn/tutorials/whats_next.html                    /learn/getting_started/whats_next.html
+
+# Move FAQ and Open API
+/reference/open-api                                 /open-api-readme

--- a/create/README.md
+++ b/create/README.md
@@ -8,4 +8,3 @@ We're always working hard to create new guides, so check back often!
 ## Table of Contents
 
 [📜 How To](/create/how_to): Step-by-step guides for efficient problem-solving
-[❓ FAQ](/create/faq.md): Frequently Asked Questions

--- a/learn/core_concepts/documents.md
+++ b/learn/core_concepts/documents.md
@@ -166,7 +166,7 @@ To upload more documents in one go, it is possible to [change the payload size l
 
 > The above code sets the payload limit to 1GB, instead of the 100MB default.
 
-**MeiliSearch uses a lot of RAM when indexing documents**. Be aware of your [RAM availability](/create/faq.md#what-are-the-recommended-requirements-for-hosting-a-meilisearch-instance) as you increase the size of your batch as this could cause MeiliSearch to crash.
+**MeiliSearch uses a lot of RAM when indexing documents**. Be aware of your [RAM availability](/resources/faq.md#what-are-the-recommended-requirements-for-hosting-a-meilisearch-instance) as you increase the size of your batch as this could cause MeiliSearch to crash.
 
 When using the [route to add new documents](/reference/api/documents.md#add-or-update-documents), all documents must be sent in an array **even if there is only one document**.
 

--- a/learn/getting_started/whats_next.md
+++ b/learn/getting_started/whats_next.md
@@ -13,7 +13,7 @@ You can find the API references here:
 And additional resources here:
 
 - [SDKs](/learn/what_is_meilisearch/sdks.md)
-- [FAQ](/create/faq.md)
+- [FAQ](/resources/faq.md)
 - [Advanced Topics](/learn/advanced)
 - [How-To Guides](/create/how_to)
 - [Postman Collection](/create/how_to/postman_collection.md): it can be tedious to re-write every route when wanting to try out an API. Try out MeiliSearch with our collection in Postman

--- a/reference/README.md
+++ b/reference/README.md
@@ -8,5 +8,4 @@ This is **timeless knowledge**. We recommend keeping it open in a spare tab, whe
 
 - [⭐ Features](/reference/features)
 - [📒 API](/reference/api)
-- [📇 OpenAPI](/reference/open-api)
 - [🛠️ Under the Hood](/reference/under_the_hood)

--- a/reference/api/README.md
+++ b/reference/api/README.md
@@ -4,7 +4,7 @@ Welcome to the MeiliSearch API documentation.
 
 ::: tip
 
-Check out [the FAQ](/create/faq.md) for answers to some common questions 💡
+Check out [the FAQ](/resources/faq.md) for answers to some common questions 💡
 
 :::
 

--- a/reference/open-api/README.md
+++ b/reference/open-api/README.md
@@ -1,5 +1,0 @@
-# OpenAPI
-
-Every [API](/reference/api) endpoint is also documented with [OpenAPI v3.0.3](http://spec.openapis.org/oas/v3.0.3).
-
-The raw YAML file is available [here](/open-api/open-api.yaml) and a web interface to test it out live is <a href="/open-api.html">here</a>.

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -21,7 +21,7 @@ MeiliSearch is really **easy to use** and thus accessible to all kinds of develo
 
 We also provide a lot of tools, including [SDKs](/learn/what_is_meilisearch/sdks.md), to help you integrate easily MeiliSearch in your project. We're adding new tools every day!
 
-Plus, you can [contact us](/create/faq.md#how-can-i-contact-the-meilisearch-team) if you need any help. We will answer for sure!
+Plus, you can [contact us](#how-can-i-contact-the-meilisearch-team) if you need any help. We will answer for sure!
 
 ## Do I need to configure MeiliSearch to get it working?
 
@@ -138,8 +138,7 @@ See more [information about the primary key](/learn/core_concepts/documents.md#p
 
 ## I have uploaded my documents, but I get no result when I search in my index.
 
-Your documents upload probably failed.
-To understand what happened, please check this [answer](/create/faq.md#i-did-a-call-to-an-api-route-and-i-only-got-an-updateid-as-a-response-what-does-it-mean).
+Your document upload probably failed. To understand what happened, please check this [answer](#i-did-a-call-to-an-api-route-and-i-only-got-an-updateid-as-a-response-what-does-it-mean).
 
 ## Is killing a MeiliSearch process safe?
 

--- a/resources/open-api-readme.md
+++ b/resources/open-api-readme.md
@@ -1,0 +1,9 @@
+---
+permalink: /open-api-readme
+---
+
+# OpenAPI
+
+Every one of MeiliSearch's [API endpoints](/reference/api) is also documented with [OpenAPI v3.0.3](http://spec.openapis.org/oas/v3.0.3).
+
+The raw YAML file is available [here](/open-api/open-api.yaml) and a web interface to test it out live is <a href="/open-api.html" target="_blank">here</a>.


### PR DESCRIPTION
Basically, this PR adds a dropdown menu (titled "Resources") in the top Navbar with links to our FAQ, OpenAPI page, and SDK repos. It also moves FAQ and OpenAPI from their previous locations into a new directory, `/resources`.

Fixes #857 