### PR TITLE
v0.26 instance options trim

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -110,10 +110,14 @@ module.exports = {
           collapsable: false,
           path: '/learn/configuration/instance_options/',
           children: [
-            '/learn/configuration/instance_options',
+            {
+              title: 'Configure Meilisearch at launch',
+              path: '/learn/configuration/instance_options',
+            },
             {
               title: 'Index settings',
               collapsable: false,
+              path: '/learn/configuration/settings',
               children: [
                 {
                   title: 'Overview',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -113,11 +113,12 @@ module.exports = {
             {
               title: 'Configure Meilisearch at launch',
               path: '/learn/configuration/instance_options',
+              sidebarDepth: 2,
             },
             {
               title: 'Index settings',
               collapsable: false,
-              path: '/learn/configuration/settings',
+              path: '/learn/configuration/settings/',
               children: [
                 {
                   title: 'Overview',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -113,7 +113,6 @@ module.exports = {
             {
               title: 'Configure Meilisearch at launch',
               path: '/learn/configuration/instance_options',
-              sidebarDepth: 2,
             },
             {
               title: 'Index settings',

--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -1,38 +1,36 @@
+---
+sidebarDepth: 2
+---
+
 # Configure Meilisearch at launch
 
-You can configure Meilisearch with **environment variables** and **command-line options**.
+You can configure Meilisearch at launch with **environment variables** and **command-line options**.
 
-These startup options affect your entire Meilisearch instance, not just a single index. For index settings, see [settings](/learn/configuration/settings.md).
+These startup options affect your entire Meilisearch instance, not just a single index. For settings that affect search within a single index, see [index settings](/learn/configuration/settings.md).
 
 ## Command-line options and flags
 
-Pass command-line options and their respective values when launching a Meilisearch instance. Command-line options take precedence over environment variables.
+Pass **command-line options** and their respective values when launching a Meilisearch instance.
 
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
 ```
 
-**Response:**
+In the previous example, `./meilisearch` is the command that launches a Meilisearch instance, while `--db-path` and `--http-addr` are options that modify this instance's behavior.
 
-```bash
-Server is listening on: http://127.0.0.1:7700
-```
-
-In the previous example, `./meilisearch` is the command that launches a Meilisearch instance and `--http-addr` is the option that sets the URL and port this instance will use. **All command-line options are prepended with `--`.**
-
-Some of these options are command-line flags and unlike command-line options, **they don't take any values**. If you use the flag, it counts as `true` and if you don't, it counts as `false`.
+Meilisearch also has a number of **command-line flags.** Unlike command-line options, **command-line flags don't take values**. If a flag is given, it is activated and changes Meilisearch's default behavior.
 
 ```bash
 ./meilisearch --no-analytics
 ```
 
-The above example disables analytics for the Meilisearch instance without accepting any values.
+The above command-line flag disables analytics for the Meilisearch instance without accepting any value.
+
+**Both command-line options and command-line flags take precedence over environment variables.** All command-line options and flags are prepended with `--`.
 
 ## Environment variables
 
 To configure a Meilisearch instance using environment variables, set the environment variable prior to launching the instance. If you are unsure how to do this, read more about [setting and listing environment variables](https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/), or [use a command-line option](#command-line-options-and-flags) instead.
-
-Environment variables are always identical to the corresponding command-line option, but prepended with `MEILI_` and written in all uppercase. Some options (e.g. `--import-snapshots`) are not available as environment variables.
 
 ```bash
 export MEILI_DB_PATH=./meilifiles
@@ -40,46 +38,11 @@ export MEILI_HTTP_ADDR=127.0.0.1:7700
 ./meilisearch
 ```
 
-**Response:**
+In the previous example, `./meilisearch` is the command that launches a Meilisearch instance, while `MEILI_DB_PATH` and `MEILI_HTTP_ADDR` are environment variables that modify this instance's behavior.
 
-```bash
-Server is listening on: http://127.0.0.1:7700
-```
+Environment variables are always identical to the corresponding command-line option, but prepended with `MEILI_` and written in all uppercase. **Some options (e.g. `--import-snapshots`) are not available as environment variables.**
 
-## Options
-
-### General
-
-- [Database path](/learn/configuration/instance_options.md#database-path)
-- [Environment](/learn/configuration/instance_options.md#environment)
-- [HTTP address & port binding](/learn/configuration/instance_options.md#http-address-port-binding)
-- [Master key](/learn/configuration/instance_options.md#master-key)
-
-### Advanced
-
-- [Disable analytics](/learn/configuration/instance_options.md#disable-analytics)
-- [Dumps](/learn/configuration/instance_options.md#dumps-destination)
-  - [Dumps destination](/learn/configuration/instance_options.md#dumps-destination)
-  - [Import dump](/learn/configuration/instance_options.md#import-dump)
-- [Log level](/learn/configuration/instance_options.md#log-level)
-- [Max index size](/learn/configuration/instance_options.md#max-index-size)
-- [Max TASK_DB size](/learn/configuration/instance_options.md#max-task-db-size)
-- [Payload limit size](/learn/configuration/instance_options.md#payload-limit-size)
-- [Snapshots](/learn/configuration/instance_options.md#schedule-snapshot-creation):
-  - [Schedule snapshot creation](/learn/configuration/instance_options.md#schedule-snapshot-creation)
-  - [Snapshot destination](/learn/configuration/instance_options.md#snapshot-destination)
-  - [Snapshot interval](/learn/configuration/instance_options.md#snapshot-interval)
-  - [Import snapshot](/learn/configuration/instance_options.md#import-snapshot)
-  - [Ignore missing snapshot](/learn/configuration/instance_options.md#ignore-missing-snapshot)
-  - [Ignore snapshot if DB exists](/learn/configuration/instance_options.md#ignore-snapshot-if-db-exists)
-- [SSL configuration](/learn/configuration/instance_options.md#ssl-authentication-path):
-  - [SSL authentication path](/learn/configuration/instance_options.md#ssl-authentication-path)
-  - [SSL certificates path](/learn/configuration/instance_options.md#ssl-certificates-path)
-  - [SSL key path](/learn/configuration/instance_options.md#ssl-key-path)
-  - [SSL OCSP path](/learn/configuration/instance_options.md#ssl-ocsp-path)
-  - [SSL require auth](/learn/configuration/instance_options.md#ssl-require-auth)
-  - [SSL resumption](/learn/configuration/instance_options.md#ssl-resumption)
-  - [SSL tickets](/learn/configuration/instance_options.md#ssl-tickets)
+## All instance options
 
 ### Database path
 
@@ -319,7 +282,9 @@ This command will throw an error if `--import-snapshot` is not defined.
 
 *This option is not available as an environment variable.*
 
-### SSL authentication path
+### SSL options
+
+#### SSL authentication path
 
 **Environment variable**: `MEILI_SSL_AUTH_PATH`
 **CLI option**: `--ssl-auth-path`
@@ -328,7 +293,7 @@ This command will throw an error if `--import-snapshot` is not defined.
 
 Enables client authentication in the specified path.
 
-### SSL certificates path
+#### SSL certificates path
 
 **Environment variable**: `MEILI_SSL_CERT_PATH`
 **CLI option**: `--ssl-cert-path`
@@ -339,7 +304,7 @@ Sets the server's SSL certificates.
 
 Value must be a path to PEM-formatted certificates. The first certificate should certify the KEYFILE supplied by `--ssl-key-path`. The last certificate should be a root CA.
 
-### SSL key path
+#### SSL key path
 
 **Environment variable**: `MEILI_SSL_KEY_PATH`
 **CLI option**: `--ssl-key-path`
@@ -350,7 +315,7 @@ Sets the server's SSL keyfiles.
 
 Value must be a path to an RSA private key or PKCS8-encoded private key, both in PEM format.
 
-### SSL OCSP path
+#### SSL OCSP path
 
 **Environment variable**: `MEILI_SSL_OCSP_PATH`
 **CLI option**: `--ssl-ocsp-path`
@@ -361,7 +326,7 @@ Sets the server's OCSP file. *Optional*
 
 Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
 
-### SSL require auth
+#### SSL require auth
 
 ::: warning
 This is a CLI flag and does not take any values. Assigning a value will throw an error.
@@ -377,7 +342,7 @@ Sends a fatal alert if the client does not complete client authentication.
 
 The environment variable accepts `n`, `no`, `f`, `false`, `off`, and `0` as `false`. An absent environment variable will also be considered as `false`, everything else is considered `true`.
 
-### SSL resumption
+#### SSL resumption
 
 ::: warning
 This is a CLI flag and does not take any values. Assigning a value will throw an error.
@@ -391,7 +356,7 @@ Activates SSL session resumption.
 
 The environment variable accepts `n`, `no`, `f`, `false`, `off`, and `0` as `false`. An absent environment variable will also be considered as `false`, everything else is considered `true`.
 
-### SSL tickets
+#### SSL tickets
 
 ::: warning
 This is a CLI flag and does not take any values. Assigning a value will throw an error.

--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -1,16 +1,18 @@
-# Instance options
+# Configure Meilisearch at launch
 
 You can configure Meilisearch with **environment variables** and **command-line options**.
 
-The configuration options described here affect your entire Meilisearch instance, not just a single index. For index settings, see [settings](/learn/configuration/settings.md).
+These startup options affect your entire Meilisearch instance, not just a single index. For index settings, see [settings](/learn/configuration/settings.md).
 
-## Configuring an instance with command-line options
+## Command-line options and flags
 
-Pass command-line options and their respective values when launching a Meilisearch instance.
+Pass command-line options and their respective values when launching a Meilisearch instance. Command-line options take precedence over environment variables.
 
 ```bash
 ./meilisearch --db-path ./meilifiles --http-addr '127.0.0.1:7700'
 ```
+
+**Response:**
 
 ```bash
 Server is listening on: http://127.0.0.1:7700
@@ -26,9 +28,9 @@ Some of these options are command-line flags and unlike command-line options, **
 
 The above example disables analytics for the Meilisearch instance without accepting any values.
 
-## Configuring an instance with environment variables
+## Environment variables
 
-In order to configure a Meilisearch instance using environment variables, you have to set the environment variable prior to launching the instance. If it's your first time doing this you may want to read more about [setting and listing environment variables](https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/), or [use a command-line option](#configuring-an-instance-with-command-line-options) instead.
+To configure a Meilisearch instance using environment variables, set the environment variable prior to launching the instance. If you are unsure how to do this, read more about [setting and listing environment variables](https://linuxize.com/post/how-to-set-and-list-environment-variables-in-linux/), or [use a command-line option](#command-line-options-and-flags) instead.
 
 Environment variables are always identical to the corresponding command-line option, but prepended with `MEILI_` and written in all uppercase. Some options (e.g. `--import-snapshots`) are not available as environment variables.
 
@@ -38,22 +40,10 @@ export MEILI_HTTP_ADDR=127.0.0.1:7700
 ./meilisearch
 ```
 
+**Response:**
+
 ```bash
 Server is listening on: http://127.0.0.1:7700
-```
-
-## Usage
-
-Command-line options take precedence over environment variables. If the same configuration option is specified both as a command-line option and as an environment variable, Meilisearch will use the command-line option and its respective value.
-
-Some configuration options must specify a value. Using a command-line option or environment variable without specifying a value will throw an error and interrupt the launch process.
-
-```bash
-./meilisearch --schedule-snapshot
-```
-
-```bash
-error: The argument '--schedule-snapshot <schedule-snapshot>' requires a value but none was supplied
 ```
 
 ## Options


### PR DESCRIPTION
Some improvements to `/learn/configuration/instance_options.md` focused around making the page more accessible from the sidebar. Note that target branch is `v0.26--instance-options-new-flag-behavior`. 

Summary:

- Change sidebar name + H1 to "Configure Meilisearch at launch"
- Eliminate "Usage" section (fold into two previous sections)
- Rename "Configuring Meilisearch with command-line options" and "Configuring Meilisearch with environment variables" to just "Command-line options" and "Environment variables"
- Display all command line options in the sidebar
  - All SSL options changed to H4s and grouped under new H3 "SSL options"
  - "Options" H2 + table of contents removed
  - Distinction between "General" and "Advanced" options removed
  - Category name changed from "Options" to "All instance options"

Probably best to review this one using the deploy preview since the changes will be easier to understand visually.