### PR TITLE
added example for 1000 "words" limitation per attribute

### DIFF
--- a/learn/core_concepts/documents.md
+++ b/learn/core_concepts/documents.md
@@ -54,11 +54,34 @@ An attribute functions a bit like a variable in most programming languages, i.e.
 
 Every field has a [data type](/reference/under_the_hood/datatypes.md) dictated by its value. Every value must be a valid [`JSON` data type](https://www.w3schools.com/js/js_json_datatypes.asp).
 
-Take note that in the case of strings, the value **[can contain at most 1000 words](/reference/features/known_limitations.md#maximum-words-per-attribute)**. If it contains more than 1000 words, only the first 1000 will be indexed.
-
 You can also apply [<clientGlossary word="ranking rules" />](/learn/core_concepts/relevancy.md#ranking-rules) to some fields. For example, you may decide recent movies should be more relevant than older ones.
 
 If you would like to adjust how a field gets handled by MeiliSearch, you can do so in the [settings](/reference/features/settings.md#settings).
+
+Take note that in the case of strings, the value **[can contain at most 1000 positions](/reference/features/known_limitations.md#maximum-words-per-attribute)**. Words exceeding the 1000 position limit will be ignored.
+
+### Example
+
+If your query is `Hello World`
+
+- `Hello` takes the position `0` of the attribute
+- `World` takes the position `1` of the attribute
+
+If your query is `Hello, World`
+
+- `Hello` takes the position `0` of the attribute
+- `,` takes the position `8` of the attribute
+- `World` takes the position `9` of the attribute
+
+`,` takes 8 spaces as it is a hard separator, you can read more about it [here](https://docs.meilisearch.com/reference/under_the_hood/datatypes.html#string).
+
+If your query is `Hello - World`
+
+- `Hello` takes the position `0` of the attribute
+- `-` takes the position `1` of the attribute
+- `World` takes the position `2` of the attribute
+
+`-` takes 1 space as it is a soft separator, you can read more about it [here](https://docs.meilisearch.com/reference/under_the_hood/datatypes.html#string).
 
 ### Field properties
 

--- a/reference/features/known_limitations.md
+++ b/reference/features/known_limitations.md
@@ -18,7 +18,7 @@ Currently, MeiliSearch has a number of known limitations. Some of these limitati
 
 ### Maximum words per attribute
 
-**Limitation:** MeiliSearch can index a maximum of __1000 words per attribute__. If an attribute contains more than 1000 words, only the first 1000 words will be indexed and the rest will be silently ignored.
+**Limitation:** MeiliSearch can index a maximum of __1000 positions per attribute__. Any words exceeding the 1000 position limit will be silently ignored.
 
 **Explanation:** This limit is enforced for relevancy reasons. The more words there are in a given attribute, the less relevant the search queries will be.
 


### PR DESCRIPTION
# Documents
A **document** is an object composed of one or more **<clientGlossary word="field" label="fields"/>**. Each field consists of an **<clientGlossary word="attribute" />** and its associated **<clientGlossary word="value" />**.
Documents function as **containers for organizing data**, and are the basic building blocks of a MeiliSearch database. To search for a document, it must first be added to an [index][indexes].
## Structure
![document structure](/document_structure.svg =573x400)
### Important terms
- **Document**: an object which contains data in the form of one or more fields.
- **[Field][fields]**: a set of two data items that are linked together: an **attribute** and a **value**.
- **Attribute**: the first part of a field. Acts as a name or description for its associated value.
- **Value**: the second part of a field, consisting of data of any valid `JSON` type.
- **[Primary Field][primary-field]**: A special field that is mandatory in all documents. It contains the primary key and document identifier.
- **[Primary Key][primary-key]**: the attribute of the primary field. **All documents in the same index must possess the same primary key.** Its associated value is the document identifier.
- **[Document Identifier][document-id]**: the value of the primary field. **Every document in a given index must have a unique identifier**.
### Formatting
Documents are represented as `JSON objects`: key-value pairs enclosed by curly brackets. As such, [any rule that applies to formatting `JSON objects`](https://www.w3schools.com/js/js_json_objects.asp) also applies to formatting MeiliSearch documents. For example, **an attribute must be a string**, while **a value must be a valid [`JSON` data type](https://www.w3schools.com/js/js_json_datatypes.asp)**.
As an example, let's say you are making an **[index][indexes]** that contains information about movies. A sample document might look like this:
```json
{
  "id": "1564saqw12ss",
  "title": "Kung Fu Panda",
  "genre": "Children's Animation",
  "release-year": 2008,
  "cast": [ {"Jack Black": "Po"}, {"Jackie Chan": "Monkey"} ]
}
```
In the above example, `"id"`, `"title"`, `"genre"`, `"release-year"`, and `"cast"` are **attributes**.
Each attribute must be associated with a **value**, e.g. `"Kung Fu Panda"` is the value of `"title"`.
At minimum, the document must contain one field with the **[primary key][primary-key]** attribute and a unique **[document id][document-id]** as its value. Above, that's: `"id": "1564saqw12ss"`.
### Limitations and requirements
Documents have a **soft maximum of 1000 fields**; beyond that the [<clientGlossary word="ranking rules" />](/learn/core_concepts/relevancy.md#ranking-rules) may no longer be effective, leading to undefined behavior.
Additionally, every document must have at minimum one field containing the **[<clientGlossary word="primary key" />][primary-key]** and a **[unique id][document-id]**.
If you try to [index a document](/learn/getting_started/quick_start.md#add-documents) that's incorrectly formatted, missing a primary key, or possessing the [wrong primary key for a given index](/learn/core_concepts/indexes.md#primary-key), it will cause an error and no documents will be added.
## Fields
A <clientGlossary word="field" /> is a set of two data items linked together: an <clientGlossary word="attribute" /> and a value. Documents are made up of fields.
An attribute functions a bit like a variable in most programming languages, i.e. it is a name that allows you to store, access, and describe some data. That data is the attribute's **value**.

Every field has a [data type](/reference/under_the_hood/datatypes.md) dictated by its value. Every value must be a valid [`JSON` data type](https://www.w3schools.com/js/js_json_datatypes.asp).

Take note that in the case of strings, the value **[can contain at most 1000 words](/reference/features/known_limitations.md#maximum-words-per-attribute)**. If it contains more than 1000 words, only the first 1000 will be indexed.

You can also apply [<clientGlossary word="ranking rules" />](/learn/core_concepts/relevancy.md#ranking-rules) to some fields. For example, you may decide recent movies should be more relevant than older ones.

If you would like to adjust how a field gets handled by MeiliSearch, you can do so in the [settings](/reference/features/settings.md#settings).

Take note that in the case of strings, the value **[can contain at most 1000 positions](/reference/features/known_limitations.md#maximum-words-per-attribute)**. Words exceeding the 1000 position limit will be ignored.

### Example

If your query is `Hello World`

- `Hello` takes the position `0` of the attribute
- `World` takes the position `1` of the attribute

If your query is `Hello, World`

- `Hello` takes the position `0` of the attribute
- `,` takes the position `8` of the attribute
- `World` takes the position `9` of the attribute

`,` takes 8 spaces as it is a hard separator, you can read more about it [here](https://docs.meilisearch.com/reference/under_the_hood/datatypes.html#string).

If your query is `Hello - World`

- `Hello` takes the position `0` of the attribute
- `-` takes the position `1` of the attribute
- `World` takes the position `2` of the attribute

`-` takes 1 space as it is a soft separator, you can read more about it [here](https://docs.meilisearch.com/reference/under_the_hood/datatypes.html#string).

### Field properties

A field may also possess **[field properties](/reference/features/field_properties.md)**. Field properties determine the characteristics and behavior of the data added to that field.
  2  reference/features/known_limitations.md 
@@ -18,7 +18,7 @@ Currently, MeiliSearch has a number of known limitations. Some of these limitati

### Maximum words per attribute

**Limitation:** MeiliSearch can index a maximum of __1000 words per attribute__. If an attribute contains more than 1000 words, only the first 1000 words will be indexed and the rest will be silently ignored.
**Limitation:** MeiliSearch can index a maximum of __1000 positions per attribute__. Any words exceeding the 1000 position limit will be silently ignored.

**Explanation:** This limit is enforced for relevancy reasons. The more words there are in a given attribute, the less relevant the search queries will be.