### PR TITLE
Add requirements for dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Hey, thank you so much for wanting to contribute! If you'd like to help improve 
 
 To contribute, clone this repository, commit your changes and open a pull request.
 
+### Requirements
+
+- Node version => v10 and < v15
+
 ### Installing & Running
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To contribute, clone this repository, commit your changes and open a pull reques
 
 ### Requirements
 
-- Node version => v10 and < v15
+- Node version >= v10 and < v15
 
 ### Installing & Running
 


### PR DESCRIPTION
Downloading `node-sass` used by `vuepress-plugin-element-tabs` is not possible when your node version is bellow v15. 

To make it compatible with node v15 and v16 node-sass should be updated to version 6 in the vuepress plugin. Because of [this line](https://github.com/superbiger/vuepress-plugin-tabs/blob/96cf59b10ccc8d877e8ba854a051ab8645e2215b/package.json#L32) it will not upgrade to the next major version. 

