### PR TITLE
Improve browsing experience

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -11,8 +11,8 @@ module.exports = {
     sidebarDepth: 1,
     smoothScroll: true,
     nav: [
-      { text: 'Learn', link: '/learn/' },
-      { text: 'Reference', link: '/reference/' },
+      { text: 'Learn', link: '/learn/getting_started/quick_start' },
+      { text: 'Reference', link: '/reference/api/' },
       { text: 'FAQ', link: '/faq' },
       {
         text: 'Integrations',
@@ -213,20 +213,6 @@ module.exports = {
       ],
       '/reference/': [
         {
-          title: '⭐ Feature references',
-          path: '/reference/features/',
-          collapsable: false,
-          children: [
-            '/reference/features/configuration',
-            '/reference/features/distinct',
-            '/reference/features/field_properties',
-            '/reference/features/search_parameters',
-            '/reference/features/settings',
-            '/reference/features/synonyms',
-            '/reference/features/web_interface',
-          ],
-        },
-        {
           title: '📒 API references',
           path: '/reference/api/',
           collapsable: false,
@@ -260,6 +246,20 @@ module.exports = {
             '/reference/api/version',
             '/reference/api/dump',
             '/reference/api/error_codes',
+          ],
+        },
+        {
+          title: '⭐ Feature references',
+          path: '/reference/features/',
+          collapsable: false,
+          children: [
+            '/reference/features/configuration',
+            '/reference/features/distinct',
+            '/reference/features/field_properties',
+            '/reference/features/search_parameters',
+            '/reference/features/settings',
+            '/reference/features/synonyms',
+            '/reference/features/web_interface',
           ],
         },
       ],

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -1,15 +1,13 @@
 ---
 permalink: /faq.html
+sidebar: auto
 ---
 
 # FAQ
 
 This FAQ is still a work in progress.
-If you have any questions we want to hear from you. Your feedback will help us improve this page!
 
-#### Table of contents
-
-[[toc]]
+If you have any questions, we want to hear from you! Your feedback will help us improve this page.
 
 ## I have never used a search engine before. Can I use Meilisearch anyway?
 

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -5,7 +5,7 @@ sidebar: auto
 
 # FAQ
 
-This FAQ is still a work in progress.
+This FAQ is created in collaboration with our users.
 
 If you have any questions that aren't answered here, we want to hear from you! Your feedback will help us improve our documentation.
 

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -7,7 +7,7 @@ sidebar: auto
 
 This FAQ is still a work in progress.
 
-If you have any questions, we want to hear from you! Your feedback will help us improve this page.
+If you have any questions that aren't answered here, we want to hear from you! Your feedback will help us improve our documentation.
 
 ## I have never used a search engine before. Can I use Meilisearch anyway?
 


### PR DESCRIPTION
Since [removing all site READMEs](github.com/meilisearch/documentation/issues/1293) may [take some more time](github.com/meilisearch/documentation/pull/1400), this PR bundles several non-invasive improvements to browsing experience, such as:

- Add sidebar to the FAQ (replaces table of contents)
- Change Learn and Reference navbar links to point to the quick start and API reference readme, respectively
- Switch the order of API references and feature references in the `/reference` sidebar