### PR TITLE
Update the geosearch examples

### DIFF
--- a/learn/advanced/geosearch.md
+++ b/learn/advanced/geosearch.md
@@ -134,7 +134,7 @@ _geoRadius(lat, lng, distance_in_meters)
 `_geoRadius` must always be used with the [`filter` search parameter](/reference/api/search.md#filter). The following filter expression would only include results within 1km of the Eiffel Tower:
 
 ```json
-{ "filter": "_geoRadius(48.8583701, 2.2922926, 1000)" }
+{ "filter": "_geoRadius(45.472735, 9.184019, 1000)" }
 ```
 
 If any of `lat`, `lng`, or `distance_in_meters` are invalid or missing, Meilisearch will return an [`invalid_filter`](/reference/api/error_codes.md#invalid-filter) error.
@@ -231,7 +231,7 @@ The following sorting rule orders results according to how close they are to the
 ```json
 {
   "sort": [
-    "_geoPoint(48.8583701, 2.2922926):asc"
+    "_geoPoint(45.472735, 9.184019):asc"
   ]
 }
 ```


### PR DESCRIPTION
Currently, the geosearch examples return nothing because there are no points in a 2km range around `45.4628328, 9.1076931`.

![image](https://user-images.githubusercontent.com/7032172/156354587-c53855b0-dfab-4d32-9316-b9bf22731895.png)

Points 1 and 2 are the two points we already have in Italy.
And I made the query from the point 3 (less than 2km from 1&2).