### PR TITLE
Add state manager to store last active code language tab.

### DIFF
--- a/.vuepress/code-samples/client.js
+++ b/.vuepress/code-samples/client.js
@@ -1,6 +1,10 @@
 import CodeSamples from './components/codeSamples'
+import Vuex from 'vuex'
+import store from './store'
 
 export default function (ctx) {
   const { Vue } = ctx
+  Vue.use(Vuex)
+  Vue.mixin({ store: store })
   Vue.component('CodeSamples', CodeSamples)
 }

--- a/.vuepress/code-samples/components/codeSamples.vue
+++ b/.vuepress/code-samples/components/codeSamples.vue
@@ -32,17 +32,28 @@ export default {
   data() {
     return {
       samples: undefined,
+      preferedLanguage: undefined,
     }
   },
   computed: {
     tabsLanguage() {
-      return this.$store.state.tabsLanguage
+      this.resolvePreferedTabsLanguage()
+      return this.preferedLanguage
     },
   },
   created() {
     this.samples = CODE_SAMPLES[this.id]
   },
   methods: {
+    /*
+    * Check if the prefered language found in the store has an existing matching code-sample-id.
+    * If not, defaults to the first language it finds in the list (often bash).
+    */
+    resolvePreferedTabsLanguage: function () {
+      const languages = this.samples.map(sample => sample.language)
+      const storedTabsLanguage = this.$store.state.tabsLanguage
+      this.preferedLanguage = languages.includes(storedTabsLanguage) ? storedTabsLanguage : languages[0]
+    },
     /*
     * Updates the tabs language state with the current active tab language.
     * Storage of the state is done in `./store.js`

--- a/.vuepress/code-samples/components/codeSamples.vue
+++ b/.vuepress/code-samples/components/codeSamples.vue
@@ -1,10 +1,14 @@
 <template>
-  <div>
-    <tabs v-if="samples" type="border-card">
+  <!-- The click listener updates the prefered tabs language state in ./store.js -->
+  <div @click="updateLanguage">
+    <!-- the active-name prop defines the current active tab -->
+    <tabs v-if="samples" type="border-card" :active-name="tabsLanguage">
+      <!-- the `name` prop compares with the parent `active-name` to determine if it is the active tab or not -->
       <tab
         v-for="sample in samples"
         :key="sample.language"
         :label="sample.label"
+        :name="sample.language"
       >
         <div v-html="sample.code" />
       </tab>
@@ -30,8 +34,26 @@ export default {
       samples: undefined,
     }
   },
+  computed: {
+    count() {
+      return this.$store.state.count
+    },
+    tabsLanguage() {
+      return this.$store.state.tabsLanguage
+    },
+  },
   created() {
     this.samples = CODE_SAMPLES[this.id]
+  },
+  methods: {
+    /*
+    * Updates the tabs language state with the current active tab language.
+    * Storage of the state is done in `./store.js`
+    */
+    updateLanguage: function (event) {
+      const tabsLanguage = event.target.id.replace('tab-', '')
+      this.$store.commit('changeTabsLanguage', tabsLanguage)
+    },
   },
 }
 </script>

--- a/.vuepress/code-samples/components/codeSamples.vue
+++ b/.vuepress/code-samples/components/codeSamples.vue
@@ -35,9 +35,6 @@ export default {
     }
   },
   computed: {
-    count() {
-      return this.$store.state.count
-    },
     tabsLanguage() {
       return this.$store.state.tabsLanguage
     },
@@ -51,8 +48,11 @@ export default {
     * Storage of the state is done in `./store.js`
     */
     updateLanguage: function (event) {
-      const tabsLanguage = event.target.id.replace('tab-', '')
-      this.$store.commit('changeTabsLanguage', tabsLanguage)
+      const classList = [...event.target.classList] // transform DOMTokenList to Array type to make it iterable.
+      if (classList.includes('el-tabs__item')) { // check if clicked element is a tab
+        const tabsLanguage = event.target.id.replace('tab-', '')
+        this.$store.commit('changeTabsLanguage', tabsLanguage)
+      }
     },
   },
 }

--- a/.vuepress/code-samples/render.js
+++ b/.vuepress/code-samples/render.js
@@ -1,12 +1,13 @@
 const vuepressmd = require('@vuepress/markdown')()
 
