### PR TITLE
Fix config path checker error handler

### DIFF
--- a/.vuepress/config-path-checker/find-and-check.js
+++ b/.vuepress/config-path-checker/find-and-check.js
@@ -2,12 +2,13 @@ const { isObject } = require('./utils')
 const { addError } = require('./result-report')
 const path = require('path')
 
-function checkPath(givenPath) {
+function checkPath(givenPath, elem) {
   if (givenPath.slice(-1) !== '/') {
+    const origin = (elem && elem.title) ? `section ${elem.title}` : 'config.json'
     addError.call(this, {
       type: 'error',
-      errMsg: 'Path in config.json file is missing a trailing slash',
-      fileUrl: path.join(__dirname, 'find-and-check.js'),
+      errMsg: `In ${origin} the path is missing a trailing slash`,
+      fileUrl: path.join(process.cwd(), '/.vuepress/config.json'),
       fullText: `path: '${givenPath}'`,
       path: givenPath,
     })
@@ -17,7 +18,7 @@ function checkPath(givenPath) {
 function searchForPath(element) {
   if (isObject(element)) {
     if (element.path && element.children) {
-      checkPath.call(this, element.path)
+      checkPath.call(this, element.path, element)
     }
     if (element.children) {
       SearchForChilds.call(this, element.children)

--- a/.vuepress/config-path-checker/find-and-check.js
+++ b/.vuepress/config-path-checker/find-and-check.js
@@ -8,7 +8,7 @@ function checkPath(givenPath) {
       type: 'error',
       errMsg: 'Path in config.json file is missing a trailing slash',
       fileUrl: path.join(__dirname, 'config.json'),
-      fullText: `path: '${path}'`,
+      fullText: `path: '${givenPath}'`,
       path: givenPath,
     })
   }

--- a/.vuepress/config-path-checker/find-and-check.js
+++ b/.vuepress/config-path-checker/find-and-check.js
@@ -7,7 +7,7 @@ function checkPath(givenPath) {
     addError.call(this, {
       type: 'error',
       errMsg: 'Path in config.json file is missing a trailing slash',
-      fileUrl: path.join(__dirname, 'config.json'),
+      fileUrl: path.join(__dirname, 'find-and-check.js'),
       fullText: `path: '${givenPath}'`,
       path: givenPath,
     })

--- a/.vuepress/config-path-checker/find-and-check.js
+++ b/.vuepress/config-path-checker/find-and-check.js
@@ -8,7 +8,7 @@ function checkPath(givenPath, elem) {
     addError.call(this, {
       type: 'error',
       errMsg: `In ${origin} the path is missing a trailing slash`,
-      fileUrl: path.join(process.cwd(), '/.vuepress/config.json'),
+      fileUrl: path.join(process.cwd(), '/.vuepress/config.js'),
       fullText: `path: '${givenPath}'`,
       path: givenPath,
     })


### PR DESCRIPTION
`path` is the whole API dealing with resolving paths and not the path that raised the error. Changed the variable to correct one. It raised these errors for you @guimachiavelli 
```
  Path in config.json file is missing a trailing slash: path: '/learn/configuration/instance_options' (/.../config.json:110:17)
  Path in config.json file is missing a trailing slash: path: '/learn/configuration/settings' (...config.json:115:21)
```

I also changed the link to where the error is thrown. Not sure why it was config.json.