### PR TITLE
Add redirect from old getting started readme

### DIFF
--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -145,19 +145,22 @@
 
 # Move settings, configuration, distinct, field properties, synonyms
 /reference/features/configuration.html              /learn/configuration/instance_options.html
-/reference/features/distinct.html              /learn/configuration/distinct.html
-/reference/features/field_properties.html              /learn/configuration/displayed_searchable_attributes.html
-/reference/features/synonyms.html              /learn/configuration/synonyms.html
-/reference/features/settings.html              /learn/configuration/settings.html
+/reference/features/distinct.html                   /learn/configuration/distinct.html
+/reference/features/field_properties.html           /learn/configuration/displayed_searchable_attributes.html
+/reference/features/synonyms.html                   /learn/configuration/synonyms.html
+/reference/features/settings.html                   /learn/configuration/settings.html
 
 # Remove search parameters feature reference
 /reference/features/search_parameters.html          /reference/api/search.html
 
 # Remove Feature reference
-/reference/features/                                /reference/
+/reference/features/                                /reference/api/
 
 # Remove Installation page
-/learn/getting_started/installation.html        /learn/getting_started/quick_start.html
+/learn/getting_started/installation.html            /learn/getting_started/quick_start.html
 
 #Remove What's next page
-/learn/getting_started/whats_next.html        /learn/getting_started/quick_start.html
+/learn/getting_started/whats_next.html              /learn/getting_started/quick_start.html
+
+# Remove Getting Started README.md
+/learn/getting_started/                             /learn/getting_started/quick_start.html


### PR DESCRIPTION
The getting started `README.md` file was removed as part of #1280 , but we forgot to add a redirect for it.

This PR adds a redirect from `/learn/getting_started/` to the quick start. It also standardizes the column spacing in the `_redirects` file, and changes a previously added redirect (`/reference/features/` should not redirect to `/reference/`, but to `/reference/api/`).