### PR TITLE
v0.21: Update configuration options

### DIFF
--- a/learn/core_concepts/documents.md
+++ b/learn/core_concepts/documents.md
@@ -158,7 +158,7 @@ Take note that the document addition request in MeiliSearch is <clientGlossary w
 
 By default, MeiliSearch limits the size of `JSON` payloads—and therefore document uploads—to 100MB.
 
-To upload more documents in one go, it is possible to [change the payload size limit](/reference/features/configuration.md#payload-limit-size) at runtime using the `http-payload-size-limit` option. The new limit must be given in bytes.
+To upload more documents in one go, it is possible to [change the payload size limit](/reference/features/configuration.md#payload-limit-size) at runtime using the `http-payload-size-limit` option.
 
 ```bash
 ./meilisearch --http-payload-size-limit=1048576000

--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -99,7 +99,7 @@ To install MeiliSearch on Windows, use Docker or compile from the source.
 
 A common compilation error (`"link.exe not found"`) can be solved by installing [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (scroll down and click on **Tools for Visual Studio 2019**).
 
-MeiliSearch will allocate 100GB on launch. If disk space is an issue on your machine, adjust the [main database](/reference/features/configuration.md#max-index-size) and [update database](/reference/features/configuration.md#max-udb-size) maximums accordingly.
+MeiliSearch will allocate 100GB on launch. If disk space is an issue on your machine, adjust the [index](/reference/features/configuration.md#max-index-size) and [update database](/reference/features/configuration.md#max-udb-size) maximums accordingly.
 :::
 
 ::::

--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -99,7 +99,7 @@ To install MeiliSearch on Windows, use Docker or compile from the source.
 
 A common compilation error (`"link.exe not found"`) can be solved by installing [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (scroll down and click on **Tools for Visual Studio 2019**).
 
-MeiliSearch will allocate 100GB on launch. If disk space is an issue on your machine, adjust the [main database](/reference/features/configuration.md#max-mdb-size) and [update database](/reference/features/configuration.md#max-udb-size) maximums accordingly.
+MeiliSearch will allocate 100GB on launch. If disk space is an issue on your machine, adjust the [main database](/reference/features/configuration.md#max-index-size) and [update database](/reference/features/configuration.md#max-udb-size) maximums accordingly.
 :::
 
 ::::

--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -95,11 +95,7 @@ cargo build --release
 :::
 
 ::: tab Windows
-To install MeiliSearch on Windows, use Docker or compile from the source.
-
-A common compilation error (`"link.exe not found"`) can be solved by installing [Visual Studio Build Tools](https://visualstudio.microsoft.com/downloads/) (scroll down and click on **Tools for Visual Studio 2019**).
-
-MeiliSearch will allocate 100GB on launch. If disk space is an issue on your machine, adjust the [index](/reference/features/configuration.md#max-index-size) and [update database](/reference/features/configuration.md#max-udb-size) maximums accordingly.
+To install MeiliSearch on Windows, use Docker or compile from source.
 :::
 
 ::::

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -208,7 +208,7 @@ MeiliSearch currently supports four log levels, listed in order of increasing ve
 
 Sets the maximum size of the index. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
-The index stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
+The `index` stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
 On **UNIX** systems (e.g. Linux, MacOS) `--max-index-size` will use the maximum page size by default.
 
@@ -230,7 +230,7 @@ getconf PAGE_SIZE
 
 Sets the maximum size of the `update` database. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
-The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the index database, which only stores processed data.
+The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `index` database, which only stores processed data.
 
 On **UNIX** systems (e.g. Linux, MacOS) `--max-udb-size` will use the maximum page size by default.
 
@@ -250,7 +250,7 @@ getconf PAGE_SIZE
 **CLI option**: `--http-payload-size-limit`
 **Default value**: `104857600` (~100MB)
 
-Sets the maximum size of accepted JSON payloads. Value must be given in bytes or explicitly stating a base unit.
+Sets the maximum size of accepted JSON payloads. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
 ### Schedule snapshot creation
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -60,11 +60,11 @@ error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value b
 ### Advanced
 
 - [Disable analytics](/reference/features/configuration.md#disable-analytics)
-- [Disable sentry](/reference/features/configuration.md#disable-sentry)
 - [Dumps](/reference/features/configuration.md#dumps-destination)
   - [Dumps destination](/reference/features/configuration.md#dumps-destination)
   - [Import dump](/reference/features/configuration.md#import-dump)
-- [Max MDB size](/reference/features/configuration.md#max-mdb-size)
+- [Log level](/reference/features/configuration.md#log-level)
+- [Max index size](/reference/features/configuration.md#max-index-size)
 - [Max UDB size](/reference/features/configuration.md#max-udb-size)
 - [Payload limit size](/reference/features/configuration.md#payload-limit-size)
 - [Snapshots](/reference/features/configuration.md#schedule-snapshot-creation):
@@ -159,17 +159,9 @@ MeiliSearch collects the following data from all instances that do not explicitl
 - Number of updates
 - Number of documents per index
 
-All collected data is used solely for the purpose of improving MeiliSearch. A full document describing why we collect this data and how we use it is forthcoming.
+All collected data is used solely for the purpose of improving MeiliSearch.
 
-### Disable sentry
-
-**Environment variable**: `MEILI_NO_SENTRY`
-**CLI option**: `--no-sentry`
-**Default value**: `false`
-
-Deactivates Sentry when set to `true`.
-
-We use [Sentry](https://sentry.io) to receive bug reports and diagnostics that help us improve MeiliSearch.
+[You can read more about our policy on data collection in our telemetry page.](/learn/what_is_meilisearch/telemetry.md)
 
 ### Dumps destination
 
@@ -193,21 +185,36 @@ MeiliSearch will only launch once the dump data has been fully indexed. The time
 
 *This option is not available as an environment variable.*
 
-### Max MDB size
+### Log level
 
-**Environment variable**: `MEILI_MAX_MDB_SIZE`
-**CLI option**: `--max-mdb-size`
+**Environment variable**: MEILI_LOG_LEVEL
+**CLI option**: `--log-level`
+**Default value**: `INFO`
+
+Defines the level of detail MeiliSearch's logs should contain.
+
+MeiliSearch outputs different information depending on the value of `--log-level`:
+
+- ERROR: logs only contain information on events that prevent MeiliSearch from functioning correctly
+- WARN: logs contain information on unexpected events that do not immediately impact an instance's functioning
+- INFO: displays high-level information on all search engine events. This is the default value of `--log-level`
+- DEBUG: more verbose than INFO, DEBUG displays additional information on all search engine events. Useful when diagnosing issues and debugging
+
+### Max Index size
+
+**Environment variable**: `MEILI_MAX_INDEX_SIZE`
+**CLI option**: `--max-index-size`
 **Default value**: `107374182400` (100 GiB)
 
-Sets the maximum size of the `main` database. Value must be given in bytes.
+Sets the maximum size of the index. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
-The `main` database stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
+The index stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
-On **UNIX** systems (e.g. Linux, MacOS) `--max-mdb-size` will use the maximum page size by default.
+On **UNIX** systems (e.g. Linux, MacOS) `--max-index-size` will use the maximum page size by default.
 
-On **Windows**, `--max-mdb-size` must be a fixed value allocated at launch. By default, this is `100GiB`, but this option allows users to change that value.
+On **Windows**, `--max-index-size` must be a fixed value allocated at launch. By default, this is `100GiB`, but this option allows users to change that value.
 
-The maximum MDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
+The maximum index size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
 
 ```bash
 getconf PAGE_SIZE
@@ -221,9 +228,10 @@ getconf PAGE_SIZE
 **CLI option**: `--max-udb-size`
 **Default value**: `107374182400` (100 GiB)
 
-Sets the maximum size of the `update` database. Value must be given in bytes.
+Sets the maximum size of the `update` database. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
-The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `main` database, which only stores processed data.
+
+The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the index database, which only stores processed data.
 
 On **UNIX** systems (e.g. Linux, MacOS) `--max-udb-size` will use the maximum page size by default.
 
@@ -243,7 +251,7 @@ getconf PAGE_SIZE
 **CLI option**: `--http-payload-size-limit`
 **Default value**: `104857600` (~100MB)
 
-Sets the maximum size of accepted JSON payloads. Value must be given in bytes.
+Sets the maximum size of accepted JSON payloads. Value must be given in bytes or explicitly stating a base unit.
 
 ### Schedule snapshot creation
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -210,16 +210,6 @@ Sets the maximum size of the index. Value must be given in bytes or explicitly s
 
 The `index` stores processed data and is different from the `update` database, which handles [pending updates](/learn/advanced/asynchronous_updates.md).
 
-On **UNIX** systems (e.g. Linux, MacOS) `--max-index-size` will use the maximum page size by default.
-
-On **Windows**, `--max-index-size` must be a fixed value allocated at launch. By default, this is `100GiB`, but this option allows users to change that value.
-
-The maximum index size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
-
-```bash
-getconf PAGE_SIZE
-```
-
 [Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 
 ### Max UDB size
@@ -231,16 +221,6 @@ getconf PAGE_SIZE
 Sets the maximum size of the `update` database. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
 
 The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the `index` database, which only stores processed data.
-
-On **UNIX** systems (e.g. Linux, MacOS) `--max-udb-size` will use the maximum page size by default.
-
-On **Windows**, `--max-udb-size` must be a fixed value allocated at launch. By default this is `100GiB`, but this option allows users to change that value.
-
-The maximum UDB size must be a modulo value of the OS's `PAGE_SIZE`. To find the OS's `PAGE_SIZE`, use the following command:
-
-```bash
-getconf PAGE_SIZE
-```
 
 [Learn more about MeiliSearch's database and storage engine.](/reference/under_the_hood/storage.md)
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -189,18 +189,18 @@ MeiliSearch will only launch once the dump data has been fully indexed. The time
 
 **Environment variable**: MEILI_LOG_LEVEL
 **CLI option**: `--log-level`
-**Default value**: `INFO`
+**Default value**: `'INFO'`
 
-Defines the level of detail MeiliSearch's logs should contain.
+Defines how much detail should be present in MeiliSearch's logs.
 
-MeiliSearch outputs different information depending on the value of `--log-level`:
+MeiliSearch currently supports four log levels, listed in order of increasing verbosity:
 
-- ERROR: logs only contain information on events that prevent MeiliSearch from functioning correctly
-- WARN: logs contain information on unexpected events that do not immediately impact an instance's functioning
-- INFO: displays high-level information on all search engine events. This is the default value of `--log-level`
-- DEBUG: more verbose than INFO, DEBUG displays additional information on all search engine events. Useful when diagnosing issues and debugging
+- `'ERROR'`: only log unexpected events indicating MeiliSearch is not functioning as expected
+- `'WARN:'` log all unexpected events, regardless of their severity
+- `'INFO:'` log all events. This is the default value of `--log-level`
+- `'DEBUG'`: log all events and including detailed information on MeiliSearch's internal processes. Useful when diagnosing issues and debugging
 
-### Max Index size
+### Max index size
 
 **Environment variable**: `MEILI_MAX_INDEX_SIZE`
 **CLI option**: `--max-index-size`
@@ -229,7 +229,6 @@ getconf PAGE_SIZE
 **Default value**: `107374182400` (100 GiB)
 
 Sets the maximum size of the `update` database. Value must be given in bytes or explicitly stating a base unit. For example, the default value can be written as `107374182400`, `'107.7Gb'`, or `'107374 Mb'`.
-
 
 The `update` database handles [pending updates](/learn/advanced/asynchronous_updates.md). This is different from the index database, which only stores processed data.
 

--- a/reference/features/known_limitations.md
+++ b/reference/features/known_limitations.md
@@ -12,7 +12,7 @@ Currently, MeiliSearch has a number of known limitations. Some of these limitati
 
 ### Database size
 
-**Limitation:** The default maximum database size is __100GiB__. This size can be modified using the options `--max-mdb-size` & `--max-udb-size` as described in the [configuration reference](/reference/features/configuration.md#max-mdb-size).
+**Limitation:** The default maximum database size is __100GiB__. This size can be modified using the options `--max-index-size` & `--max-udb-size` as described in the [configuration reference](/reference/features/configuration.md#max-index-size).
 
 **Explanation:** MeiliSearch uses two databases: one for storage and one for updates. On launch, LMDB needs to know the maximum size that it will need to reserve on disk for both of them.
 


### PR DESCRIPTION
Log level
- [x] /reference/features/configuration.md: add option description (alphabetic order)

Analytics
- [x] /reference/features/configuration.html#disable-analytics
- [x] /reference/features/configuration: remove --no-sentry L#165-174
- [x] /reference/features/configuration: add line explaining sentry is now handled by --no-analytics L#163
- [x] /reference/features/configuration: link to telemetry page L#163

MAX_MDB_SIZE
- [x] /reference/features/configuration L#68, L#218, L#219, L#226, L#228
- [x] /learn/getting_started/installation L#102
- [x] /reference/features/known_limitations L#15
- [x] /reference/features/configuration: add line explaining users can specify human-readable units

HTTP-PAYLOAD-SIZE-LIMIT
- [x] /learn/core_concepts/documents: remove "must be in bytes" L#161
- [x] /reference/features/configuration: update description clarifying a user can specify the units L#263
