### PR TITLE
[react example] fix JS example: import Meilisearch requires {}

### DIFF
--- a/create/how_to/meilisearch_react.md
+++ b/create/how_to/meilisearch_react.md
@@ -267,7 +267,7 @@ Replace this comment in App.js by the code snippet below:
 `// TODO configure the MeiliSearch Client`
 
 ```javascript
-import MeiliSearch from "meilisearch";
+import { MeiliSearch } from "meilisearch";
 
 const client = new MeiliSearch({
   host: "http://127.0.0.1:7700/",


### PR DESCRIPTION
The current example does not work with the latest version of the lib.