### PR TITLE
Explain how to uses tags

### DIFF
--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -85,7 +85,15 @@ git clone https://github.com/meilisearch/MeiliSearch
 cd MeiliSearch
 ```
 
-In the cloned repository, compile MeiliSearch.
+In the cloned repository, you can choose which release you want to use.
+See the list of all release [here](https://github.com/meilisearch/MeiliSearch/releases).
+Then run the following command whith whichever tags you selected:
+
+```bash
+git checkout v0.25.2
+```
+
+The last part is to compile MeiliSearch.
 
 ```bash
 # Update the rust toolchain to the latest version


### PR DESCRIPTION
If a user needs to compile from the source we want him to use a release instead of using the latest commit that was pushed on main.
This commit adds a little explanation on how the tags works
