### PR TITLE
Feature reference config

### DIFF
--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -2,7 +2,7 @@
 
 Many options are available to configure a MeiliSearch instance. Each of these options is added on MeiliSearch instance launch.
 
-Options can be either communicated through **environment variables** or **command line options**. If both are provided for the same option, the command line option value is kept.
+## Configuring an instance with command-line flags
 
 ## Passing arguments via the command line
 
@@ -16,7 +16,7 @@ Options are added at launch.
 Server is listening on: http://127.0.0.1:7700
 ```
 
-## Passing arguments via the environment variables
+## Configuring an instance with environment variables
 
 The format of the environment variables is identical to the command line options with the exception that it is uppercased and `MEILI_` is prepended.
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -30,6 +30,8 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Usage
 
+Command-line flags take precedence over environment variables. If an option is specified both as a flag and an environment variable, the command-line flag and its respective value will be used.
+
 All options should have a value specified. Adding a command-line flag or environment variable without a value will throw an error.
 
 Command-line flags take precedence over environment variables. If an option is specified both as a flag and an environment variable, the command-line flag and its respective value will be used.

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -1,12 +1,10 @@
 # Configuration
 
-Many options are available to configure a MeiliSearch instance. Each of these options is added on MeiliSearch instance launch.
+Options can be passed to a MeiliSearch instance through **environment variables** and **command line options**. 
 
 ## Configuring an instance with command-line flags
 
-## Passing arguments via the command line
-
-Options are added at launch.
+Options and their respective arguments must be passed when launching the instance.
 
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
@@ -18,7 +16,7 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Configuring an instance with environment variables
 
-The format of the environment variables is identical to the command line options with the exception that it is uppercased and `MEILI_` is prepended.
+Environment variables are always identical to the command-line flags, but prepended with `MEILI_` and written in upper case.
 
 ```bash
 export MEILI_DB_PATH=./meilifiles

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -34,11 +34,13 @@ Command-line flags take precedence over environment variables. If an option is s
 
 All options should have a value specified. Adding a command-line flag or environment variable without a value will throw an error.
 
-Command-line flags take precedence over environment variables. If an option is specified both as a flag and an environment variable, the command-line flag and its respective value will be used.
+```bash
+./meilisearch --schedule-snapshot
+```
 
-**Example**:
-`meilisearch --schedule-snapshot` throws an error.
-`meilisearch --schedule-snapshot=true` activates snapshots scheduling properly.
+```bash
+error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value but none was supplied
+```
 
 ## Options
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -44,14 +44,14 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 
 ## Options
 
