### PR TITLE
Remove the compiling from the sources part

### DIFF
--- a/learn/getting_started/installation.md
+++ b/learn/getting_started/installation.md
@@ -113,10 +113,6 @@ To learn more about the Windows command prompt, follow this [introductory guide]
 
 ::::
 
-::: tip Compile for Best Performance
-For best performance, compile Meilisearch on the machine you intend to run it on. This way, the binary is optimized for your specific architecture.
-:::
-
 ## Cloud deploy
 
 To deploy Meilisearch on a cloud service, follow one of our dedicated guides:


### PR DESCRIPTION
closes #1390 
After a little bit of testing, I noticed no difference by compiling from the source.
So instead of updating that part, we decided to remove it entirely, you can see the discussion here: https://github.com/meilisearch/documentation/pull/1390#discussion_r791981840