### PR TITLE
V0.24: attributesToHighlight

### DIFF
--- a/reference/features/search_parameters.md
+++ b/reference/features/search_parameters.md
@@ -299,18 +299,18 @@ If `attributesToCrop` is not configured, `cropLength` has no effect on the retur
 **Expected value**: an array of <clientGlossary word="attribute" label="attributes" /> or `["*"]`
 **Default value**: `null`
 
-Highlights matching query terms in the specified attributes. Both string and numeric values, whether inside arrays and objects or not, are highlighted.
-
-Parameter values must be given as an array of attributes: `attributesToHighlight=["attributeA", "attributeB"]`.
-
-Alternatively, you can provide `["*"]` as a value: `attributesToHighlight=["*"]`. In this case, all the attributes present in `attributesToRetrieve` will be assigned to `attributesToHighlight`.
+Highlights matching query terms in the specified attributes by enclosing them in `<em>` tags. `attributesToHighlight` highlights matches in fields containing strings, numeric values, arrays, and objects.
 
 When this parameter is set, returned documents include a `_formatted` object containing the highlighted terms.
 
-::: tip
-The highlighting performed by this parameter consists of wrapping matching query terms in `<em>` tags. It is not possible to change the tag or its attributes.
+Parameter values must be given as an array of attributes: `attributesToHighlight=["attributeA", "attributeB"]`.
 
