### PR TITLE
v0.21: searchable attributes

### DIFF
--- a/reference/api/searchable_attributes.md
+++ b/reference/api/searchable_attributes.md
@@ -43,7 +43,7 @@ List the settings.
 Update the [searchable attributes](/reference/features/field_properties.md#searchable-fields) of an index.
 
 ::: warning
-Manually updating `searchableAttributes` will change the order of the returned documents' fields.
+Manually updating `searchableAttributes` will change the displayed order of document fields in the JSON response.
 :::
 
 #### Path variables

--- a/reference/api/searchable_attributes.md
+++ b/reference/api/searchable_attributes.md
@@ -43,7 +43,7 @@ List the settings.
 Update the [searchable attributes](/reference/features/field_properties.md#searchable-fields) of an index.
 
 ::: warning
-Manually updating `searchableAttributes` will change the displayed order of document fields in the JSON response.
+Due to an implementation bug, manually updating `searchableAttributes` will change the displayed order of document fields in the JSON response. This behavior is inconsistent and will be fixed in a future release.
 :::
 
 #### Path variables

--- a/reference/api/searchable_attributes.md
+++ b/reference/api/searchable_attributes.md
@@ -42,6 +42,10 @@ List the settings.
 
 Update the [searchable attributes](/reference/features/field_properties.md#searchable-fields) of an index.
 
+::: warning
+Manually updating `searchableAttributes` will change the order of the returned documents' fields. This will be fixed in a future MeiliSearch release.
+:::
+
 #### Path variables
 
 | Variable      | Description   |

--- a/reference/api/searchable_attributes.md
+++ b/reference/api/searchable_attributes.md
@@ -43,7 +43,7 @@ List the settings.
 Update the [searchable attributes](/reference/features/field_properties.md#searchable-fields) of an index.
 
 ::: warning
-Manually updating `searchableAttributes` will change the order of the returned documents' fields. This will be fixed in a future MeiliSearch release.
+Manually updating `searchableAttributes` will change the order of the returned documents' fields.
 :::
 
 #### Path variables

--- a/reference/features/field_properties.md
+++ b/reference/features/field_properties.md
@@ -45,7 +45,7 @@ You may want to make some attributes non-searchable, or change the [attribute ra
 After manually updating the `searchableAttributes` list, **subsequent new attributes will no longer be automatically added** unless the settings are [reset](/reference/api/searchable_attributes.md#reset-searchable-attributes).
 
 ::: warning
-Manually updating `searchableAttributes` will change the order of the returned documents' fields.
+Manually updating `searchableAttributes` will change the displayed order of document fields in the JSON response.
 :::
 
 #### Example

--- a/reference/features/field_properties.md
+++ b/reference/features/field_properties.md
@@ -45,7 +45,7 @@ You may want to make some attributes non-searchable, or change the [attribute ra
 After manually updating the `searchableAttributes` list, **subsequent new attributes will no longer be automatically added** unless the settings are [reset](/reference/api/searchable_attributes.md#reset-searchable-attributes).
 
 ::: warning
-Manually updating `searchableAttributes` will change the displayed order of document fields in the JSON response.
+Due to an implementation bug, manually updating `searchableAttributes` will change the displayed order of document fields in the JSON response. This behavior is inconsistent and will be fixed in a future release.
 :::
 
 #### Example

--- a/reference/features/field_properties.md
+++ b/reference/features/field_properties.md
@@ -42,8 +42,10 @@ If you'd like to restore your searchable attributes list to this default behavio
 
 You may want to make some attributes non-searchable, or change the [attribute ranking order](/learn/core_concepts/relevancy.md#attribute-ranking-order) after documents have been indexed. To do so, simply place the attributes in the desired order and send the updated list using the [update searchable attributes endpoint](/reference/api/searchable_attributes.md#update-searchable-attributes).
 
+After manually updating the `searchableAttributes` list, **subsequent new attributes will no longer be automatically added** unless the settings are [reset](/reference/api/searchable_attributes.md#reset-searchable-attributes).
+
 ::: warning
-Be aware that after manually updating the `searchableAttributes` list, subsequent new attributes will no longer be automatically added unless the settings are [reset](/reference/api/searchable_attributes.md#reset-searchable-attributes).
+Manually updating `searchableAttributes` will change the order of the returned documents' fields. This will be fixed in a future MeiliSearch release.
 :::
 
 #### Example

--- a/reference/features/field_properties.md
+++ b/reference/features/field_properties.md
@@ -45,7 +45,7 @@ You may want to make some attributes non-searchable, or change the [attribute ra
 After manually updating the `searchableAttributes` list, **subsequent new attributes will no longer be automatically added** unless the settings are [reset](/reference/api/searchable_attributes.md#reset-searchable-attributes).
 
 ::: warning
-Manually updating `searchableAttributes` will change the order of the returned documents' fields. This will be fixed in a future MeiliSearch release.
+Manually updating `searchableAttributes` will change the order of the returned documents' fields.
 :::
 
 #### Example


### PR DESCRIPTION
Manual updates to `searchableAttributes` change the order of the returned documents' fields.

- [x] reference/api/searchable_attributes: add warning  (L#12?)
- [x] reference/features/field_properties: add warning  (L#48?)