-#### General
+### General
 
 - [Database path](/reference/features/configuration.md#database-path)
 - [HTTP address & port binding](/reference/features/configuration.md#http-address-port-binding)
 - [Master key](/reference/features/configuration.md#master-key)
 - [Environment](/reference/features/configuration.md#environment)
 
-#### Advanced
+### Advanced
 
 - [Analytics](/reference/features/configuration.md#analytics)
 - [Payload Limit Size](/reference/features/configuration.md#payload-limit-size)

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -16,6 +16,8 @@ Pass command-line options and their respective values when launching a MeiliSear
 Server is listening on: http://127.0.0.1:7700
 ```
 
+In the previous example, `./meilisearch` is the command that launches a MeiliSearch instance and `--http-addr` is the option that sets the URL and port this instance will use. **All command-line options are prepended with `--`.**
+
 ## Configuring an instance with environment variables
 
 In order to configure a MeiliSearch instance using environment variables, you have to set the environment variable prior to launching the instance. If it's your first time doing this you may want to read more about [setting and listing environment variables](https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/), or [use a command-line option](#configuring-an-instance-with-command-line-options) instead.
@@ -57,7 +59,7 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 
 ### Advanced
 
-- [Analytics](/reference/features/configuration.md#analytics)
+- [Disable analytics](/reference/features/configuration.md#disable-analytics)
 - [Disable sentry](/reference/features/configuration.md#disable-sentry)
 - [Dumps](/reference/features/configuration.md#dumps-destination)
   - [Dumps destination](/reference/features/configuration.md#dumps-destination)
@@ -86,7 +88,7 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 
 **Environment variable**: `MEILI_DB_PATH`
 **CLI option**: `--db-path`
-**Default value**: `"./data.ms"`
+**Default value**: `"data.ms/"`
 
 Designates the location where database files will be created and retrieved.
 
@@ -131,14 +133,17 @@ Sets the HTTP address and port MeiliSearch will use.
 
 Sets the instance's master key, automatically protecting all routes except [`GET /health`](/reference/api/health.md).
 
+::: note
+You must supply an alphanumeric string when using this option.
+:::
+
 Providing a master key is mandatory when `--env` is set to `production`; if none is given, then MeiliSearch will throw an error and refuse to launch.
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
-
 [Learn more about MeiliSearch's use of security keys.](/reference/features/authentication.md)
 
-### Analytics
+### Disable analytics
 
 **Environment variable**: `MEILI_NO_ANALYTICS`
 **CLI option**: `--no-analytics`
@@ -155,8 +160,6 @@ MeiliSearch collects the following data from all instances that do not explicitl
 - Last update time
 - Number of updates
 - Number of documents per index
-
-If a user does not disable analytics, they may also provide an email address and their server provider by setting the environment variables `MEILI_USER_EMAIL` and `MEILI_SERVER_PROVIDER`.
 
 All collected data is used solely for the purpose of improving MeiliSearch. A full document describing why we collect this data and how we use it is forthcoming.
 
@@ -302,7 +305,7 @@ This command will throw an error if:
 - A database already exists
 - No valid snapshot can be found in the specified path
 
-This behavior can be modified with the [`--ignore-snapshot-if-db-exists`](#ignore-snapshot-if-db-exists) and [`--ignore-missing-snapshot`](#ignore-missing-snapshot) options, respectively. 
+This behavior can be modified with the [`--ignore-snapshot-if-db-exists`](#ignore-snapshot-if-db-exists) and [`--ignore-missing-snapshot`](#ignore-missing-snapshot) options, respectively.
 
 *This option is not available as an environment variable.*
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -264,7 +264,7 @@ On **Windows**, `getconf` returns a fixed size that will be allocated when launc
 **CLI option**: `--no-sentry`
 **Default value**: `false`
 
-Deactivate Sentry when set to `true`.
+Deactivates Sentry when set to `true`.
 
 We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that help us improve MeiliSearch.
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -222,49 +222,41 @@ SSL support tickets.
 
 **Environment variable**: `MEILI_MAX_MDB_SIZE`
 **CLI option**: `--max-mdb-size`
+**Default value**: `107374182400` (100 GiB)
 
-The maximum size, in bytes, of the `main` database. The `main` database stores the processed data.
+Set the maximum size of the `main` database, in bytes. The `main` database stores the processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
-The size must be a modulo value of your OS `PAGE_SIZE` otherwise it will throw an error.
-You can find out about the `PAGE_SIZE` with the following command:
+The maximum MDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
 ```bash
 getconf PAGE_SIZE
 ```
 
-Depending on the OS, it is either the size that will be allocated on launch or the maximum size the database can attain.
+On **UNIX** systems (e.g. Linux, MacOS) `getconf` returns the maximum page size.
 
-- On **UNIX** it is the maximum size.
-- On **Windows** it is a fixed size that will be allocated on launch.
-  Because this allocates 100GiB on MeiliSearch launch, a Windows user can use this option to decrease the size of the database.
+On **Windows**, `getconf` returns a fixed size that will be allocated when launching the instance.
 
-[To know more about storage in MeiliSearch look at this guide](/reference/under_the_hood/storage.md)
-
-**Default value**: `107374182400` (100 GiB)
+[Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 
 ### Max UDB size
 
 **Environment variable**: `MEILI_MAX_UDB_SIZE`
 **CLI option**: `--max-udb-size`
+**Default value**: `107374182400` (100 GiB)
 
-The maximum size, in bytes, of the `update` database. The `update` database stores the [pending updates](/learn/advanced/asynchronous_updates.md).
+The maximum size, in bytes, of the `update` database. The `update` database handles the [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `main` database, which only stores processed data.
 
-The size must be a modulo value of your OS `PAGE_SIZE` otherwise it will throw an error.
-You can find out about the `PAGE_SIZE` with the following command:
+The maximum UDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
 ```bash
 getconf PAGE_SIZE
 ```
 
-Depending on the OS, it is either the size that will be allocated on launch or the maximum size the database can attain.
+On **UNIX** systems (e.g. Linux, MacOS) `getconf` returns the maximum page size.
 
-- On **UNIX** it is the maximum size.
-- On **Windows** it is a fixed size that will be allocated on launch.
-  Because this allocates 100GiB on MeiliSearch launch, a Windows user can use this option to decrease the size of the database.
+On **Windows**, `getconf` returns a fixed size that will be allocated when launching the instance.
 
-[To know more about storage in MeiliSearch look at this guide](/reference/under_the_hood/storage.md)
-
-**Default value**: `107374182400` (100 GiB)
+[Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 
 ### Disable sentry
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -116,7 +116,6 @@ Configures the instance's environment. Value must be either `production` or `dev
 When the server environment is set to `development`, providing a master key is not mandatory. This is useful when debugging and prototyping, but dangerous otherwise since API routes are unprotected.
 :::
 
-
 ### HTTP address & port binding
 
 **Environment variable**: `MEILI_HTTP_ADDR`
@@ -224,15 +223,15 @@ Sets the maximum size of the `main` database. Value must be given in bytes.
 
 The `main` database stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
+On **UNIX** systems (e.g. Linux, MacOS) `--max-mdb-size` will always use the maximum page size.
+
+On **Windows**, `--max-mdb-size` must be a fixed value allocated at launch. By default, this is `100GiB`, but this option allows users to change that value.
+
 The maximum MDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
 ```bash
 getconf PAGE_SIZE
 ```
-
-On **UNIX** systems (e.g. Linux, MacOS) `getconf` returns the maximum page size.
-
-On **Windows**, `getconf` returns a fixed size that will be allocated when launching the instance.
 
 [Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 
@@ -246,15 +245,15 @@ Sets the maximum size of the `update` database. Value must be given in bytes.
 
 The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `main` database, which only stores processed data.
 
+On **UNIX** systems (e.g. Linux, MacOS) `--max-udb-size` will always use the maximum page size.
+
+On **Windows**, `--max-udb-size` must be a fixed value allocated at launch. By default this is `100GiB`, but this option allows users to change that value.
+
 The maximum UDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
 ```bash
 getconf PAGE_SIZE
 ```
-
-On **UNIX** systems (e.g. Linux, MacOS) `getconf` returns the maximum page size.
-
-On **Windows**, `getconf` returns a fixed size that will be allocated when launching the instance.
 
 [Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -125,7 +125,6 @@ If no master key is provided in a `production` environment, MeiliSearch will thr
 
 [Learn more about MeiliSearch's use of security keys.](/reference/features/authentication.md)
 
-
 ### Analytics
 
 **Environment variable**: `MEILI_NO_ANALYTICS`
@@ -334,7 +333,6 @@ Sets the server's SSL certificates.
 
 Value must be a path to PEM-formatted certificates. The first certificate should certify the KEYFILE supplied by `--ssl-key-path`. The last certificate should be a root CA.
 
-
 ### SSL key path
 
 **Environment variable**: `MEILI_SSL_KEY_PATH`
@@ -344,7 +342,6 @@ Value must be a path to PEM-formatted certificates. The first certificate should
 Sets the server's SSL keyfiles.
 
 Value must be a path to an RSA private key or PKCS8-encoded private key, both in PEM format.
-
 
 ### SSL OCSP path
 
@@ -356,7 +353,6 @@ Sets the server's OCSP file. *Optional*
 
 Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
 
-
 ### SSL require auth
 
 **Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
@@ -367,7 +363,6 @@ Makes SSL authentication mandatory.
 
 Sends a fatal alert if the client does not complete client authentication.
 
-
 ### SSL resumption
 
 **Environment variable**: `MEILI_SSL_RESUMPTION`
@@ -375,7 +370,6 @@ Sends a fatal alert if the client does not complete client authentication.
 **Default value**: `None`
 
 Activates SSL session resumption.
-
 
 ### SSL tickets
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -223,7 +223,7 @@ Sets the maximum size of the `main` database. Value must be given in bytes.
 
 The `main` database stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
-On **UNIX** systems (e.g. Linux, MacOS) `--max-mdb-size` will always use the maximum page size.
+On **UNIX** systems (e.g. Linux, MacOS) `--max-mdb-size` will use the maximum page size by default.
 
 On **Windows**, `--max-mdb-size` must be a fixed value allocated at launch. By default, this is `100GiB`, but this option allows users to change that value.
 
@@ -245,7 +245,7 @@ Sets the maximum size of the `update` database. Value must be given in bytes.
 
 The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `main` database, which only stores processed data.
 
-On **UNIX** systems (e.g. Linux, MacOS) `--max-udb-size` will always use the maximum page size.
+On **UNIX** systems (e.g. Linux, MacOS) `--max-udb-size` will use the maximum page size by default.
 
 On **Windows**, `--max-udb-size` must be a fixed value allocated at launch. By default this is `100GiB`, but this option allows users to change that value.
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -16,7 +16,7 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Configuring an instance with environment variables
 
-Environment variables are always identical to the command-line flags, but prepended with `MEILI_` and written in upper case.
+Environment variables are always identical to the command-line flags, but prepended with `MEILI_` and written in uppercase.
 
 ```bash
 export MEILI_DB_PATH=./meilifiles
@@ -70,7 +70,7 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 - [Max UDB Size](/reference/features/configuration.md#max-udb-size)
 - [SSL Configuration](/reference/features/configuration.md#ssl-authentication-path):
   - [SSL Authentication Path](/reference/features/configuration.md#ssl-authentication-path)
-  - [SSL Certicates Path](/reference/features/configuration.md#ssl-certificates-path)
+  - [SSL Certificates Path](/reference/features/configuration.md#ssl-certificates-path)
   - [SSL Key Path](/reference/features/configuration.md#ssl-key-path)
   - [SSL OCSP Path](/reference/features/configuration.md#ssl-ocsp-path)
   - [SSL Require Auth](/reference/features/configuration.md#ssl-require-auth)
@@ -100,7 +100,7 @@ Set the HTTP address and port the MeiliSearch instance server will use.
 **CLI option**: `--master-key`
 **Default value**: `None`
 
-Set an instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when environment is set to `production`.
+Set an instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when `environment` is set to `production`.
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
@@ -142,7 +142,7 @@ By default, MeiliSearch collects the following data from all instances that do n
 - Number of updates
 - Number of documents per index
 
-Additionally, a user does not disable analytics, they may also provide an email address and their server provider by setting the environment variables `MEILI_USER_EMAIL` and `MEILI_SERVER_PROVIDER`.
+Additionally, if a user does not disable analytics, they may also provide an email address and their server provider by setting the environment variables `MEILI_USER_EMAIL` and `MEILI_SERVER_PROVIDER`.
 
 All collected data is used solely for the purpose of improving MeiliSearch.
 
@@ -292,7 +292,7 @@ Sets the directory path where MeiliSearch will create snapshots.
 **CLI option**: `--snapshot-interval-sec`
 **Default value**: `86400` (1 day)
 
-Defines the interval between the creation of each snapshot. Value should be given in seconds.
+Defines the interval between the creation of each snapshot. Value must be given in seconds.
 
 ### Import Snapshot
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -47,13 +47,20 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 ### General
 
 - [Database path](/reference/features/configuration.md#database-path)
+- [Environment](/reference/features/configuration.md#environment)
 - [HTTP address & port binding](/reference/features/configuration.md#http-address-port-binding)
 - [Master key](/reference/features/configuration.md#master-key)
-- [Environment](/reference/features/configuration.md#environment)
 
 ### Advanced
 
 - [Analytics](/reference/features/configuration.md#analytics)
+- [Disable Sentry](/reference/features/configuration.md#disable-sentry)
+- [Dumps](/reference/features/configuration.md#dumps-destination)
+  - [Dumps Destination](/reference/features/configuration.md#dumps-destination)
+  - [Import Dump](/reference/features/configuration.md#import-dump)
+  - [Dump Batch Size](/reference/features/configuration.md#dump-batch-size)
+- [Max MDB Size](/reference/features/configuration.md#max-mdb-size)
+- [Max UDB Size](/reference/features/configuration.md#max-udb-size)
 - [Payload Limit Size](/reference/features/configuration.md#payload-limit-size)
 - [Snapshots](/reference/features/configuration.md#schedule-snapshot-creation):
   - [Schedule Snapchot Creation](/reference/features/configuration.md#schedule-snapshot-creation)
@@ -62,12 +69,6 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
   - [Import Snapshot](/reference/features/configuration.md#import-snapshot)
   - [Ignore Missing Snapshot](/reference/features/configuration.md#ignore-missing-snapshot)
   - [Ignore Snapshot if DB Exists](/reference/features/configuration.md#ignore-snapshot-if-db-exists)
-- [Dumps](/reference/features/configuration.md#dumps-destination)
-  - [Dumps Destination](/reference/features/configuration.md#dumps-destination)
-  - [Import Dump](/reference/features/configuration.md#import-dump)
-  - [Dump Batch Size](/reference/features/configuration.md#dump-batch-size)
-- [Max MDB Size](/reference/features/configuration.md#max-mdb-size)
-- [Max UDB Size](/reference/features/configuration.md#max-udb-size)
 - [SSL Configuration](/reference/features/configuration.md#ssl-authentication-path):
   - [SSL Authentication Path](/reference/features/configuration.md#ssl-authentication-path)
   - [SSL Certificates Path](/reference/features/configuration.md#ssl-certificates-path)
@@ -76,7 +77,6 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
   - [SSL Require Auth](/reference/features/configuration.md#ssl-require-auth)
   - [SSL Resumption](/reference/features/configuration.md#ssl-resumption)
   - [SSL Tickets](/reference/features/configuration.md#ssl-tickets)
-- [Disable Sentry](/reference/features/configuration.md#disable-sentry)
 
 ### Database path
 
@@ -85,6 +85,21 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 **Default value**: `"./data.ms"`
 
 Set the location of the database file.
+
+### Environment
+
+**Environment variable**: `MEILI_ENV`
+**CLI option**: `--env`
+**Default value**: `development`
+
+By default, MeiliSearch runs in `development` mode.
+
+- `production`: setting a [master key](/reference/features/authentication.md) is **mandatory**.
+- `development`: setting a [master key](/reference/features/authentication.md) is **optional**. Log level is automatically set to `info`.
+
+If the server is running in `development` mode, logs are more verbose and providing a master key is not mandatory. This is useful when debugging, but dangerous otherwise since update routes are unprotected.
+
+The [web interface](/reference/features/web_interface.md#web-interface) is disabled in `production` mode.
 
 ### HTTP address & port binding
 
@@ -109,20 +124,6 @@ If no master key is provided in a `production` environment, the MeiliSearch inst
 [Learn more about MeiliSearch's use of security keys in this guide.](/reference/features/authentication.md)
 
 
-### Environment
-
-**Environment variable**: `MEILI_ENV`
-**CLI option**: `--env`
-**Default value**: `development`
-
-By default, MeiliSearch runs in `development` mode.
-
-- `production`: setting a [master key](/reference/features/authentication.md) is **mandatory**.
-- `development`: setting a [master key](/reference/features/authentication.md) is **optional**. Log level is automatically set to `info`.
-
-If the server is running in `development` mode, logs are more verbose and providing a master key is not mandatory. This is useful when debugging, but dangerous otherwise since update routes are unprotected.
-
-The [web interface](/reference/features/web_interface.md#web-interface) is disabled in `production` mode.
 
 ### Analytics
 
@@ -148,75 +149,56 @@ All collected data is used solely for the purpose of improving MeiliSearch.
 
 A full document describing why we collect this data and how we use it is forthcoming.
 
-### Payload limit size
+### Disable Sentry
 
-**Environment variable**: `MEILI_HTTP_PAYLOAD_SIZE_LIMIT`
-**CLI option**: `--http-payload-size-limit`
-**Default value**: `104857600` (~100MB)
+**Environment variable**: `MEILI_NO_SENTRY`
+**CLI option**: `--no-sentry`
+**Default value**: `false`
 
-Set the maximum size, in bytes, of accepted JSON payloads.
+Deactivates Sentry when set to `true`.
 
-### SSL authentication path
+We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that help us improve MeiliSearch.
 
-**Environment variable**: `MEILI_SSL_AUTH_PATH`
-**CLI option**: `--ssl-auth-path`
-**Default value**: `None`
+### Dumps Destination
 
-Enable client authentication and accept certificates signed by the roots provided in CERTFILE.
+**Environment variable**: `MEILI_DUMPS_DIR`
+**CLI option**: `--dumps-dir`
+**Default value**: `dumps/`
 
-### SSL Certificates Path
+Sets the directory for dump file storage.
 
-**Environment variable**: `MEILI_SSL_CERT_PATH`
-**CLI option**: `--ssl-cert-path`
+[Learn more about creating dumps of MeiliSearch instances](/reference/api/dump.md).
 
-Read server certificates from CERTFILE. This should contain PEM-format certificates in the right order (the first certificate should certify KEYFILE, the last should be a root CA).
+### Import Dump
 
-**Default value**: `None`
+**Environment variable**: N/A
+**CLI option**: `--import-dump`
+**Default value**: `none`
 
-### SSL key path
+Imports a dump located in the specified path. Must be a `.dump` file.
 
-**Environment variable**: `MEILI_SSL_KEY_PATH`
-**CLI option**: `--ssl-key-path`
+The MeiliSearch instance will only be launched once the dump data has been fully indexed.
 
-Read private key from KEYFILE.  This should be a RSA private key or PKCS8-encoded private key, in PEM format.
+This option is not available as an environment variable.
 
-**Default value**: `None`
+### Dump Batch Size
 
-### SSL OCSP path
+**Environment variable**: `MEILI_DUMP_BATCH_SIZE`
+**CLI option**: `--dump-batch-size`
+**Default value**: `1024`
 
-**Environment variable**: `MEILI_SSL_OCSP_PATH`
-**CLI option**: `--ssl-ocsp-path`
+Sets the batch size used in the dump importation process. This number corresponds to the maximum number of documents indexed in each batch. A larger value will take less time but use more memory.
 
-Read DER-encoded OCSP response from OCSPFILE and staple to certificate. *Optional*.
+Bigger batch sizes can speed up the import process, but require more RAM. Setting a larger size than a system can handle might cause a MeiliSearch instance to crash; if this happens, consider reducing the batch size.
 
-**Default value**: `None`
+**Example**
+A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSearch will not index all 2600 in one go. Instead, the instance will:
 
-### SSL require auth
+1. First index documents 0 -> 999 (1000 docs)
+2. Then index documents 1000 -> 1999 (1000 docs)
+3. And finally index documents 2000 -> 2599 (600 docs)
 
-**Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
-**CLI option**: `--ssl-require-auth`
-
-Send a fatal alert if the client does not complete client authentication.
-
-**Default value**: `None`
-
-### SSL resumption
-
-**Environment variable**: `MEILI_SSL_RESUMPTION`
-**CLI option**: `--ssl-resumption`
-
-SSL support session resumption.
-
-**Default value**: `None`
-
-### SSL tickets
-
-**Environment variable**: `MEILI_SSL_TICKETS`
-**CLI option**: `--ssl-tickets`
-
-SSL support tickets.
-
-**Default value**: `None`
+[Learn more about MeiliSearch dumps](/reference/features/dumps.md)
 
 ### Max MDB size
 
@@ -258,15 +240,13 @@ On **Windows**, `getconf` returns a fixed size that will be allocated when launc
 
 [Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 
-### Disable sentry
+### Payload Limit Size
 
-**Environment variable**: `MEILI_NO_SENTRY`
-**CLI option**: `--no-sentry`
-**Default value**: `false`
+**Environment variable**: `MEILI_HTTP_PAYLOAD_SIZE_LIMIT`
+**CLI option**: `--http-payload-size-limit`
+**Default value**: `104857600` (~100MB)
 
-Deactivates Sentry when set to `true`.
-
-We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that help us improve MeiliSearch.
+Set the maximum size, in bytes, of accepted JSON payloads.
 
 ### Schedule snapshot creation
 
@@ -333,43 +313,64 @@ This command will throw an error if `--import-snapshot` is not defined.
 
 This option is not available as an environment variable.
 
-### Dumps destination
+### SSL Authentication Path
 
-**Environment variable**: `MEILI_DUMPS_DIR`
-**CLI option**: `--dumps-dir`
-**Default value**: `dumps/`
+**Environment variable**: `MEILI_SSL_AUTH_PATH`
+**CLI option**: `--ssl-auth-path`
+**Default value**: `None`
 
-Sets the directory for dump file storage.
+Enable client authentication and accept certificates signed by the roots provided in CERTFILE.
 
-[Learn more about creating dumps of MeiliSearch instances](/reference/api/dump.md).
+### SSL Certificates Path
 
-### Import dump
+**Environment variable**: `MEILI_SSL_CERT_PATH`
+**CLI option**: `--ssl-cert-path`
 
-**Environment variable**: N/A
-**CLI option**: `--import-dump`
-**Default value**: `none`
+Read server certificates from CERTFILE. This should contain PEM-format certificates in the right order (the first certificate should certify KEYFILE, the last should be a root CA).
 
-Imports a dump located in the specified path. Must be a `.dump` file.
+**Default value**: `None`
 
-The MeiliSearch instance will only be launched once the dump data has been fully indexed.
+### SSL Key Path
 
-This option is not available as an environment variable.
+**Environment variable**: `MEILI_SSL_KEY_PATH`
+**CLI option**: `--ssl-key-path`
 
-### Dump batch size
+Read private key from KEYFILE.  This should be a RSA private key or PKCS8-encoded private key, in PEM format.
 
-**Environment variable**: `MEILI_DUMP_BATCH_SIZE`
-**CLI option**: `--dump-batch-size`
-**Default value**: `1024`
+**Default value**: `None`
 
-Sets the batch size used in the dump importation process. This number corresponds to the maximum number of documents indexed in each batch. A larger value will take less time but use more memory.
+### SSL OCSP path
 
-Bigger batch sizes can speed up the import process, but require more RAM. Setting a larger size than a system can handle might cause a MeiliSearch instance to crash; if this happens, consider reducing the batch size.
+**Environment variable**: `MEILI_SSL_OCSP_PATH`
+**CLI option**: `--ssl-ocsp-path`
 
-**Example**
-A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSearch will not index all 2600 in one go. Instead, the instance will:
+Read DER-encoded OCSP response from OCSPFILE and staple to certificate. *Optional*.
 
-1. First index documents 0 -> 999 (1000 docs)
-2. Then index documents 1000 -> 1999 (1000 docs)
-3. And finally index documents 2000 -> 2599 (600 docs)
+**Default value**: `None`
 
-[Learn more about MeiliSearch dumps](/reference/features/dumps.md)
+### SSL Require Auth
+
+**Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
+**CLI option**: `--ssl-require-auth`
+
+Send a fatal alert if the client does not complete client authentication.
+
+**Default value**: `None`
+
+### SSL Resumption
+
+**Environment variable**: `MEILI_SSL_RESUMPTION`
+**CLI option**: `--ssl-resumption`
+
+SSL support session resumption.
+
+**Default value**: `None`
+
+### SSL Tickets
+
+**Environment variable**: `MEILI_SSL_TICKETS`
+**CLI option**: `--ssl-tickets`
+
+SSL support tickets.
+
+**Default value**: `None`

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -1,10 +1,10 @@
 # Configuration
 
-Options can be passed to a MeiliSearch instance through **environment variables** and **command line options**.
+You can configure MeiliSearch with **environment variables** and **command line options**.
 
 ## Configuring an instance with command-line flags
 
-Options and their respective arguments must be passed when launching the instance.
+Pass options and their respective values as command-line flags when launching a MeiliSearch instance.
 
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
@@ -16,7 +16,7 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Configuring an instance with environment variables
 
-Environment variables are always identical to the command-line flags, but prepended with `MEILI_` and written in uppercase.
+Environment variables are always identical to the command-line flags, but prepended with `MEILI_` and written in uppercase. Some options (e.g. `--import-snapshots`) are not available as environment variables.
 
 ```bash
 export MEILI_DB_PATH=./meilifiles
@@ -30,9 +30,9 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Usage
 
-Command-line flags take precedence over environment variables. If an option is specified both as a flag and an environment variable, the command-line flag and its respective value will be used.
+Command-line flags take precedence over environment variables. If an option is specified both as a flag and as an environment variable, MeiliSearch will use the command-line flag and its respective value.
 
-All options should have a value specified. Adding a command-line flag or environment variable without a value will throw an error.
+All options must specify a value. Using a command-line flag or environment variable without specifying a value will throw an error and interrupt the launch process.
 
 ```bash
 ./meilisearch --schedule-snapshot
@@ -84,7 +84,7 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 **CLI option**: `--db-path`
 **Default value**: `"./data.ms"`
 
-Set the location of the database file.
+Sets the location of the database file.
 
 ### Environment
 
@@ -92,14 +92,16 @@ Set the location of the database file.
 **CLI option**: `--env`
 **Default value**: `development`
 
-By default, MeiliSearch runs in `development` mode.
+Configures the instance's environment. Value must be either `production` or `development`.
 
-- `production`: setting a [master key](/reference/features/authentication.md) is **mandatory**.
-- `development`: setting a [master key](/reference/features/authentication.md) is **optional**. Log level is automatically set to `info`.
+The main differences between the two environments are:
 
-If the server is running in `development` mode, logs are more verbose and providing a master key is not mandatory. This is useful when debugging, but dangerous otherwise since update routes are unprotected.
+- `production`: setting a [master key](/reference/features/authentication.md) is **mandatory**. Logging is disabled
+- `development`: setting a [master key](/reference/features/authentication.md) is **optional**. Log level is automatically set to `info`
 
-The [web interface](/reference/features/web_interface.md#web-interface) is disabled in `production` mode.
+When the server environment is set to `development`, providing a master key is not mandatory. This is useful when debugging and prototyping, but dangerous otherwise since API update routes are unprotected.
+
+Both logging and the [web interface](/reference/features/web_interface.md#web-interface) are disabled in `production`.
 
 ### HTTP address & port binding
 
@@ -107,7 +109,7 @@ The [web interface](/reference/features/web_interface.md#web-interface) is disab
 **CLI option**: `--http-addr`
 **Default value**: `"127.0.0.1:7700"`
 
-Set the HTTP address and port the MeiliSearch instance server will use.
+Sets the HTTP address and port MeiliSearch will use.
 
 ### Master Key
 
@@ -115,14 +117,13 @@ Set the HTTP address and port the MeiliSearch instance server will use.
 **CLI option**: `--master-key`
 **Default value**: `None`
 
-Set an instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when `environment` is set to `production`.
+Sets an instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when `--env` is set to `production`.
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
-If no master key is provided in a `production` environment, the MeiliSearch instance will throw an error and refuse to launch.
+If no master key is provided in a `production` environment, MeiliSearch will throw an error and refuse to launch.
 
 [Learn more about MeiliSearch's use of security keys in this guide.](/reference/features/authentication.md)
-
 
 
 ### Analytics
@@ -131,7 +132,7 @@ If no master key is provided in a `production` environment, the MeiliSearch inst
 **CLI option**: `--no-analytics`
 **Default value**: `false`
 
-If set to `true`, deactivates MeiliSearch's built-in analytics and telemetry.
+Deactivates MeiliSearch's built-in analytics and telemetry when set to `true`.
 
 By default, MeiliSearch collects the following data from all instances that do not explicitly opt-out:
 
@@ -143,11 +144,9 @@ By default, MeiliSearch collects the following data from all instances that do n
 - Number of updates
 - Number of documents per index
 
-Additionally, if a user does not disable analytics, they may also provide an email address and their server provider by setting the environment variables `MEILI_USER_EMAIL` and `MEILI_SERVER_PROVIDER`.
+If a user does not disable analytics, they may also provide an email address and their server provider by setting the environment variables `MEILI_USER_EMAIL` and `MEILI_SERVER_PROVIDER`.
 
-All collected data is used solely for the purpose of improving MeiliSearch.
-
-A full document describing why we collect this data and how we use it is forthcoming.
+All collected data is used solely for the purpose of improving MeiliSearch. A full document describing why we collect this data and how we use it is forthcoming.
 
 ### Disable Sentry
 
@@ -165,7 +164,7 @@ We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that h
 **CLI option**: `--dumps-dir`
 **Default value**: `dumps/`
 
-Sets the directory for dump file storage.
+Sets the directory where MeiliSearch will store dump files.
 
 [Learn more about creating dumps of MeiliSearch instances](/reference/api/dump.md).
 
@@ -175,11 +174,11 @@ Sets the directory for dump file storage.
 **CLI option**: `--import-dump`
 **Default value**: `none`
 
-Imports a dump located in the specified path. Must be a `.dump` file.
+Imports a dump located in the specified path. Path must point to a `.dump` file.
 
-The MeiliSearch instance will only be launched once the dump data has been fully indexed.
+MeiliSearch will only launch once the dump data has been fully indexed. The time this takes depends on the size of the dump file and the value of `--dump-batch-size`.
 
-This option is not available as an environment variable.
+*This option is not available as an environment variable.*
 
 ### Dump Batch Size
 
@@ -187,12 +186,12 @@ This option is not available as an environment variable.
 **CLI option**: `--dump-batch-size`
 **Default value**: `1024`
 
-Sets the batch size used in the dump importation process. This number corresponds to the maximum number of documents indexed in each batch. A larger value will take less time but use more memory.
+Sets the maximum number of documents indexed in a batch when importing a dump file.
 
-Bigger batch sizes can speed up the import process, but require more RAM. Setting a larger size than a system can handle might cause a MeiliSearch instance to crash; if this happens, consider reducing the batch size.
+Bigger batch sizes can speed up the import process, but will use more RAM. Setting a larger batch size than a system can handle might cause MeiliSearch to crash; if this happens, consider reducing the batch size.
 
 **Example**
-A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSearch will not index all 2600 in one go. Instead, the instance will:
+A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSearch will not index all 2600 documents in one go. Instead, the instance will:
 
 1. First index documents 0 -> 999 (1000 docs)
 2. Then index documents 1000 -> 1999 (1000 docs)
@@ -206,7 +205,9 @@ A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSear
 **CLI option**: `--max-mdb-size`
 **Default value**: `107374182400` (100 GiB)
 
-Set the maximum size of the `main` database, in bytes. The `main` database stores the processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
+Set the maximum size of the `main` database. Value must be given in bytes.
+
+The `main` database stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
 The maximum MDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
@@ -226,7 +227,9 @@ On **Windows**, `getconf` returns a fixed size that will be allocated when launc
 **CLI option**: `--max-udb-size`
 **Default value**: `107374182400` (100 GiB)
 
-The maximum size, in bytes, of the `update` database. The `update` database handles the [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `main` database, which only stores processed data.
+Sets the maximum size of the `update` database. Value must be given in bytes.
+
+The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `main` database, which only stores processed data.
 
 The maximum UDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
@@ -246,7 +249,7 @@ On **Windows**, `getconf` returns a fixed size that will be allocated when launc
 **CLI option**: `--http-payload-size-limit`
 **Default value**: `104857600` (~100MB)
 
-Set the maximum size, in bytes, of accepted JSON payloads.
+Sets the maximum size of accepted JSON payloads. Value must be given in bytes.
 
 ### Schedule snapshot creation
 
@@ -264,7 +267,7 @@ Activates scheduled snapshots when set to `true`. Disabled by default.
 **CLI option**: `--snapshot-dir`
 **Default value**: `snapshots/`
 
-Sets the directory path where MeiliSearch will create snapshots.
+Sets the directory where MeiliSearch will store snapshots.
 
 ### Snapshot Interval
 
@@ -272,22 +275,22 @@ Sets the directory path where MeiliSearch will create snapshots.
 **CLI option**: `--snapshot-interval-sec`
 **Default value**: `86400` (1 day)
 
-Defines the interval between the creation of each snapshot. Value must be given in seconds.
+Defines the interval between each snapshot. Value must be given in seconds.
 
 ### Import Snapshot
 
 **Environment variable**: N/A
 **CLI option**: `--import-snapshot`
-**Default value**: `none`
+**Default value**: `None`
 
-Launches an instance with a previously-generated snapshot.
+Launches an instance by importing a previously-generated snapshot.
 
 This command will throw an error if:
 
 - A database already exists
 - No valid snapshot can be found in the specified path
 
-This option is not available as an environment variable.
+*This option is not available as an environment variable.*
 
 ### Ignore missing snapshot
 
@@ -295,11 +298,11 @@ This option is not available as an environment variable.
 **CLI option**: `--ignore-missing-snapshot`
 **Default value**: `false`
 
-Prevents a MeiliSearch instance from throwing an error when the path supplied to `--import-snapshot` does not point to a valid snapshot file.
+Prevents a MeiliSearch instance from throwing an error when `--import-snapshot` does not point to a valid snapshot file.
 
 This command will throw an error if `--import-snapshot` is not defined.
 
-This option is not available as an environment variable.
+*This option is not available as an environment variable.*
 
 ### Ignore snapshot if DB exists
 
@@ -307,11 +310,11 @@ This option is not available as an environment variable.
 **CLI option**: `--ignore-snapshot-if-db-exists`
 **Default value**: `false`
 
-Prevents a MeiliSearch instance with an existing database from throwing an error when `--import-snapshot` is used.
+Prevents a MeiliSearch instance with an existing database from throwing an error when using `--import-snapshot`.
 
 This command will throw an error if `--import-snapshot` is not defined.
 
-This option is not available as an environment variable.
+*This option is not available as an environment variable.*
 
 ### SSL Authentication Path
 
@@ -319,58 +322,65 @@ This option is not available as an environment variable.
 **CLI option**: `--ssl-auth-path`
 **Default value**: `None`
 
-Enable client authentication and accept certificates signed by the roots provided in CERTFILE.
+Enables client authentication in the specified path.
 
 ### SSL Certificates Path
 
 **Environment variable**: `MEILI_SSL_CERT_PATH`
 **CLI option**: `--ssl-cert-path`
-
-Read server certificates from CERTFILE. This should contain PEM-format certificates in the right order (the first certificate should certify KEYFILE, the last should be a root CA).
-
 **Default value**: `None`
+
+Sets the server's SSL certificates.
+
+Value must be a path to PEM-formatted certificates. The first certificate should certify the KEYFILE supplied by `--ssl-key-path`. The last certificate should be a root CA.
+
 
 ### SSL Key Path
 
 **Environment variable**: `MEILI_SSL_KEY_PATH`
 **CLI option**: `--ssl-key-path`
-
-Read private key from KEYFILE.  This should be a RSA private key or PKCS8-encoded private key, in PEM format.
-
 **Default value**: `None`
+
+Sets the server's SSL keyfiles.
+
+Value must be a path to an RSA private key or PKCS8-encoded private key, both in PEM format.
+
 
 ### SSL OCSP path
 
 **Environment variable**: `MEILI_SSL_OCSP_PATH`
 **CLI option**: `--ssl-ocsp-path`
-
-Read DER-encoded OCSP response from OCSPFILE and staple to certificate. *Optional*.
-
 **Default value**: `None`
+
+Sets the server's OCSP file. *Optional*
+
+Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
+
 
 ### SSL Require Auth
 
 **Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
 **CLI option**: `--ssl-require-auth`
-
-Send a fatal alert if the client does not complete client authentication.
-
 **Default value**: `None`
+
+Makes SSL authentication mandatory.
+
+Sends a fatal alert if the client does not complete client authentication.
+
 
 ### SSL Resumption
 
 **Environment variable**: `MEILI_SSL_RESUMPTION`
 **CLI option**: `--ssl-resumption`
-
-SSL support session resumption.
-
 **Default value**: `None`
+
+Activates SSL session resumption.
+
 
 ### SSL Tickets
 
 **Environment variable**: `MEILI_SSL_TICKETS`
 **CLI option**: `--ssl-tickets`
-
-SSL support tickets.
-
 **Default value**: `None`
+
+Activates SSL tickets.

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -136,7 +136,7 @@ If no master key is provided in a `development` environment, all routes will be 
 
 Deactivates MeiliSearch's built-in telemetry when set to `true`.
 
-By default, MeiliSearch collects the following data from all instances that do not explicitly opt-out:
+MeiliSearch collects the following data from all instances that do not explicitly opt-out:
 
 - Application version
 - Environment (development or production)

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -18,7 +18,9 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Configuring an instance with environment variables
 
-Environment variables are always identical to the command-line flags, but prepended with `MEILI_` and written in uppercase. Some options (e.g. `--import-snapshots`) are not available as environment variables.
+In order to configure a MeiliSearch instance using environment variables, you have to set the environment variable prior to launching the instance. If it's your first time doing this you may want to read more about [setting and listing environment variables](https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/), or [use a command-line option](#configuring-an-instance-with-command-line-options) instead.
+
+Environment variables are always identical to the corresponding command-line option, but prepended with `MEILI_` and written in all uppercase. Some options (e.g. `--import-snapshots`) are not available as environment variables.
 
 ```bash
 export MEILI_DB_PATH=./meilifiles
@@ -86,7 +88,7 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 **CLI option**: `--db-path`
 **Default value**: `"./data.ms"`
 
-Sets the location of the database file.
+Designates the location where database files will be created and retrieved.
 
 ### Environment
 
@@ -96,14 +98,22 @@ Sets the location of the database file.
 
 Configures the instance's environment. Value must be either `production` or `development`.
 
-The main differences between the two environments are:
+`production`:
 
-- `production`: setting a [master key](/reference/features/authentication.md) is **mandatory**. Logging is disabled
-- `development`: setting a [master key](/reference/features/authentication.md) is **optional**. Log level is automatically set to `info`
+- Setting a [master key](/reference/features/authentication.md) is **mandatory**
+- Logging is disabled
+- The [web interface](/reference/features/web_interface.md#web-interface) is disabled
 
-When the server environment is set to `development`, providing a master key is not mandatory. This is useful when debugging and prototyping, but dangerous otherwise since API update routes are unprotected.
+`development`:
 
-Logging and the [web interface](/reference/features/web_interface.md#web-interface) are disabled in `production`.
+- Setting a [master key](/reference/features/authentication.md) is **optional**
+- Logs are printed to the standard output
+- The web interface is enabled
+
+::: tip
+When the server environment is set to `development`, providing a master key is not mandatory. This is useful when debugging and prototyping, but dangerous otherwise since API routes are unprotected.
+:::
+
 
 ### HTTP address & port binding
 
@@ -140,7 +150,7 @@ MeiliSearch collects the following data from all instances that do not explicitl
 
 - Application version
 - Environment (development or production)
-- Number of days since the first start (segment development/production
+- Number of days instance has been active since creation
 - Database size
 - Last update time
 - Number of updates

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -104,7 +104,7 @@ Set an instance's master key, automatically protecting all routes except `GET /h
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
-If no master key is provided in a `production` environment, the MeiliSearch instance will throw an error and refuse to launch. 
+If no master key is provided in a `production` environment, the MeiliSearch instance will throw an error and refuse to launch.
 
 [Learn more about MeiliSearch's use of security keys in this guide.](/reference/features/authentication.md)
 
@@ -130,7 +130,7 @@ The [web interface](/reference/features/web_interface.md#web-interface) is disab
 **CLI option**: `--no-analytics`
 **Default value**: `false`
 
-If set to `true`, deactivates MeiliSearch's built-in analytics and telemetry. 
+If set to `true`, deactivates MeiliSearch's built-in analytics and telemetry.
 
 By default, MeiliSearch collects the following data from all instances that do not explicitly opt-out:
 
@@ -160,12 +160,11 @@ Set the maximum size, in bytes, of accepted JSON payloads.
 
 **Environment variable**: `MEILI_SSL_AUTH_PATH`
 **CLI option**: `--ssl-auth-path`
-
-Enable client authentication, and accept certificates signed by those roots provided in CERTFILE
-
 **Default value**: `None`
 
-### SSL certificates path
+Enable client authentication and accept certificates signed by the roots provided in CERTFILE.
+
+### SSL Certificates Path
 
 **Environment variable**: `MEILI_SSL_CERT_PATH`
 **CLI option**: `--ssl-cert-path`

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-Options can be passed to a MeiliSearch instance through **environment variables** and **command line options**. 
+Options can be passed to a MeiliSearch instance through **environment variables** and **command line options**.
 
 ## Configuring an instance with command-line flags
 
@@ -82,56 +82,38 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 
 **Environment variable**: `MEILI_DB_PATH`
 **CLI option**: `--db-path`
-
-Defines the location for the database files.
-
 **Default value**: `"./data.ms"`
+
+Set the location of the database file.
 
 ### HTTP address & port binding
 
 **Environment variable**: `MEILI_HTTP_ADDR`
 **CLI option**: `--http-addr`
+**Default value**: `"127.0.0.1:7700"`
 
 The address the HTTP server will listen on.
 
-**Default value**: `"127.0.0.1:7700"`
-
-### Master key
+### Master Key
 
 **Environment variable**: `MEILI_MASTER_KEY`
 **CLI option**: `--master-key`
-
-The master key allowing you to do everything on the server. If no master key is provided all routes will be accessible without keys. This is only possible if you are in `development` environment. An error is thrown if you try to start MeiliSearch without any master key when the environment is set to `production`.
-
-[Learn more about the permission and authentication in this guide.](/reference/features/authentication.md)
-
 **Default value**: `None`
 
-### Analytics
+The master key granting access to all MeiliSearch's API routes. Providing a mandatory key is mandatory when environment is set to `production`.
 
-**Environment variable**: `MEILI_NO_ANALYTICS`
-**CLI option**: `--no-analytics`
+If no master key is provided all routes will be unprotected and publicly accessible.
 
-Deactivates analytics.
+This is only possible if you are in `development` environment. An error is thrown if you try to start MeiliSearch without any master key when the environment is set to `production`.
 
-Analytics allow us to know how many users are using MeiliSearch and the following:
+[Learn more about MeiliSearch's use of security keys in this guide.](/reference/features/authentication.md)
 
-- The application version.
-- The environment: development/production.
-- The number of days since the first start: Segment development/production.
-- The user email: (*Optional*) If the user wants to have alerts.
-- The server provider: (*Optional*).
-- The database size.
-- The last update time.
-- The number of updates.
-- The number of documents per index.
-
-**Default value**: `false`
 
 ### Environment
 
 **Environment variable**: `MEILI_ENV`
 **CLI option**: `--env`
+**Default value**: `development`
 
 By default, MeiliSearch runs in `development` mode.
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -272,63 +272,66 @@ We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that h
 
 **Environment variable**: `MEILI_SCHEDULE_SNAPSHOT`
 **CLI option**: `--schedule-snapshot`
-
-To activate scheduled snapshots, set this value to `true`. Disabled by default.
-
-[Read more about snapshots](/reference/features/snapshots.md).
-
 **Default value**: `false`
+
+Activates scheduled snapshots when set to `true`. Disabled by default.
+
+[Learn more about snapshots](/reference/features/snapshots.md).
 
 ### Snapshot destination
 
 **Environment variable**: `MEILI_SNAPSHOT_DIR`
 **CLI option**: `--snapshot-dir`
-
-The directory path where MeiliSearch will create snapshots.
-
 **Default value**: `snapshots/`
 
-### Snapshot interval
+Sets the directory path where MeiliSearch will create snapshots.
+
+### Snapshot Interval
 
 **Environment variable**: `MEILI_SNAPSHOT_INTERVAL_SEC`
 **CLI option**: `--snapshot-interval-sec`
-
-Defines the time gap in seconds between each snapshot creation.
-
 **Default value**: `86400` (1 day)
 
-### Import snapshot
+Defines the interval between the creation of each snapshot. Value should be given in seconds.
 
+### Import Snapshot
+
+**Environment variable**: N/A
 **CLI option**: `--import-snapshot`
+**Default value**: `none`
 
-The path of the snapshot file to import.
+Launches an instance with a previously-generated snapshot.
 
-This command will stop the process if:
+This command will throw an error if:
 
 - A database already exists
-- No snapshot exists in the given path.
+- No valid snapshot can be found in the specified path
 
-If this command is not called, no snapshot will be imported.
+This option is not available as an environment variable.
 
 ### Ignore missing snapshot
 
+**Environment variable**: N/A
 **CLI option**: `--ignore-missing-snapshot`
-
-The engine ignores missing snapshots and does not throw an error in this case.
-
-Requires `--import-snapshot` to be defined.
-
 **Default value**: `false`
+
+Prevents a MeiliSearch instance from throwing an error when the path supplied to `--import-snapshot` does not point to a valid snapshot file.
+
+This command will throw an error if `--import-snapshot` is not defined.
+
+This option is not available as an environment variable.
 
 ### Ignore snapshot if DB exists
 
+**Environment variable**: N/A
 **CLI option**: `--ignore-snapshot-if-db-exists`
-
-If a database already exists, MeiliSearch will attempt to launch using that database instead of importing a snapshot. No error is thrown in this case.
-
-Requires `--import-snapshot` to be defined.
-
 **Default value**: `false`
+
+Prevents a MeiliSearch instance with an existing database from throwing an error when `--import-snapshot` is used.
+
+This command will throw an error if `--import-snapshot` is not defined.
+
+This option is not available as an environment variable.
 
 ### Dumps destination
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -92,7 +92,7 @@ Set the location of the database file.
 **CLI option**: `--http-addr`
 **Default value**: `"127.0.0.1:7700"`
 
-The address the HTTP server will listen on.
+Set the HTTP address and port the MeiliSearch instance server will use.
 
 ### Master Key
 
@@ -100,9 +100,9 @@ The address the HTTP server will listen on.
 **CLI option**: `--master-key`
 **Default value**: `None`
 
-The master key granting access to all MeiliSearch's API routes. Providing a mandatory key is mandatory when environment is set to `production`.
+Set an instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when environment is set to `production`.
 
-If no master key is provided all routes will be unprotected and publicly accessible.
+If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
 This is only possible if you are in `development` environment. An error is thrown if you try to start MeiliSearch without any master key when the environment is set to `production`.
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -104,7 +104,7 @@ Set an instance's master key, automatically protecting all routes except `GET /h
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
-This is only possible if you are in `development` environment. An error is thrown if you try to start MeiliSearch without any master key when the environment is set to `production`.
+If no master key is provided in a `production` environment, the MeiliSearch instance will throw an error and refuse to launch. 
 
 [Learn more about MeiliSearch's use of security keys in this guide.](/reference/features/authentication.md)
 
@@ -117,14 +117,36 @@ This is only possible if you are in `development` environment. An error is throw
 
 By default, MeiliSearch runs in `development` mode.
 
-- `production`: the [master key](/reference/features/authentication.md) is **mandatory**.
-- `development`: the [master key](/reference/features/authentication.md) is **optional**, and logs are output in "info" mode (_console output_).
+- `production`: setting a [master key](/reference/features/authentication.md) is **mandatory**.
+- `development`: setting a [master key](/reference/features/authentication.md) is **optional**. Log level is automatically set to `info`.
 
-If the server is running in development mode more logs will be displayed, and the master key can be avoided which implies that there is no security on the updates routes.
-This is useful to debug when integrating the engine with another service.
-In production mode, the [web interface](/reference/features/web_interface.md#web-interface) is disabled.
+If the server is running in `development` mode, logs are more verbose and providing a master key is not mandatory. This is useful when debugging, but dangerous otherwise since update routes are unprotected.
 
-**Default value**: `development`
+The [web interface](/reference/features/web_interface.md#web-interface) is disabled in `production` mode.
+
+### Analytics
+
+**Environment variable**: `MEILI_NO_ANALYTICS`
+**CLI option**: `--no-analytics`
+**Default value**: `false`
+
+If set to `true`, deactivates MeiliSearch's built-in analytics and telemetry. 
+
+By default, MeiliSearch collects the following data from all instances that do not explicitly opt-out:
+
+- Application version
+- Environment (development or production)
+- Number of days since the first start (segment development/production
+- Database size
+- Last update time
+- Number of updates
+- Number of documents per index
+
+Additionally, a user does not disable analytics, they may also provide an email address and their server provider by setting the environment variables `MEILI_USER_EMAIL` and `MEILI_SERVER_PROVIDER`.
+
+All collected data is used solely for the purpose of improving MeiliSearch.
+
+A full document describing why we collect this data and how we use it is forthcoming.
 
 ### Payload limit size
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -54,29 +54,29 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 ### Advanced
 
 - [Analytics](/reference/features/configuration.md#analytics)
-- [Disable Sentry](/reference/features/configuration.md#disable-sentry)
+- [Disable sentry](/reference/features/configuration.md#disable-sentry)
 - [Dumps](/reference/features/configuration.md#dumps-destination)
-  - [Dumps Destination](/reference/features/configuration.md#dumps-destination)
-  - [Import Dump](/reference/features/configuration.md#import-dump)
-  - [Dump Batch Size](/reference/features/configuration.md#dump-batch-size)
-- [Max MDB Size](/reference/features/configuration.md#max-mdb-size)
-- [Max UDB Size](/reference/features/configuration.md#max-udb-size)
-- [Payload Limit Size](/reference/features/configuration.md#payload-limit-size)
+  - [Dumps destination](/reference/features/configuration.md#dumps-destination)
+  - [Import dump](/reference/features/configuration.md#import-dump)
+  - [Dump batch size](/reference/features/configuration.md#dump-batch-size)
+- [Max MDB size](/reference/features/configuration.md#max-mdb-size)
+- [Max UDB size](/reference/features/configuration.md#max-udb-size)
+- [Payload limit size](/reference/features/configuration.md#payload-limit-size)
 - [Snapshots](/reference/features/configuration.md#schedule-snapshot-creation):
-  - [Schedule Snapchot Creation](/reference/features/configuration.md#schedule-snapshot-creation)
-  - [Snapshot Destination](/reference/features/configuration.md#snapshot-destination)
-  - [Snapshot Interval](/reference/features/configuration.md#snapshot-interval)
-  - [Import Snapshot](/reference/features/configuration.md#import-snapshot)
-  - [Ignore Missing Snapshot](/reference/features/configuration.md#ignore-missing-snapshot)
-  - [Ignore Snapshot if DB Exists](/reference/features/configuration.md#ignore-snapshot-if-db-exists)
-- [SSL Configuration](/reference/features/configuration.md#ssl-authentication-path):
-  - [SSL Authentication Path](/reference/features/configuration.md#ssl-authentication-path)
-  - [SSL Certificates Path](/reference/features/configuration.md#ssl-certificates-path)
-  - [SSL Key Path](/reference/features/configuration.md#ssl-key-path)
-  - [SSL OCSP Path](/reference/features/configuration.md#ssl-ocsp-path)
-  - [SSL Require Auth](/reference/features/configuration.md#ssl-require-auth)
-  - [SSL Resumption](/reference/features/configuration.md#ssl-resumption)
-  - [SSL Tickets](/reference/features/configuration.md#ssl-tickets)
+  - [Schedule snapshot creation](/reference/features/configuration.md#schedule-snapshot-creation)
+  - [Snapshot destination](/reference/features/configuration.md#snapshot-destination)
+  - [Snapshot interval](/reference/features/configuration.md#snapshot-interval)
+  - [Import snapshot](/reference/features/configuration.md#import-snapshot)
+  - [Ignore missing snapshot](/reference/features/configuration.md#ignore-missing-snapshot)
+  - [Ignore snapshot if DB exists](/reference/features/configuration.md#ignore-snapshot-if-db-exists)
+- [SSL configuration](/reference/features/configuration.md#ssl-authentication-path):
+  - [SSL authentication path](/reference/features/configuration.md#ssl-authentication-path)
+  - [SSL certificates path](/reference/features/configuration.md#ssl-certificates-path)
+  - [SSL key path](/reference/features/configuration.md#ssl-key-path)
+  - [SSL OCSP path](/reference/features/configuration.md#ssl-ocsp-path)
+  - [SSL require auth](/reference/features/configuration.md#ssl-require-auth)
+  - [SSL resumption](/reference/features/configuration.md#ssl-resumption)
+  - [SSL tickets](/reference/features/configuration.md#ssl-tickets)
 
 ### Database path
 
@@ -101,7 +101,7 @@ The main differences between the two environments are:
 
 When the server environment is set to `development`, providing a master key is not mandatory. This is useful when debugging and prototyping, but dangerous otherwise since API update routes are unprotected.
 
-Both logging and the [web interface](/reference/features/web_interface.md#web-interface) are disabled in `production`.
+Logging and the [web interface](/reference/features/web_interface.md#web-interface) are disabled in `production`.
 
 ### HTTP address & port binding
 
@@ -111,19 +111,19 @@ Both logging and the [web interface](/reference/features/web_interface.md#web-in
 
 Sets the HTTP address and port MeiliSearch will use.
 
-### Master Key
+### Master key
 
 **Environment variable**: `MEILI_MASTER_KEY`
 **CLI option**: `--master-key`
 **Default value**: `None`
 
-Sets an instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when `--env` is set to `production`.
+Sets the instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when `--env` is set to `production`.
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
 If no master key is provided in a `production` environment, MeiliSearch will throw an error and refuse to launch.
 
-[Learn more about MeiliSearch's use of security keys in this guide.](/reference/features/authentication.md)
+[Learn more about MeiliSearch's use of security keys.](/reference/features/authentication.md)
 
 
 ### Analytics
@@ -148,7 +148,7 @@ If a user does not disable analytics, they may also provide an email address and
 
 All collected data is used solely for the purpose of improving MeiliSearch. A full document describing why we collect this data and how we use it is forthcoming.
 
-### Disable Sentry
+### Disable sentry
 
 **Environment variable**: `MEILI_NO_SENTRY`
 **CLI option**: `--no-sentry`
@@ -158,7 +158,7 @@ Deactivates Sentry when set to `true`.
 
 We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that help us improve MeiliSearch.
 
-### Dumps Destination
+### Dumps destination
 
 **Environment variable**: `MEILI_DUMPS_DIR`
 **CLI option**: `--dumps-dir`
@@ -168,7 +168,7 @@ Sets the directory where MeiliSearch will store dump files.
 
 [Learn more about creating dumps of MeiliSearch instances](/reference/api/dump.md).
 
-### Import Dump
+### Import dump
 
 **Environment variable**: N/A
 **CLI option**: `--import-dump`
@@ -180,7 +180,7 @@ MeiliSearch will only launch once the dump data has been fully indexed. The time
 
 *This option is not available as an environment variable.*
 
-### Dump Batch Size
+### Dump batch size
 
 **Environment variable**: `MEILI_DUMP_BATCH_SIZE`
 **CLI option**: `--dump-batch-size`
@@ -205,7 +205,7 @@ A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSear
 **CLI option**: `--max-mdb-size`
 **Default value**: `107374182400` (100 GiB)
 
-Set the maximum size of the `main` database. Value must be given in bytes.
+Sets the maximum size of the `main` database. Value must be given in bytes.
 
 The `main` database stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
@@ -243,7 +243,7 @@ On **Windows**, `getconf` returns a fixed size that will be allocated when launc
 
 [Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 
-### Payload Limit Size
+### Payload limit size
 
 **Environment variable**: `MEILI_HTTP_PAYLOAD_SIZE_LIMIT`
 **CLI option**: `--http-payload-size-limit`
@@ -269,7 +269,7 @@ Activates scheduled snapshots when set to `true`. Disabled by default.
 
 Sets the directory where MeiliSearch will store snapshots.
 
-### Snapshot Interval
+### Snapshot interval
 
 **Environment variable**: `MEILI_SNAPSHOT_INTERVAL_SEC`
 **CLI option**: `--snapshot-interval-sec`
@@ -277,7 +277,7 @@ Sets the directory where MeiliSearch will store snapshots.
 
 Defines the interval between each snapshot. Value must be given in seconds.
 
-### Import Snapshot
+### Import snapshot
 
 **Environment variable**: N/A
 **CLI option**: `--import-snapshot`
@@ -316,7 +316,7 @@ This command will throw an error if `--import-snapshot` is not defined.
 
 *This option is not available as an environment variable.*
 
-### SSL Authentication Path
+### SSL authentication path
 
 **Environment variable**: `MEILI_SSL_AUTH_PATH`
 **CLI option**: `--ssl-auth-path`
@@ -324,7 +324,7 @@ This command will throw an error if `--import-snapshot` is not defined.
 
 Enables client authentication in the specified path.
 
-### SSL Certificates Path
+### SSL certificates path
 
 **Environment variable**: `MEILI_SSL_CERT_PATH`
 **CLI option**: `--ssl-cert-path`
@@ -335,7 +335,7 @@ Sets the server's SSL certificates.
 Value must be a path to PEM-formatted certificates. The first certificate should certify the KEYFILE supplied by `--ssl-key-path`. The last certificate should be a root CA.
 
 
-### SSL Key Path
+### SSL key path
 
 **Environment variable**: `MEILI_SSL_KEY_PATH`
 **CLI option**: `--ssl-key-path`
@@ -357,7 +357,7 @@ Sets the server's OCSP file. *Optional*
 Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
 
 
-### SSL Require Auth
+### SSL require auth
 
 **Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
 **CLI option**: `--ssl-require-auth`
@@ -368,7 +368,7 @@ Makes SSL authentication mandatory.
 Sends a fatal alert if the client does not complete client authentication.
 
 
-### SSL Resumption
+### SSL resumption
 
 **Environment variable**: `MEILI_SSL_RESUMPTION`
 **CLI option**: `--ssl-resumption`
@@ -377,7 +377,7 @@ Sends a fatal alert if the client does not complete client authentication.
 Activates SSL session resumption.
 
 
-### SSL Tickets
+### SSL tickets
 
 **Environment variable**: `MEILI_SSL_TICKETS`
 **CLI option**: `--ssl-tickets`

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -262,10 +262,11 @@ On **Windows**, `getconf` returns a fixed size that will be allocated when launc
 
 **Environment variable**: `MEILI_NO_SENTRY`
 **CLI option**: `--no-sentry`
-
-We use [Sentry](https://sentry.io) to get bug reports and diagnostics, and improve MeiliSearch experience. To deactivate Sentry, set this value to `true`.
-
 **Default value**: `false`
+
+Deactivate Sentry when set to `true`.
+
+We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that help us improve MeiliSearch.
 
 ### Schedule snapshot creation
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -152,10 +152,9 @@ A full document describing why we collect this data and how we use it is forthco
 
 **Environment variable**: `MEILI_HTTP_PAYLOAD_SIZE_LIMIT`
 **CLI option**: `--http-payload-size-limit`
+**Default value**: `104857600` (~100MB)
 
-The maximum size, in bytes, of accepted JSON payloads.
-
-**Default value**: `104857600` (+=100MB)
+Set the maximum size, in bytes, of accepted JSON payloads.
 
 ### SSL authentication path
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -1,10 +1,12 @@
 # Configuration
 
-You can configure MeiliSearch with **environment variables** and **command line options**.
+You can configure MeiliSearch with **environment variables** and **command-line options**.
 
-## Configuring an instance with command-line flags
+The configuration options described here affect your entire MeiliSearch instance, not just a single index. For index settings, see [settings](/reference/features/settings.md).
 
-Pass options and their respective values as command-line flags when launching a MeiliSearch instance.
+## Configuring an instance with command-line options
+
+Pass command-line options and their respective values when launching a MeiliSearch instance.
 
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
@@ -30,9 +32,9 @@ Server is listening on: http://127.0.0.1:7700
 
 ## Usage
 
-Command-line flags take precedence over environment variables. If an option is specified both as a flag and as an environment variable, MeiliSearch will use the command-line flag and its respective value.
+Command-line options take precedence over environment variables. If the same configuration option is specified both as a command-line option and as an environment variable, MeiliSearch will use the command-line option and its respective value.
 
-All options must specify a value. Using a command-line flag or environment variable without specifying a value will throw an error and interrupt the launch process.
+**All configuration options must specify a value.** Using a command-line option or environment variable without specifying a value will throw an error and interrupt the launch process.
 
 ```bash
 ./meilisearch --schedule-snapshot
@@ -117,11 +119,12 @@ Sets the HTTP address and port MeiliSearch will use.
 **CLI option**: `--master-key`
 **Default value**: `None`
 
-Sets the instance's master key, automatically protecting all routes except `GET /health`. Providing a key is mandatory when `--env` is set to `production`.
+Sets the instance's master key, automatically protecting all routes except [`GET /health`](/reference/api/health.md).
+
+Providing a master key is mandatory when `--env` is set to `production`; if none is given, then MeiliSearch will throw an error and refuse to launch.
 
 If no master key is provided in a `development` environment, all routes will be unprotected and publicly accessible.
 
-If no master key is provided in a `production` environment, MeiliSearch will throw an error and refuse to launch.
 
 [Learn more about MeiliSearch's use of security keys.](/reference/features/authentication.md)
 
@@ -131,7 +134,7 @@ If no master key is provided in a `production` environment, MeiliSearch will thr
 **CLI option**: `--no-analytics`
 **Default value**: `false`
 
-Deactivates MeiliSearch's built-in analytics and telemetry when set to `true`.
+Deactivates MeiliSearch's built-in telemetry when set to `true`.
 
 By default, MeiliSearch collects the following data from all instances that do not explicitly opt-out:
 
@@ -163,9 +166,9 @@ We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that h
 **CLI option**: `--dumps-dir`
 **Default value**: `dumps/`
 
-Sets the directory where MeiliSearch will store dump files.
+Sets the directory where MeiliSearch will create dump files.
 
-[Learn more about creating dumps of MeiliSearch instances](/reference/api/dump.md).
+[Learn more about creating dumps](/reference/api/dump.md).
 
 ### Import dump
 
@@ -173,7 +176,7 @@ Sets the directory where MeiliSearch will store dump files.
 **CLI option**: `--import-dump`
 **Default value**: `none`
 
-Imports a dump located in the specified path. Path must point to a `.dump` file.
+Imports the dump file located at the specified path. Path must point to a `.dump` file.
 
 MeiliSearch will only launch once the dump data has been fully indexed. The time this takes depends on the size of the dump file and the value of `--dump-batch-size`.
 
@@ -256,7 +259,7 @@ Sets the maximum size of accepted JSON payloads. Value must be given in bytes.
 **CLI option**: `--schedule-snapshot`
 **Default value**: `false`
 
-Activates scheduled snapshots when set to `true`. Disabled by default.
+Activates scheduled snapshots when set to `true`. Snapshots are disabled by default.
 
 [Learn more about snapshots](/reference/features/snapshots.md).
 
@@ -282,12 +285,14 @@ Defines the interval between each snapshot. Value must be given in seconds.
 **CLI option**: `--import-snapshot`
 **Default value**: `None`
 
-Launches an instance by importing a previously-generated snapshot.
+Launches MeiliSearch after importing a previously-generated snapshot at the given filepath.
 
 This command will throw an error if:
 
 - A database already exists
 - No valid snapshot can be found in the specified path
+
+This behavior can be modified with the [`--ignore-snapshot-if-db-exists`](#ignore-snapshot-if-db-exists) and [`--ignore-missing-snapshot`](#ignore-missing-snapshot) options, respectively. 
 
 *This option is not available as an environment variable.*
 
@@ -297,7 +302,7 @@ This command will throw an error if:
 **CLI option**: `--ignore-missing-snapshot`
 **Default value**: `false`
 
-Prevents a MeiliSearch instance from throwing an error when `--import-snapshot` does not point to a valid snapshot file.
+Prevents a MeiliSearch instance from throwing an error when [`--import-snapshot`](#import-snapshot) does not point to a valid snapshot file.
 
 This command will throw an error if `--import-snapshot` is not defined.
 
@@ -309,7 +314,7 @@ This command will throw an error if `--import-snapshot` is not defined.
 **CLI option**: `--ignore-snapshot-if-db-exists`
 **Default value**: `false`
 
-Prevents a MeiliSearch instance with an existing database from throwing an error when using `--import-snapshot`.
+Prevents a MeiliSearch instance with an existing database from throwing an error when using `--import-snapshot`. Instead, the snapshot will be ignored and MeiliSearch will launch using the existing database.
 
 This command will throw an error if `--import-snapshot` is not defined.
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -337,37 +337,39 @@ This option is not available as an environment variable.
 
 **Environment variable**: `MEILI_DUMPS_DIR`
 **CLI option**: `--dumps-dir`
-
-Path of the directory where dumps will be created if the [dump route](/reference/api/dump.md#create-a-dump) is called.
-
 **Default value**: `dumps/`
+
+Sets the directory for dump file storage.
+
+[Learn more about creating dumps of MeiliSearch instances](/reference/api/dump.md).
 
 ### Import dump
 
+**Environment variable**: N/A
 **CLI option**: `--import-dump`
+**Default value**: `none`
 
-Import a dump from the specified path. Must be a `.dump` file.
+Imports a dump located in the specified path. Must be a `.dump` file.
 
-As the data contained in the dump needs to be indexed, the process will take an amount of time corresponding to the size of the dump. Only when the import is complete and successful will the MeiliSearch server start.
+The MeiliSearch instance will only be launched once the dump data has been fully indexed.
+
+This option is not available as an environment variable.
 
 ### Dump batch size
 
 **Environment variable**: `MEILI_DUMP_BATCH_SIZE`
 **CLI option**: `--dump-batch-size`
+**Default value**: `1024`
 
 Sets the batch size used in the dump importation process. This number corresponds to the maximum number of documents indexed in each batch. A larger value will take less time but use more memory.
 
-If a dump import process is killed, this means that you do not have enough RAM. Consider reducing your batch size.
-
-If you find that a dump import process is too slow and you have a lot of RAM to spare, consider increasing the batch size, as it will accelerate the indexation. However, if this leads to the dump process failing, you've gone too far and run out of memory. In this case, you should decrease the batch size until you find the right balance between speed and memory overhead.
+Bigger batch sizes can speed up the import process, but require more RAM. Setting a larger size than a system can handle might cause a MeiliSearch instance to crash; if this happens, consider reducing the batch size.
 
 **Example**
-Imagine you set `--dump-batch-size 1000` and your dump contains 2600 documents. Instead of indexing all 2600 docs in one go, the engine will :
+A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSearch will not index all 2600 in one go. Instead, the instance will:
 
-1. Index documents 0 -> 999 (1000 docs)
-2. Index documents 1000 -> 1999 (1000 docs)
-3. Index documents 2000 -> 2599 (600 docs)
+1. First index documents 0 -> 999 (1000 docs)
+2. Then index documents 1000 -> 1999 (1000 docs)
+3. And finally index documents 2000 -> 2599 (600 docs)
 
-**Default value**: `1024`
-
-[Read more about dumps](/reference/features/dumps.md)
+[Learn more about MeiliSearch dumps](/reference/features/dumps.md)


### PR DESCRIPTION
Clarifies language around how to configure MeiliSearch with cli flags and env vars.

SSL options are still unclear. This will be addressed in a future PR.

Fixes #978.

Duplicate of #976 (PR couldn't be merged with my current permissions).