### PR TITLE
Add an option in check-md to ignore some links with anchors

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -291,7 +291,8 @@ module.exports = {
       {
         pattern: '**/*.md',
         strictExt: true,
-        ignorePattern: ['errors', 'document_structure'],
+        ignoreFilePattern: ['errors', 'document_structure'],
+        ignoreHashPattern: ['actions-2'],
         exitLevel: 'warn',
       },
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,7 +2371,7 @@ chalk@^4.0.0:
 
 check-md@1.0.0, "check-md@https://github.com/bidoubiwa/check-md#add_ignore_pattern":
   version "1.0.1"
-  resolved "https://github.com/bidoubiwa/check-md#e135a42adc659ea0bec6d330c3ef5263d69a072c"
+  resolved "https://github.com/bidoubiwa/check-md#e02c680f53dd65a3f24289fcf0cd13da519da275"
   dependencies:
     chalk "^4.0.0"
     commander "^5.0.0"


### PR DESCRIPTION
When using multiple same headers for example: 

```
## usage 

## usage
```

Markdown gives the possibility to do this `#usage -2` to go to the second part. 
Unfortunately this breaks with the `check-links` tests. 
My MVP solution was to add a `ignoreHashPath` as an option to ignore the failed check.

⚠️ Be aware that this make it not possibility to know that the link is breaking