### PR TITLE
Update dumps directory

### DIFF
--- a/create/how_to/updating.md
+++ b/create/how_to/updating.md
@@ -157,7 +157,7 @@ Now that all fields are displayed, proceed to the next step.
 Before creating your dump, make sure that your [dump directory](/reference/features/configuration.md#dumps-destination) is somewhere accessible. By default, dumps are created in a folder called `dumps` at the root of your MeiliSearch directory.
 
 ::: note
-If you are running MeiliSearch in a service using `systemd`, like AWS or a DO droplet, the dumps folder can be found at the root directory, `cd /`.
+If you are running MeiliSearch in a service using `systemd`, like AWS or a DO droplet, the dumps folder can be found in the configuration file directory, `cd /var/opt/meilisearch/dumps`.
 :::
 
 If you're unsure where your MeiliSearch directory is located, try this:


### PR DESCRIPTION
The dumps would be now create in a specific directory: `/var/opt/meilisearch/dumps`
This will be available only for MeiliSearch v0.23.0
See: meilisearch/cloud-scripts#55