### PR TITLE
Revert "users should check the index status before they start searching"

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -413,9 +413,6 @@ getting_started_add_documents_md: |-
     -H 'Content-Type: application/json' \
     --data-binary @movies.json
   ```
-getting_started_get_update: |-
-  curl \
-    -X GET 'http://localhost:7700/indexes/movies/updates/0' 
 getting_started_search_md: |-
   ```bash
   curl \

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -68,7 +68,6 @@ settings_guide_searchable_1: |-
 settings_guide_displayed_1: |-
 documents_guide_add_movie_1: |-
 getting_started_add_documents_md: |-
-getting_started_get_update: |-
 getting_started_search_md: |-
 faceted_search_update_settings_1: |-
 faceted_search_filter_1: |-

--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -101,15 +101,7 @@ See our guide on [asynchronous updates](/learn/advanced/asynchronous_updates.md)
 
 ## Search
 
-Before you start querying, we recommend that you check the status of your index. You can do that using:
-
-<CodeSamples id="getting_started_get_update" />
-
-Once the update shows `processed`, you can start searching.
-
-::: warning
-Attempting to search before all documents are indexed will result in undefined behavior.
-:::
+Now that your documents have been ingested into MeiliSearch, you are able to search them.
 
 MeiliSearch [offers many parameters](/reference/features/search_parameters.md) that you can play with to refine your search or change the format of the returned documents. However, by default, the search is already relevant.
 


### PR DESCRIPTION
Reverts meilisearch/documentation#1173

We have an unknown error causing this new code sample to not be found. In addition, it should perhaps be standardized with the other getting started code samples (use `127.0.0.1` instead of `localhost`; wrapped in three upticks and marked as bash).

We also still need to request the integrations team to create code samples in other languages for this. So let's take a little longer to work on this PR.