### PR TITLE
Improve the docker command to launch MeiliSearch

### DIFF
--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -40,10 +40,14 @@ Using **Docker** you can choose to run [any available tags](https://hub.docker.c
 This command starts the **latest stable release** of MeiliSearch.
 
 ```bash
+# Fetch the latest version of MeiliSearch image from DockerHub
+docker pull getmeili/meilisearch:latest
+
+# Launch MeiliSearch
 docker run -it --rm \
     -p 7700:7700 \
     -v $(pwd)/data.ms:/data.ms \
-    getmeili/meilisearch
+    getmeili/meilisearch:latest
 ```
 
 Data written to a **Docker container is not persistent** and is deleted along with the container when the latter is stopped. Docker volumes are not deleted when containers are removed. It is then recommended to share volumes between your containers and your host machine to provide persistent storage. MeiliSearch writes data to `/data.ms`


### PR DESCRIPTION
This ensures the users will run the real `latest` Docker image of MeiliSearch and not the one found locally.
Indeed, when running

```
docker run -it --rm \
    -p 7700:7700 \
    -v $(pwd)/data.ms:/data.ms \
    getmeili/meilisearch:latest
```

Docker will try to find the `latest` image locally, and only if it does not find any local image for `getmeili/meilisearch:latest`, it will fetch the new one remotely. So the users can think they are using the latest stable version of MeiliSearch, but actually, they are using an older one.

Also, I made the command clearer because `getmeili/meilisearch` = `getmeili/meilisearch:latest`, which is not obvious for every new Docker user.