### PR TITLE
standardize authentication_header code sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -465,7 +465,7 @@ phrase_search_1: |-
   --data-binary '{ "q": "\"african american\" horror" }'
 authentication_header_1: |-
   curl -X GET 'http://127.0.0.1:7700/keys' \
-    --header 'X-Meili-API-Key: masterKey'
+    -H 'X-Meili-API-Key: masterKey'
 sorting_guide_update_sortable_attributes_1: |-
   curl \
   -X POST 'http://localhost:7700/indexes/books/settings/sortable-attributes' \

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -465,7 +465,7 @@ phrase_search_1: |-
   --data-binary '{ "q": "\"african american\" horror" }'
 authentication_header_1: |-
   curl -X GET 'http://127.0.0.1:7700/keys' \
-    --header "X-Meili-API-Key: masterKey"
+    --header 'X-Meili-API-Key: masterKey'
 sorting_guide_update_sortable_attributes_1: |-
   curl \
   -X POST 'http://localhost:7700/indexes/books/settings/sortable-attributes' \


### PR DESCRIPTION
For some reason this code sample uses double quotes in its header, where every other code sample on the site use single quotes, e.g. for the `Content-Type` field. It's also the only code sample on the site to use `--header` instead of `-H`. 

Of note, it is the only code sample on our site to demonstrate communicating w/ a protected instance using `X-Meili-API-Key`, so there may be a good reason for this distinction. I can't imagine what it would be though, so it's probably better to be consistent 👀 