### PR TITLE
./vuepress/code-samples/sdks.json: fix path to cURL samples

### DIFF
--- a/.vuepress/code-samples/sdks.json
+++ b/.vuepress/code-samples/sdks.json
@@ -2,7 +2,7 @@
   {
     "language": "bash",
     "label": "cURL",
-    "url": "https://raw.githubusercontent.com/meilisearch/documentation/main/.code-samples.meilisearch.yaml"
+    "url": "https://raw.githubusercontent.com/meilisearch/documentation/master/.code-samples.meilisearch.yaml"
   },
   {
     "language": "javascript",


### PR DESCRIPTION
A bit counter-intuitive, but `cURL` code samples are located in the `master`, not the `main` branch.

Fixes #1152.