### PR TITLE
Fix the link to the permitted list of actions

### DIFF
--- a/reference/api/keys.md
+++ b/reference/api/keys.md
@@ -92,7 +92,7 @@ An array of API actions permitted for the key. `["*"]` for all actions.
 
 An array of indexes the key is authorized to act on. `["*"]` for all indexes.
 
-Only the key's [permitted actions](#actions) can be used on these indexes.
+Only the key's [permitted actions](#actions-2) can be used on these indexes.
 
 #### `expiresAt`
 


### PR DESCRIPTION
<img width="539" alt="image" src="https://user-images.githubusercontent.com/4116980/155520187-73b63db0-bffb-49fb-b9a4-f2a0269b338e.png">

I think this link should point to:

<img width="744" alt="image" src="https://user-images.githubusercontent.com/4116980/155520046-9e1c5d5e-6ea4-4e02-920b-ec316ea799dc.png">

But currently, it is pointing to the "actions" above:

<img width="645" alt="image" src="https://user-images.githubusercontent.com/4116980/155520116-b9884a99-98af-4a06-9f1d-77bcd17ac918.png">


I think we should create a new anchor for this case because what I understood is the docs created an anchor automatically since an anchor with the same name was already defined previously (but I'm not sure how to do that!). 