### PR TITLE
Add integration tools in ressources

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -33,6 +33,36 @@ module.exports = {
               { text: 'Swift', link: 'https://github.com/meilisearch/meilisearch-swift' },
             ],
           },
+          {
+            text: 'Frameworks',
+            items: [
+              { text: 'Rails', link: 'https://github.com/meilisearch/meilisearch-rails' },
+              { text: 'Laravel', link: 'https://github.com/laravel/scout' },
+            ],
+          },
+          {
+            text: 'Front-end tools',
+            items: [
+              { text: 'instant-meiliSearch', link: 'https://github.com/meilisearch/instant-meilisearch' },
+              { text: 'docs-searchbar.js', link: 'https://github.com/meilisearch/docs-searchbar.js' },
+            ],
+          },
+          {
+            text: 'Plugins',
+            items: [
+              { text: 'Gatsby', link: 'https://github.com/meilisearch/gatsby-plugin-meilisearch/' },
+              { text: 'Vuepress', link: 'https://github.com/meilisearch/vuepress-plugin-meilisearch' },
+              { text: 'Strapi', link: 'https://github.com/meilisearch/strapi-plugin-meilisearch/' },
+            ],
+          },
+          {
+            text: 'DevOp tools',
+            items: [
+              { text: 'Kubernetes', link: 'https://github.com/meilisearch/meilisearch-kubernetes' },
+              { text: 'GCP', link: 'https://github.com/meilisearch/meilisearch-gcp' },
+              { text: 'AWS', link: 'https://github.com/meilisearch/meilisearch-aws' },
+            ],
+          },
         ],
       },
       { text: 'Slack', link: 'https://slack.meilisearch.com' },


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Add the integrations inside the resources drop down.

<img width="508" alt="Screenshot 2022-01-26 at 13 47 57" src="https://user-images.githubusercontent.com/33010418/151165668-32723223-ae7f-4670-aa4c-51068c5432df.png">


## Why

Front end and integration meilisearch is a big part of the user experience.
Since the only thing the doc does not cover is how you integrate meilisearch in different environments it could be very cool that we make it accessible for them to be aware of them.

While the navbar is long, I think it is still readable and shows the users that they are able to add their MeiliSearch in a lot of different places! 

Algolia also adds the integrations inside their navbar: 
<img width="1424" alt="Screenshot 2022-01-26 at 13 42 33" src="https://user-images.githubusercontent.com/33010418/151164902-48f7f277-1c12-421d-8d20-7254caad6495.png">

After discussing this with @dichotommy he suggested the following
- Rename `resource` to `integrations`
- Put the FAQ back in the navbar
- Remove the Open API page (finding a new place to add it is something @dichotommy want to work on with the docs team)

