### PR TITLE
Remove MeiliSearch dataset dependency

### DIFF
--- a/reference/under_the_hood/storage.md
+++ b/reference/under_the_hood/storage.md
@@ -52,7 +52,7 @@ MeiliSearch will always demand a certain amount of space to use as a [memory map
 
 ## Measured disk usage
 
-We did some measurements on the default [movies.json](https://github.com/meilisearch/MeiliSearch/blob/master/datasets/movies/movies.json) dataset that you can find in the [getting started guide](/learn/getting_started/quick_start.md#add-documents).
+We did some measurements on the default <a id="downloadMovie" href="/movies.json" download="movies.json">movies.json</a> dataset that you can find in the [getting started guide](/learn/getting_started/quick_start.md#add-documents).
 
 This dataset is a JSON file of 8.6 MB and has 19,553 documents. When we index this file in MeiliSearch, the amount of disk space taken by LMDB is 122MB.
 

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -47,7 +47,9 @@ If you have any hesitation about your language handling, please contact us.
 
 ## Do you provide a real dataset to test MeiliSearch?
 
-For now, we provide this [movies dataset](https://github.com/meilisearch/MeiliSearch/blob/master/datasets/movies/movies.json). More datasets are coming soon!
+In this documentation, we provide this <a id="downloadMovie" href="/movies.json" download="movies.json">movies.json</a> dataset.
+
+More datasets and setting configurations are available [in this repository](https://github.com/meilisearch/datasets/).
 
 ## I did a call to an API route, and I only got an `updateId` as a response. What does it mean?
 


### PR DESCRIPTION
Remove the links coming from the dataset contained in the MeiliSearch's repository: https://github.com/meilisearch/MeiliSearch/tree/main/datasets/movies