### PR TITLE
minor changes to windows installation instructions

### DIFF
--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -35,7 +35,7 @@ meilisearch
 :::
 
 ::: tab Docker
-Using **Docker** you can choose to run [any available tags](https://hub.docker.com/r/getmeili/meilisearch/tags).
+Using **Docker** you can choose to run [any available tag](https://hub.docker.com/r/getmeili/meilisearch/tags).
 
 This command starts the **latest stable release** of MeiliSearch.
 
@@ -100,12 +100,12 @@ cargo build --release
 
 To install MeiliSearch on Windows, you can:
 
-- use Docker
+- use Docker (see "Docker" tab above)
 - [download the latest binary](https://github.com/meilisearch/MeiliSearch/releases)
-- use the installation script (cf `cURL` tab) if you have installed [Cygwin](https://www.cygwin.com/) or equivalent
-- compile from source
+- use the installation script (see "cURL" tab above) if you have installed [Cygwin](https://www.cygwin.com/) or equivalent
+- compile from source (see "Source" tab above)
 
-If you are new to the Windows CMD, you can follow this [guide](https://www.makeuseof.com/tag/a-beginners-guide-to-the-windows-command-line/) to get started.
+To learn more about the Windows command prompt, follow this [introductory guide](https://www.makeuseof.com/tag/a-beginners-guide-to-the-windows-command-line/).
 
 ::::
 


### PR DESCRIPTION
direct continuation of PR #1122

the choice of how to describe the windows command line is really tricky.

"command line": most common term, very clear to most programmers, but technically inaccurate since Windows doesn't contain a built-in command line.
"command prompt": most accurate—it's what window has built-in—but it's a much less commonly used term than "command line", and the word "prompt" could be unclear to non-native speakers
"CMD" or "cmd.exe": it's the name of the program so therefore sort of unmistakeable, but could mean absolutely nothing to the reader. also confusing because **cmd is the CMD command to open cmd.exe** (this sentence hurts my brain)

i went with "command prompt" because it gives the most helpful and relevant google results.