### PR TITLE
Fixed : The docker link on the quickstart documentation leads to a 404 page #1501

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -45,7 +45,7 @@ meilisearch
 :::
 
 ::: tab Docker
-When using **Docker**, you can run [any available tag](https://hub.docker.com/r/getmeili/Meilisearch/tags).
+When using **Docker**, you can run [any available tag](https://hub.docker.com/r/getmeili/meilisearch/tags).
 
 These commands launch the **latest stable release** of Meilisearch.
 


### PR DESCRIPTION
Hey! I have updated the docker link on the quickstart documentation leads to a 404 page. I have updated it to https://hub.docker.com/r/getmeili/meilisearch/tags. Please Review my PR.
Thanks!

#1501 