### PR TITLE
Fix position of the copy button inside a code block

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -20,6 +20,10 @@ body
 .code-copy
     position: sticky;
     left: 0px;
+    svg {
+      right: -6px;
+      bottom: -6px !important;
+    }
 
 {$contentClass} a code
   color $accentColor


### PR DESCRIPTION
## Current problem 

The copy button inside a code block overlaps with text (see [here](https://deploy-preview-944--dreamy-wiles-8fd85b.netlify.app/reference/features/filtering.html#examples))

## Solution

Adapt the position of the button in style. Note that I had to use a `!important` because we use the external library `vuepress-plugin-code-copy` and it's the only way to override the initial style of the button.

## How to test 

Go to http://localhost:8081/reference/features/filtering.html#examples and check the position of the button

## Screenshots

Before: 
![Capture d’écran 2021-05-31 à 11 33 09](https://user-images.githubusercontent.com/30866152/120174711-b0193880-c205-11eb-9502-e46ed10c8be0.png)


After: 
![Capture d’écran 2021-05-31 à 11 32 53](https://user-images.githubusercontent.com/30866152/120174719-b27b9280-c205-11eb-9405-15b1ac232294.png)


