### PR TITLE
Add trace in log level

### DIFF
--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -199,6 +199,7 @@ MeiliSearch currently supports four log levels, listed in order of increasing ve
 - `'WARN:'` log all unexpected events, regardless of their severity
 - `'INFO:'` log all events. This is the default value of `--log-level`
 - `'DEBUG'`: log all events and including detailed information on MeiliSearch's internal processes. Useful when diagnosing issues and debugging
+- `'TRACE'`: log all events, details, and even more detailed information on MeiliSearch's internal processes. We do not advise using this level as it is overkill. Consider using `DEBUG` instead.
 
 ### Max index size
 

--- a/reference/features/configuration.md
+++ b/reference/features/configuration.md
@@ -199,7 +199,7 @@ MeiliSearch currently supports four log levels, listed in order of increasing ve
 - `'WARN:'` log all unexpected events, regardless of their severity
 - `'INFO:'` log all events. This is the default value of `--log-level`
 - `'DEBUG'`: log all events and including detailed information on MeiliSearch's internal processes. Useful when diagnosing issues and debugging
-- `'TRACE'`: log all events, details, and even more detailed information on MeiliSearch's internal processes. We do not advise using this level as it is overkill. Consider using `DEBUG` instead.
+- `'TRACE'`: log all events, and even more detailed information on MeiliSearch's internal processes. We do not advise using this level as it is overkill and overwhelming. Use `DEBUG` before considering `TRACE`.
 
 ### Max index size
 


### PR DESCRIPTION
To keep the doc exhaustive and follow the moto 

> the documentation is always complete but never finished

I think we should not hide any feature. 

I've added the missing log level as this may be used by external contributors but also for futur meili developers that uses the doc to know the possibilities MeiliSeach offers. 
