### PR TITLE
#FreeUnderTheHood

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -161,7 +161,7 @@ module.exports = {
         {
           title: '🛠️ Under the Hood',
           path: '/reference/under_the_hood/',
-          collapsable: true,
+          collapsable: false,
           children: [
             '/reference/under_the_hood/bucket_sort',
             '/reference/under_the_hood/concat',


### PR DESCRIPTION
For too long the "Under the Hood" section of our docs has been automatically collapsed, hidden, living like a second-class citizen. No more.

It's time to #FreeUnderTheHood

(I love this job)