### PR TITLE
Revert docker command

### DIFF
--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -46,7 +46,7 @@ docker pull getmeili/meilisearch:latest
 # Launch MeiliSearch
 docker run -it --rm \
     -p 7700:7700 \
-    -v $(pwd)/data.ms:/home/meili/data.ms \
+    -v $(pwd)/data.ms:/data.ms \
     getmeili/meilisearch:latest
 ```
 


### PR DESCRIPTION
I rollback the change I did in this PR https://github.com/meilisearch/documentation/pull/1329

Why? Here is the story

- A [PR](https://github.com/meilisearch/MeiliSearch/pull/1759) regarding the dockerfile was accepted, merged, and released in v0.24.0
- I realized, after the v0.24.0 release, this change in the dockerfile impacted the `data.ms` path: for the docker users, the default path was `/home/meili` and not `/` anymore. So, this change impacted the documentation command as well.
- So I created this PR (https://github.com/meilisearch/documentation/pull/1329) to fix the v0.24.0 documentation
- Some weeks later, we realized this dockerfile PR introduced a bug for the Linux users in v0.24.0
- Many spent a lot of time to fix this, but without any success
- We decided to [rollback the PR](https://github.com/meilisearch/MeiliSearch/pull/2032) and to come back to the initial behavior -> in v0.25.0, the data.ms will be in `/` and not in `/home/meili` anymore
- So, I need to create the PR you see right now, for v0.25.0 😇 

More information here: https://github.com/meilisearch/MeiliSearch/issues/2051