### PR TITLE
Remove code samples arrow

### DIFF
--- a/.vuepress/styles/index.styl
+++ b/.vuepress/styles/index.styl
@@ -27,3 +27,7 @@ body
 
 {$contentClass} a code
   color $accentColor
+
+.el-tabs 
+  .el-tabs__item
+   padding 0 15px


### PR DESCRIPTION
As described on #1249, the docs now have code samples 11 SDKs, which forces janky horizontal scrolling via easy-to-miss buttons.

This PR removes some horizontal padding to avoid horizontal scrolling.