### PR TITLE
Remove errors for v0.21

### DIFF
--- a/errors.yaml
+++ b/errors.yaml
@@ -20,12 +20,8 @@ errors:
     description: "The maximum number of fields for a document is 65,535. When this number is exceeded, this error is returned."
   - code: missing_document_id
     description: "A document does not contain any value for the required primary key, and is thus invalid. Check documents in the current addition for the invalid ones."
-  - code: invalid_facet
-    description: "The facet provided with the search is invalid. Check our [guide on faceting](https://docs.meilisearch.com/reference/features/faceted_search.html) to troubleshoot."
   - code: invalid_filter
     description: "The filter provided with the search is invalid. Check our [guide on filtering](https://docs.meilisearch.com/reference/features/filtering.html) to troubleshoot."
-  - code: bad_parameter
-    description: "The request contains invalid parameters, check the error message for more information."
   - code: bad_request
     description: "The request is invalid, check the error message for more information."
   - code: document_not_found
@@ -36,16 +32,12 @@ errors:
     description: "The provided token is invalid."
   - code: missing_authorization_header
     description: "The requested resources are protected with an API key, that was not provided in the request header. Check our guide on [authentication](https://docs.meilisearch.com/reference/features/authentication.html) for more information."
-  - code: missing_header
-    description: "A header is missing in the HTTP request."
   - code: not_found
     description: "The requested resources could not be found."
   - code: payload_too_large
     description: "The payload sent to the server was too large. Check out this [guide](https://docs.meilisearch.com/reference/features/configuration.html#payload-limit-size) to customize the maximum payload size accepted by MeiliSearch."
   - code: unretrievable_document
     description: "The document exists in store, but there was an error retrieving it. This probably comes from an inconsistent state in the database."
-  - code: search_error
-    description: "There was an error in the search."
   - code: unsupported_media_type
     description: "The payload content type is not supported by MeiliSearch. Currently, MeiliSearch supports only JSON payloads."
   - code: dump_already_in_progress


### PR DESCRIPTION
Remove `invalid_facet`, `missing_header`, `search_error`, and `bad_parameter` from the docs error page. These are being removed as part of v0.21.