### PR TITLE
Add missing redirect

### DIFF
--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -125,6 +125,9 @@
 # New errors page
 /errors                                             /reference/api/error_codes.html
 
+# Rename Authentication guide
+/reference/features/authentication.html             /reference/features/security.html
+
 # Move Security guide
 /reference/features/security.html                   /learn/advanced/security.html
 


### PR DESCRIPTION
Redirect from old authentication guide location to new security guide location.

We missed this one at the time 😞 Thanks for the reminder @bidoubiwa !