### PR TITLE
v0.21: Dumps

### DIFF
--- a/create/how_to/updating.md
+++ b/create/how_to/updating.md
@@ -223,7 +223,7 @@ Once the response to the previous command looks like this (`"status": "done"`), 
 ```json
 {
   "uid": "20200929-114144097",
-  "status": "done"
+  "status": "done",
   "startedAt": "2020-09-29T11:41:44.392327Z",
   "finishedAt": "2020-09-29T11:41:50.792147Z"
 }
@@ -241,7 +241,7 @@ curl -L https://install.meilisearch.com | sh
 ./meilisearch --import-dump /dumps/your_dump_file.dump
 ```
 
-> Importing a dump is the same process as indexing documents. This can take time and cause a spike in memory usage.
+Importing a dump requires indexing all the documents it contains. Depending on the size of your dataset, this process can take a long time and cause a spike in memory usage.
 
 Finally, don’t forget to set `displayedAttributes` back to its previous value if necessary. You can do this using the [update displayed attributes endpoint](/reference/api/displayed_attributes.md#update-displayed-attributes).
 

--- a/create/how_to/updating.md
+++ b/create/how_to/updating.md
@@ -115,7 +115,7 @@ In this guide, we will:
 ### Step 1: Set all fields as displayed attributes
 
 ::: note
-This step is not mandatory when creating dumps in MeiliSearch v0.21 and above.
+If your dump was created in MeiliSearch v0.21 or or above, continue to step 2.
 :::
 
 When creating dumps, MeiliSearch calls the same method as the [get documents endpoint](/reference/api/documents.md#get-documents). This means that all fields must be [displayed](/reference/features/field_properties.md#displayed-fields) in order to be saved in the dump.

--- a/create/how_to/updating.md
+++ b/create/how_to/updating.md
@@ -206,7 +206,8 @@ The server should return a response that looks like this:
 ```json
 {
   "uid": "20210212-151153878",
-  "status": "in_progress"
+  "status": "in_progress",
+  "startedAt": "2021-02-12T15:11:53.402327Z"
 }
 ```
 
@@ -221,8 +222,10 @@ Once the response to the previous command looks like this (`"status": "done"`), 
 
 ```json
 {
-  "uid": "20210212-151153878",
+  "uid": "20200929-114144097",
   "status": "done"
+  "startedAt": "2020-09-29T11:41:44.392327Z",
+  "finishedAt": "2020-09-29T11:41:50.792147Z"
 }
 ```
 
@@ -238,7 +241,7 @@ curl -L https://install.meilisearch.com | sh
 ./meilisearch --import-dump /dumps/your_dump_file.dump
 ```
 
-> Importing a dump is the same process as indexing documents. This can take time and cause a spike in memory usage; to save memory, use a [smaller batch size](/reference/features/configuration.md#dump-batch-size).
+> Importing a dump is the same process as indexing documents. This can take time and cause a spike in memory usage.
 
 Finally, don’t forget to set `displayedAttributes` back to its previous value if necessary. You can do this using the [update displayed attributes endpoint](/reference/api/displayed_attributes.md#update-displayed-attributes).
 

--- a/create/how_to/updating.md
+++ b/create/how_to/updating.md
@@ -114,6 +114,10 @@ In this guide, we will:
 
 ### Step 1: Set all fields as displayed attributes
 
+::: note
+This step is not mandatory when creating dumps in MeiliSearch v0.21 and above.
+:::
+
 When creating dumps, MeiliSearch calls the same method as the [get documents endpoint](/reference/api/documents.md#get-documents). This means that all fields must be [displayed](/reference/features/field_properties.md#displayed-fields) in order to be saved in the dump.
 
 Start by using the [get displayed attributes endpoint](/reference/api/displayed_attributes.md#get-displayed-attributes) to verify that **all attributes are displayed**.

--- a/reference/api/dump.md
+++ b/reference/api/dump.md
@@ -8,7 +8,7 @@ During a [dump export](/reference/api/dump.md#create-a-dump), all indexes of the
 
 During a dump import, all indexes contained in the indicated `.dump` file are imported along with their associated documents and settings. Any existing index with the same uid as an index in the dump file will be overwritten.
 
-Dump imports are [performed at launch](/reference/features/configuration.md#import-dump) using an option.
+Dump imports must be performed when launching a MeiliSearch instance [using the `import-dump` command-line option](/reference/features/configuration.md#import-dump).
 
 ## Create a dump
 
@@ -50,7 +50,7 @@ The returned status could be:
 ```json
 {
   "uid": "20200929-114144097",
-  "status": "done"
+  "status": "done",
   "startedAt": "2020-09-29T11:41:44.392327Z",
   "finishedAt": "2020-09-29T11:41:50.792147Z"
 }

--- a/reference/api/dump.md
+++ b/reference/api/dump.md
@@ -8,7 +8,7 @@ During a [dump export](/reference/api/dump.md#create-a-dump), all indexes of the
 
 During a dump import, all indexes contained in the indicated `.dump` file are imported along with their associated documents and settings. Any existing index with the same uid as an index in the dump file will be overwritten.
 
-Dump imports are [performed at launch](/reference/features/configuration.md#import-dump) using an option. [Batch size](/reference/features/configuration.md#dump-batch-size) can also be set at this time.
+Dump imports are [performed at launch](/reference/features/configuration.md#import-dump) using an option.
 
 ## Create a dump
 
@@ -25,7 +25,8 @@ Triggers a dump creation process. Once the process is complete, a dump is create
 ```json
 {
   "uid": "20200929-114144097",
-  "status": "in_progress"
+  "status": "in_progress",
+  "startedAt": "2020-09-29T11:41:44.392327Z"
 }
 ```
 
@@ -50,5 +51,7 @@ The returned status could be:
 {
   "uid": "20200929-114144097",
   "status": "done"
+  "startedAt": "2020-09-29T11:41:44.392327Z",
+  "finishedAt": "2020-09-29T11:41:50.792147Z"
 }
 ```

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -64,7 +64,6 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 - [Dumps](/reference/features/configuration.md#dumps-destination)
   - [Dumps destination](/reference/features/configuration.md#dumps-destination)
   - [Import dump](/reference/features/configuration.md#import-dump)
-  - [Dump batch size](/reference/features/configuration.md#dump-batch-size)
 - [Max MDB size](/reference/features/configuration.md#max-mdb-size)
 - [Max UDB size](/reference/features/configuration.md#max-udb-size)
 - [Payload limit size](/reference/features/configuration.md#payload-limit-size)
@@ -190,28 +189,9 @@ Sets the directory where MeiliSearch will create dump files.
 
 Imports the dump file located at the specified path. Path must point to a `.dump` file.
 
-MeiliSearch will only launch once the dump data has been fully indexed. The time this takes depends on the size of the dump file and the value of `--dump-batch-size`.
+MeiliSearch will only launch once the dump data has been fully indexed. The time this takes depends on the size of the dump file.
 
 *This option is not available as an environment variable.*
-
-### Dump batch size
-
-**Environment variable**: `MEILI_DUMP_BATCH_SIZE`
-**CLI option**: `--dump-batch-size`
-**Default value**: `1024`
-
-Sets the maximum number of documents indexed in a batch when importing a dump file.
-
-Bigger batch sizes can speed up the import process, but will use more RAM. Setting a larger batch size than a system can handle might cause MeiliSearch to crash; if this happens, consider reducing the batch size.
-
-**Example**
-A dump contains 2600 documents. If `--dump-batch-size` is set to 1000, MeiliSearch will not index all 2600 documents in one go. Instead, the instance will:
-
-1. First index documents 0 -> 999 (1000 docs)
-2. Then index documents 1000 -> 1999 (1000 docs)
-3. And finally index documents 2000 -> 2599 (600 docs)
-
-[Learn more about MeiliSearch dumps](/reference/features/dumps.md)
 
 ### Max MDB size
 

--- a/reference/features/dumps.md
+++ b/reference/features/dumps.md
@@ -10,13 +10,19 @@ To create a dump of your dataset, you need to use the appropriate HTTP route: [`
 
 The above code triggers a dump creation process.
 
-At any given moment, you can check the status of a particular dump creation process using the previously received dump uid, like so: [`GET /dumps/:dump_uid/status`](/reference/api/dump.md#get-dump-status). Using this route, you can know whether your dump is still processing, has already been created, or has encountered a problem.
+You can check the status of a particular dump creation process using the previously received dump uid, like so: [`GET /dumps/:dump_uid/status`](/reference/api/dump.md#get-dump-status). Using this route, you can know whether your dump is still processing, has already been created, or has encountered a problem.
 
 <CodeSamples id="get_dump_status_1" />
 
 After your dump creation process is done, the dump file is created and added to the dump folder. By default, this folder is `/dumps` at the root of your MeiliSearch binary, [but this can be customized](/reference/features/configuration.md#dumps-destination).
 
 Note that **if your dump folder does not already exist when the dump creation process is called, MeiliSearch will create it**.
+
+If you shut down an instance after creating a dump, you will not be able to use the dumps endpoint for its status once the instance is running once again. This has no effect on the dump file.
+
+::: note
+If a dump file is visible in the file system, the dump process was successfully completed. MeiliSearch will never create a partial dump file if you interrupt an instance while it is generating a dump.
+:::
 
 ## Importing a dump
 
@@ -27,8 +33,6 @@ As the data contained in the dump needs to be indexed, the process will take som
 ```bash
 ./meilisearch --import-dump /dumps/20200813-042312213.dump
 ```
-
-If your dataset is very large, it is a good practice to index documents in large batches using the `--dump-batch-size` command-line flag or `MEILI_DUMP_BATCH_SIZE` environment variable. This will speed up the indexing process, but requires more memory and may cause your dump import to fail. [Read more about configuring your dump batch size here](/reference/features/configuration.md#dump-batch-size).
 
 ## Use cases
 

--- a/reference/features/dumps.md
+++ b/reference/features/dumps.md
@@ -10,7 +10,7 @@ To create a dump of your dataset, you need to use the appropriate HTTP route: [`
 
 The above code triggers a dump creation process.
 
-You can check the status of a particular dump creation process using the previously received dump uid, like so: [`GET /dumps/:dump_uid/status`](/reference/api/dump.md#get-dump-status). Using this route, you can know whether your dump is still processing, has already been created, or has encountered a problem.
+You can check the status of a particular dump creation process using the previously received `dump uid`: [`GET /dumps/:dump_uid/status`](/reference/api/dump.md#get-dump-status). Using this route, you can check whether your dump is still processing, has already been created, or has encountered a problem.
 
 <CodeSamples id="get_dump_status_1" />
 
@@ -18,7 +18,7 @@ After your dump creation process is done, the dump file is created and added to 
 
 Note that **if your dump folder does not already exist when the dump creation process is called, MeiliSearch will create it**.
 
-If you shut down an instance after creating a dump, you will not be able to use the dumps endpoint for its status once the instance is running once again. This has no effect on the dump file.
+If you restart MeiliSearch after creating a dump, you will not be able to use the dumps endpoint to find out that dump's `status`. This has no effect on the dump file itself.
 
 ::: note
 If a dump file is visible in the file system, the dump process was successfully completed. MeiliSearch will never create a partial dump file if you interrupt an instance while it is generating a dump.


### PR DESCRIPTION
- [x] reference/features/configuration.md: remove --dump-batch-size L#67, L#193, L#200, #L208
- [x] create/how_to/updating: remove --dump-batch-size L#241
- [x] reference/api/dump: remove --dump-batch-size L#11
- [x] reference/features/dumps: remove --dump-batch-size L#31
- [x] add startedAt field to POST /dumps route (reference/features/dumps, create/how_to/updating (L#220-227), reference/api/dump (L#49-54))
- [x] add startedAt and finishedAt fields to GET /dumps/:uid/status route (create/how_to/updating (L#204-212), reference/api/dump (L#25-30))
- [x] reference/features/dumps: update text so users know that only successfully completed dumps generate dump files and that a dump's status becomes unavailable after restarting an instance