### PR TITLE
Fix typos found in documentation

### DIFF
--- a/learn/contributing/contributing_to_docs.md
+++ b/learn/contributing/contributing_to_docs.md
@@ -76,7 +76,7 @@ For **reviewing issues**, we consider a couple criteria:
 2. Is our documentation the best place for this information? Sometimes an idea for new content might work better on our blog than the docs, or it might be more effective to link to an external resource than write it ourselves.
 3. Can we reproduce this error?
 
-If multiple people create similar issues (or upvote 👍 an issue to show suport), that makes us more likely to divert resources towards that task.
+If multiple people create similar issues (or upvote 👍 an issue to show support), that makes us more likely to divert resources towards that task.
 
 For **reviewing contributor PRs**, we start by making sure the PR is up to our **quality standard**.
 

--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -309,7 +309,7 @@ The code above comes in multiple parts:
 
 - The `<body>` of the page is the entry point for React. `instant-meilisearch` adds the search bar and search results here by manipulating the DOM.
 - `<script src="..">` tags are [CDNs](https://en.wikipedia.org/wiki/Content_delivery_network) that import libraries needed to run `instant-meilisearch` in [React](https://reactjs.org/).
-- The `<script>` containing JavaScript initalize React and renders the code that will be rendered in the body. Customization of `instant-meilisearch` happens here as well.
+- The `<script>` containing JavaScript initialize React and renders the code that will be rendered in the body. Customization of `instant-meilisearch` happens here as well.
 
 To use `instant-meilisearch` in `React` using `npm` or `yarn` please visit [meilisearch-react](https://github.com/meilisearch/meilisearch-react).
 

--- a/reference/api/dump.md
+++ b/reference/api/dump.md
@@ -38,7 +38,7 @@ Get the status of a dump creation process using the uid returned after calling t
 The returned status could be:
 
 - `in_progress`: Dump creation is in progress.
-- `failed`: An error occured during dump process, and the task was aborted.
+- `failed`: An error occurred during dump process, and the task was aborted.
 - `done`: Dump creation is finished and was successful.
 
 ### Example


### PR DESCRIPTION
Fix some typos i found in the documentations