### PR TITLE
Fix the compiling from the source part

### DIFF
--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -114,7 +114,8 @@ To learn more about the Windows command prompt, follow this [introductory guide]
 ::::
 
 ::: tip Compile for Best Performance
-For best performance, compile MeiliSearch on the machine you intend to run it on. This way, the binary is optimized for your specific architecture.
+For best performance, compile MeiliSearch on the machine you intend to run it on with the following environment variable set `RUSTFLAGS="-C target-cpu=native"`.
+This way, the binary is optimized for your CPU, and rust will use more aggressive optimizations.
 :::
 
 ## Cloud deploy


### PR DESCRIPTION
We forgot to the `target-cpu=native` flag when compiling meilisearch from the source, so it had no impact on the performances currently.