-If you need finer control over the highlights and their format, we recommend using [the `matches` search parameter](#matches).
+Alternatively, you can provide `["*"]` as a value: `attributesToHighlight=["*"]`. In this case, all the attributes present in [`attributesToRetrieve`](/reference/features/search_parameters.md#attributes-to-retrieve) will be assigned to `attributesToHighlight`.
+
+::: tip
+It is not possible to change the `<em>` tag or its attributes.
+
+If you need finer control over the formatted output, we recommend using [the `matches` search parameter](#matches).
 :::
 
 ### Example

--- a/reference/features/search_parameters.md
+++ b/reference/features/search_parameters.md
@@ -299,7 +299,7 @@ If `attributesToCrop` is not configured, `cropLength` has no effect on the retur
 **Expected value**: an array of <clientGlossary word="attribute" label="attributes" /> or `["*"]`
 **Default value**: `null`
 
-Highlights matching query terms in the specified attributes by enclosing them in `<em>` tags. `attributesToHighlight` highlights matches in fields containing strings, numeric values, arrays, and objects.
+Highlights matching query terms in the specified attributes by enclosing them in `<em>` tags. `attributesToHighlight` only works on values of the following types: string, number, array, object.
 
 When this parameter is set, returned documents include a `_formatted` object containing the highlighted terms.
 
@@ -319,7 +319,7 @@ The following query highlights matches present in the `overview` attribute:
 
 <CodeSamples id="search_parameter_guide_highlight_1" />
 
-The highlighted version can then be found in the returned document's `_formatted` object:
+The highlighted version of the text would then be found in the `_formatted` object included in each returned document:
 
 ```json
 {

--- a/reference/features/search_parameters.md
+++ b/reference/features/search_parameters.md
@@ -299,25 +299,27 @@ If `attributesToCrop` is not configured, `cropLength` has no effect on the retur
 **Expected value**: an array of <clientGlossary word="attribute" label="attributes" /> or `["*"]`
 **Default value**: `null`
 
-Highlights matching query terms in the given attributes. When this parameter is set, the `_formatted` object is added to the response for each document, within which you can find the highlighted text.
+Highlights matching query terms in the specified attributes. Both string and numeric values, whether inside arrays and objects or not, are highlighted.
 
-Values can be supplied as an array of attributes: `attributesToHighlight=["attributeA", "attributeB"]`.
+Parameter values must be given as an array of attributes: `attributesToHighlight=["attributeA", "attributeB"]`.
 
 Alternatively, you can provide `["*"]` as a value: `attributesToHighlight=["*"]`. In this case, all the attributes present in `attributesToRetrieve` will be assigned to `attributesToHighlight`.
 
-::: tip
-The highlighting performed by this parameter consists of wrapping matching query terms in `<em>` tags. Neither this tag nor this behavior can be modified.
+When this parameter is set, returned documents include a `_formatted` object containing the highlighted terms.
 
-If a different type of highlighting is desired, we recommend [the `matches` parameter](#matches), which provides much finer control over the output.
+::: tip
+The highlighting performed by this parameter consists of wrapping matching query terms in `<em>` tags. It is not possible to change the tag or its attributes.
+
+If you need finer control over the highlights and their format, we recommend using [the `matches` search parameter](#matches).
 :::
 
 ### Example
 
-If you wanted to highlight query matches that appear within the `overview` attribute:
+The following query highlights matches terms present in the `overview` attribute:
 
 <CodeSamples id="search_parameter_guide_highlight_1" />
 
-You would get the following response with the **highlighted version in the `_formatted` object**:
+The highlighted version can be found in the returned document's `_formatted` object:
 
 ```json
 {

--- a/reference/features/search_parameters.md
+++ b/reference/features/search_parameters.md
@@ -315,11 +315,11 @@ If you need finer control over the formatted output, we recommend using [the `ma
 
 ### Example
 
-The following query highlights matches terms present in the `overview` attribute:
+The following query highlights matches present in the `overview` attribute:
 
 <CodeSamples id="search_parameter_guide_highlight_1" />
 
-The highlighted version can be found in the returned document's `_formatted` object:
+The highlighted version can then be found in the returned document's `_formatted` object:
 
 ```json
 {

--- a/reference/features/search_parameters.md
+++ b/reference/features/search_parameters.md
@@ -303,9 +303,7 @@ Highlights matching query terms in the specified attributes by enclosing them in
 
 When this parameter is set, returned documents include a `_formatted` object containing the highlighted terms.
 
-Parameter values must be given as an array of attributes: `attributesToHighlight=["attributeA", "attributeB"]`.
-
-Alternatively, you can provide `["*"]` as a value: `attributesToHighlight=["*"]`. In this case, all the attributes present in [`attributesToRetrieve`](/reference/features/search_parameters.md#attributes-to-retrieve) will be assigned to `attributesToHighlight`.
+You can provide `["*"]` as a value: `attributesToHighlight=["*"]`. In this case, all the attributes present in [`attributesToRetrieve`](/reference/features/search_parameters.md#attributes-to-retrieve) will be assigned to `attributesToHighlight`.
 
 ::: tip
 It is not possible to change the `<em>` tag or its attributes.

--- a/reference/features/search_parameters.md
+++ b/reference/features/search_parameters.md
@@ -332,7 +332,7 @@ The highlighted version can then be found in the returned document's `_formatted
     "id": "50393",
     "title": "Kung Fu Panda Holiday",
     "poster": "https://image.tmdb.org/t/p/w1280/gp18R42TbSUlw9VnXFqyecm52lq.jpg",
-    "overview": "The Winter Feast is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year <em>Shifu</em> informs Po that as Dragon Warrior, it is his duty to host the formal Winter Feast at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between <em>Shifu</em> and Mr. Ping.",
+    "overview": "The <em>Winter Feast</em> is Po's favorite holiday. Every year he and his father hang decorations, cook together, and serve noodle soup to the villagers. But this year Shifu informs Po that as Dragon Warrior, it is his duty to host the formal <em>Winter Feast</em> at the Jade Palace. Po is caught between his obligations as the Dragon Warrior and his family traditions: between Shifu and Mr. Ping.",
     "release_date": 1290729600
   }
 }


### PR DESCRIPTION
 In v0.24, `attributesToHighlight` works on both string and numeric values.

This PR updates the text to reflect that change and generally tries to improve wording on this search parameter's reference.