### PR TITLE
Remove initial paragraph from Feature Reference intro

### DIFF
--- a/reference/features/README.md
+++ b/reference/features/README.md
@@ -1,7 +1,5 @@
 # Feature References
 
-Want to know something about MeiliSearch? Chances are high that it's written down here.
-
 This section is where we document all of MeiliSearch's user-facing features and tools. This does not include [API routes](/reference/api) or [details of the MeiliSearch engine](/reference/under_the_hood); these each have their own section.
 
 Understanding our reference documentation is easier with background knowledge of MeiliSearch's [core concepts](/learn/core_concepts). If you're a **new user**, you might prefer to start with an [explanation of MeiliSearch's features](/learn/what_is_meilisearch/features.md) or our [quick start guide](/learn/getting_started/quick_start.md).


### PR DESCRIPTION
First paragraph of the Feature Reference currently says: `Want to know something about MeiliSearch? Chances are high that it's written down here.`

Not sure what this adds. If I want to know about e.g. Core Concepts it's not actually in this section, so it's potentially misleading.