-function codeBlockWrapper(sample, codeBlockLanguage) {
-  return `\`\`\` ${codeBlockLanguage}\n${sample}\n\`\`\``
+function codeBlockWrapper(sample, language) {
+  // remove if the text is `This code sample has not been added yet :(`
+  return `\`\`\` ${language}\n${sample}\n\`\`\``
 }
 
-function renderCodeSample({ sampleBody, sampleId, codeBlockLanguage }) {
+function renderCodeSample({ sampleBody, sampleId, language }) {
   if (!sampleId.match(/.*_md$/)) {
-    sampleBody = codeBlockWrapper(sampleBody, codeBlockLanguage)
+    sampleBody = codeBlockWrapper(sampleBody, language)
   }
   const htmlRender = vuepressmd.render(sampleBody)
   return htmlRender.html
@@ -25,23 +26,24 @@ module.exports = function (fetchedSamples) {
     const { samples, language, label } = sampleSet
 
     for (const sampleId in samples) {
-      const previousSamples = allSamples[sampleId] || []
+      const sampleBody = samples[sampleId]
 
-      const sampleBody = samples[sampleId] || 'This code sample has not been added yet :('
-      const codeBlockLanguage = samples[sampleId] ? language : ''
+      if (sampleBody) {
+        const previousSamples = allSamples[sampleId] || []
 
-      allSamples[sampleId] = [
-        ...previousSamples,
-        {
-          language, // language identifier. Ex: csharp
-          label, // label appearing on the tab
-          code: renderCodeSample({ // render in HTML
-            sampleBody,
-            sampleId,
-            codeBlockLanguage, // code block language ex: ```javascript ````
-          }),
-        },
-      ]
+        allSamples[sampleId] = [
+          ...previousSamples,
+          {
+            language, // language identifier. Ex: csharp
+            label, // label appearing on the tab
+            code: renderCodeSample({ // render in HTML
+              sampleBody,
+              sampleId,
+              language, // code block language ex: ```javascript ````
+            }),
+          },
+        ]
+      }
     }
     return allSamples
   }, {})

--- a/.vuepress/code-samples/sdks.json
+++ b/.vuepress/code-samples/sdks.json
@@ -35,7 +35,7 @@
     "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-go/main/.code-samples.meilisearch.yaml"
   },
   {
-    "language": "c#",
+    "language": "csharp",
     "label": "C#",
     "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-dotnet/main/.code-samples.meilisearch.yaml"
   },

--- a/.vuepress/code-samples/store.js
+++ b/.vuepress/code-samples/store.js
@@ -1,0 +1,20 @@
+import Vue from 'vue'
+import Vuex from 'vuex'
+
+Vue.use(Vuex)
+
+export default new Vuex.Store({
+  state: {
+    // Uses the stored language in the local storage
+    // if it does not exists, default to `bash`
+    tabsLanguage: localStorage.getItem('tabsLanguage') || 'bash',
+  },
+  mutations: {
+    changeTabsLanguage(state, language) {
+      // Adds the prefered tab language to the local storage
+      localStorage.setItem('tabsLanguage', language)
+      // Update the language state. It will reflect on all code-samples tabs
+      state.tabsLanguage = language
+    },
+  },
+})

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "@popperjs/core": "^2.10.2",
     "mermaid": "8.13.3",
     "moment": "^2.29.1",
-    "vue-eslint-parser": "^7.10.0",
     "vuepress": "^1.8.2",
     "vuepress-plugin-code-copy": "^1.0.6",
     "vuepress-plugin-container": "^2.1.5",
@@ -43,7 +42,8 @@
     "vuepress-plugin-meilisearch": "^0.10.8",
     "vuepress-plugin-seo": "^0.1.4",
     "vuepress-plugin-sitemap": "^2.3.1",
-    "vuepress-plugin-zooming": "^1.1.8"
+    "vuepress-plugin-zooming": "^1.1.8",
+    "vuex": "^3.6.2"
   },
   "engines": {
     "node": ">=12 <15"
@@ -52,6 +52,7 @@
     "vuepress-plugin-check-md/check-md": "https://github.com/bidoubiwa/check-md#add_ignore_pattern"
   },
   "devDependencies": {
+    "vue-eslint-parser": "^7.10.0",
     "babel-eslint": "^10.1.0",
     "bent": "^7.3.12",
     "eslint": "^7.25.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -978,104 +978,6 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-
-"@oclif/command@^1.5.20", "@oclif/command@^1.8.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@oclif/command/-/command-1.8.0.tgz#c1a499b10d26e9d1a611190a81005589accbb339"
-  integrity sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==
-  dependencies:
-    "@oclif/config" "^1.15.1"
-    "@oclif/errors" "^1.3.3"
-    "@oclif/parser" "^3.8.3"
-    "@oclif/plugin-help" "^3"
-    debug "^4.1.1"
-    semver "^7.3.2"
-
-"@oclif/config@^1.15.1", "@oclif/config@^1.17.0":
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/@oclif/config/-/config-1.17.0.tgz#ba8639118633102a7e481760c50054623d09fcab"
-  integrity sha512-Lmfuf6ubjQ4ifC/9bz1fSCHc6F6E653oyaRXxg+lgT4+bYf9bk+nqrUpAbrXyABkCqgIBiFr3J4zR/kiFdE1PA==
-  dependencies:
-    "@oclif/errors" "^1.3.3"
-    "@oclif/parser" "^3.8.0"
-    debug "^4.1.1"
-    globby "^11.0.1"
-    is-wsl "^2.1.1"
-    tslib "^2.0.0"
-
-"@oclif/errors@^1.2.2", "@oclif/errors@^1.3.3":
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/@oclif/errors/-/errors-1.3.5.tgz#a1e9694dbeccab10fe2fe15acb7113991bed636c"
-  integrity sha512-OivucXPH/eLLlOT7FkCMoZXiaVYf8I/w1eTAM1+gKzfhALwWTusxEx7wBmW0uzvkSg/9ovWLycPaBgJbM3LOCQ==
-  dependencies:
-    clean-stack "^3.0.0"
-    fs-extra "^8.1"
-    indent-string "^4.0.0"
-    strip-ansi "^6.0.0"
-    wrap-ansi "^7.0.0"
-
-"@oclif/linewrap@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@oclif/linewrap/-/linewrap-1.0.0.tgz#aedcb64b479d4db7be24196384897b5000901d91"
-  integrity sha512-Ups2dShK52xXa8w6iBWLgcjPJWjais6KPJQq3gQ/88AY6BXoTX+MIGFPrWQO1KLMiQfoTpcLnUwloN4brrVUHw==
-
-"@oclif/parser@^3.8.0", "@oclif/parser@^3.8.3":
-  version "3.8.5"
-  resolved "https://registry.yarnpkg.com/@oclif/parser/-/parser-3.8.5.tgz#c5161766a1efca7343e1f25d769efbefe09f639b"
-  integrity sha512-yojzeEfmSxjjkAvMRj0KzspXlMjCfBzNRPkWw8ZwOSoNWoJn+OCS/m/S+yfV6BvAM4u2lTzX9Y5rCbrFIgkJLg==
-  dependencies:
-    "@oclif/errors" "^1.2.2"
-    "@oclif/linewrap" "^1.0.0"
-    chalk "^2.4.2"
-    tslib "^1.9.3"
-
-"@oclif/plugin-help@^3", "@oclif/plugin-help@^3.2.0":
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/@oclif/plugin-help/-/plugin-help-3.2.3.tgz#cd24010e7eb326782843d3aa6d6b5a4affebb2c3"
-  integrity sha512-l2Pd0lbOMq4u/7xsl9hqISFqyR9gWEz/8+05xmrXFr67jXyS6EUCQB+mFBa0wepltrmJu0sAFg9AvA2mLaMMqQ==
-  dependencies:
-    "@oclif/command" "^1.5.20"
-    "@oclif/config" "^1.15.1"
-    "@oclif/errors" "^1.2.2"
-    chalk "^4.1.0"
-    indent-string "^4.0.0"
-    lodash.template "^4.4.0"
-    string-width "^4.2.0"
-    strip-ansi "^6.0.0"
-    widest-line "^3.1.0"
-    wrap-ansi "^4.0.0"
-
-"@percy/config@^1.0.0-beta.36":
-  version "1.0.0-beta.68"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.0.0-beta.68.tgz#5a4ce58a116bb47db5060aedd13f64dda67ca961"
-  integrity sha512-1M2lWeubTPSMDzIgRSyXJwI6EeJIVNnNhDsU//DnMDNb93B/lpJbLnrvMWVztUh//M0EODXfaP30MXMyy/VF6A==
-  dependencies:
-    "@percy/logger" "1.0.0-beta.68"
-    ajv "^8.6.2"
-    cosmiconfig "^7.0.0"
-    yaml "^1.10.0"
-
-"@percy/logger@1.0.0-beta.68", "@percy/logger@^1.0.0-beta.36":
-  version "1.0.0-beta.68"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.0.0-beta.68.tgz#6c42ba7d7b4350db99c3ba5fa622db7daf27e442"
-  integrity sha512-PmKMLOexQUlsPASy4vQEQRYa0KHec/6xWsAg/wnWhGgmnQA4l9EKcz7ZvjDWA6H+wrErLM+FdvMsd8POf417CQ==
-
-"@percy/migrate@^0.10.0":
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/@percy/migrate/-/migrate-0.10.0.tgz#4157bd8ca1638f1cc072086074c8edec57978abc"
-  integrity sha512-3vOmOPmEeMlIZyCEDClZ2VER+4LH/Zp/YhvLkZeKH9RKxbktROF4Dnfs1u3m4YQ1gglerqK6VXFJfOjLJGyVuw==
-  dependencies:
-    "@oclif/command" "^1.8.0"
-    "@oclif/config" "^1.17.0"
-    "@oclif/plugin-help" "^3.2.0"
-    "@percy/config" "^1.0.0-beta.36"
-    "@percy/logger" "^1.0.0-beta.36"
-    cross-spawn "^7.0.3"
-    inquirer "^8.0.0"
-    inquirer-glob-prompt "^0.1.0"
-    jscodeshift "^0.11.0"
-    semver "^7.3.4"
-
 "@popperjs/core@^2.10.2":
   version "2.10.2"
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.10.2.tgz#0798c03351f0dea1a5a4cabddf26a55a7cbee590"
@@ -4303,9 +4205,9 @@ eslint-plugin-standard@^5.0.0:
   integrity sha512-eSIXPc9wBM4BrniMzJRBm2uoVuXz2EPa+NXPk2+itrVt+r5SbKFERx/IgrK/HmfjddyKVz2f+j+7gBRvu19xLg==
 
 eslint-plugin-vue@^7.9.0:
-  version "7.18.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-7.18.0.tgz#02a452142330c7f27c242db21a1b9e25238540f6"
-  integrity sha512-ceDXlXYMMPMSXw7tdKUR42w9jlzthJGJ3Kvm3YrZ0zuQfvAySNxe8sm6VHuksBW0+060GzYXhHJG6IHVOfF83Q==
+  version "7.20.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-7.20.0.tgz#98c21885a6bfdf0713c3a92957a5afeaaeed9253"
+  integrity sha512-oVNDqzBC9h3GO+NTgWeLMhhGigy6/bQaQbHS+0z7C4YEu/qK/yxHvca/2PTZtGNPsCrHwOTgKMrwu02A9iPBmw==
   dependencies:
     eslint-utils "^2.1.0"
     natural-compare "^1.4.0"
@@ -10015,6 +9917,11 @@ vuepress@^1.8.2:
     envinfo "^7.2.0"
     opencollective-postinstall "^2.0.2"
     update-notifier "^4.0.0"
+
+vuex@^3.6.2:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/vuex/-/vuex-3.6.2.tgz#236bc086a870c3ae79946f107f16de59d5895e71"
+  integrity sha512-ETW44IqCgBpVomy520DT5jf8n0zoCac+sxWnn+hMe/CzaSejb/eVw2YToiXYX+Ex/AuHHia28vWTq4goAexFbw==
 
 watchpack-chokidar2@^2.0.1:
   version "2.0.1"


### PR DESCRIPTION

This PR adds a state manager that upon clicking on a different label in the code-samples tabs, stores the language.

On language update, all other code-samples are updated accordingly. 

Meaning that if I click on `ruby`, the `ruby` tabs becomes not only the active one in the tabs I'm using, but in all others across the documentation. 

**Additionally** The store manager stores the language inside the local storage. 

Meaning that if you reload the page, the `ruby` will still be the one active

