### PR TITLE
docs(comparison): clarify some algolia points

### DIFF
--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -97,7 +97,7 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 | Multi-index search | Early 2022 | ✅ | ✅ | ✅ |
 | Exact phrase search | ✅ | ✅ | ❌ | ✅ |
 | Geo search |  ✅  | ✅ | ✅ | ✅ |
-| Sort by  |  ✅  | 🔶 <br> Limited to one `sort_by` rule per index. Indexes have to be duplicated for each sort field and sort order | 🔶 <br> Does not support sort on string field | ✅ |
+| Sort by  |  ✅  | 🔶 <br> Limited to one `sort_by` rule per index. Indexes may have to be duplicated for each sort field and sort order | 🔶 <br> Does not support sort on string field | ✅ |
 | Filtering |  ✅ <br> Support complex filter queries with an SQL-like syntax.  | 🔶 <br> Does not support `OR` operation across multiple fields | 🔶 <br> Does not support `OR` operation across multiple fields | ✅ |
 | Faceted search |  ✅ | ✅ | ✅ | ✅ |
 | Distinct attributes <br><div style="color:#A9A9A9;font-size:0.9em;">De-duplicate documents by a field value</div>| ✅ | ✅ | ✅  | ✅ |
@@ -128,7 +128,7 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 | Maximum number of indexes | No limitation | No limitation | No limitation | No limitation |
 | Maximum index size | 100GB default, configurable  | 128Gb | Constrained by RAM | No limitation |
 | Maximum words per attribute | No limitation | No limitation | No limitation | No limitation |
-| Maximum document size | No limitation | 10KB | No limitation | 100KB default, configurable  |
+| Maximum document size | No limitation | 100KB, configurable | No limitation | 100KB default, configurable  |
 
 ### Community
 


### PR DESCRIPTION
- virtual replicas allow for sorting without the surcharge of duplicating the records: https://www.algolia.com/doc/guides/managing-results/refine-results/sorting/in-depth/relevant-sort/#step-one---create-a-virtual-replica-index
- the default max document size is 100kb, but used to be smaller
