### PR TITLE
Fix filtering/faceted search redirects

### DIFF
--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -77,5 +77,5 @@
 
 # Group filters and facets content
 /reference/api/attributes_for_faceting.html         /reference/api/filterable_attributes.html
-/reference/feature/filtering.html                   /reference/api/filtering_and_faceted_search.html
-/reference/feature/faceted_search.html              /reference/api/filtering_and_faceted_search.html
+/reference/feature/filtering.html                   /reference/feature/filtering_and_faceted_search.html
+/reference/feature/faceted_search.html              /reference/feature/filtering_and_faceted_search.html

--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -77,5 +77,5 @@
 
 # Group filters and facets content
 /reference/api/attributes_for_faceting.html         /reference/api/filterable_attributes.html
-/reference/feature/filtering.html                   /reference/feature/filtering_and_faceted_search.html
-/reference/feature/faceted_search.html              /reference/feature/filtering_and_faceted_search.html
+/reference/features/filtering.html                   /reference/features/filtering_and_faceted_search.html
+/reference/features/faceted_search.html              /reference/features/filtering_and_faceted_search.html

--- a/errors.yaml
+++ b/errors.yaml
@@ -21,7 +21,7 @@ errors:
   - code: missing_document_id
     description: "A document does not contain any value for the required primary key, and is thus invalid. Check documents in the current addition for the invalid ones."
   - code: invalid_filter
-    description: "The filter provided with the search is invalid. Check our [guide on filtering](https://docs.meilisearch.com/reference/features/filtering.html) to troubleshoot."
+    description: "The filter provided with the search is invalid. Check our [guide on filtering](https://docs.meilisearch.com/reference/features/filtering_and_faceted_search.html) to troubleshoot."
   - code: bad_request
     description: "The request is invalid, check the error message for more information."
   - code: document_not_found


### PR DESCRIPTION
As reported on meilisearch/MeiliSearch/issues/1648, old links pointing to `reference/features/filtering` do not work and lead the user to a 404.

The reason for this is that the current redirect rule sends users to the `/reference/api/filtering_and_faceted_search.html`  instead of `/reference/features/filtering_and_faceted_search.html`