### PR TITLE
Remove unnecessary param from the create key path

### DIFF
--- a/reference/api/keys.md
+++ b/reference/api/keys.md
@@ -146,7 +146,7 @@ For an explanation of these fields, see the [get all keys endpoint](#returned-fi
 
 ## Create a key
 
-<RouteHighlighter method="POST" route="/keys/:key"/>
+<RouteHighlighter method="POST" route="/keys"/>
 
 Create an API key with the provided description, permissions, and expiration date.
 


### PR DESCRIPTION
The param `/:key` is not necessary 🍕 

![image](https://user-images.githubusercontent.com/4116980/149426288-83545cd0-2bb1-406d-8501-09787d27f76d.png)
