### PR TITLE
add sort param to GET and POST search routes

### DIFF
--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -35,8 +35,10 @@ This is the preferred route to perform search when an API key is required, as it
 | **cropLength**            | `Integer`              | Length used to crop field values                                                                | `200`                                                                                           |
 | **attributesToHighlight** | `[Strings]`            | Attributes whose values will contain highlighted matching terms                                 | `null`                                                                                          |
 | **matches**               | `Boolean`              | Defines whether an object that contains information about the matches should be returned or not | `false`                                                                                         |
+| **sort**               | `[Strings]`              | Sort search results according to the attributes and sorting order (`asc` or `desc`) specified | `null`                                                                                         |
 > `filter` accepts a query string. You can find more about the filter syntax on [our dedicated page](/reference/features/filtering_and_faceted_search.md).
 > `cropLength` is automatically rounded to match word boundaries.
+> `sort` requires attributes to be given as `attribute:sorting_order`. You can find more about the syntax on [our dedicate page](/reference/features/sorting.md#using-sort).
 
 [Learn more about how to use the search parameters](/reference/features/search_parameters.md).
 
@@ -129,9 +131,11 @@ This route should only be used when no API key is required. If an API key is req
 | **[cropLength](/reference/features/search_parameters.md#crop-length)**                        | Length used to crop field values                                                                |    `200`      |
 | **[attributesToHighlight](/reference/features/search_parameters.md#attributes-to-highlight)** | Attributes whose values will contain highlighted matching terms                                 |    `null`     |
 | **[matches](/reference/features/search_parameters.md#matches)**                               | Defines whether an object that contains information about the matches should be returned or not |   `false`     |
+| **[sort](/reference/features/search_parameters.md#sort)**                               | Sort search results according to the attributes and sorting order (`asc` or `desc`) specified |   `null`     |
 
 > `filter` accepts a query string. You can find about the filter syntax on [our dedicated page](/reference/features/filtering_and_faceted_search.md).
 > `cropLength` is automatically rounded to match word boundaries.
+> `sort` requires attributes to be given as `attribute:sorting_order`. You can find more about the syntax on [our dedicate page](/reference/features/sorting.md#using-sort).
 
 [Learn more about how to use the search parameters](/reference/features/search_parameters.md).
 


### PR DESCRIPTION
Hey guys, thank you for a really awesome project!

I noticed that the `sort` param is not present in the API reference for the [GET](https://docs.meilisearch.com/reference/api/search.html#query-parameters) and [POST](https://docs.meilisearch.com/reference/api/search.html#body) search routes. I eventually learned about the `sort` param from the `/references/features/search_parameters` page, but I think it would be great to have it under `/references/api/search` as well.

I honestly haven't checked if there is an existing PR/issue about this, so apologies if this is a duplicate. Feel free to close this if that's the case!
