### PR TITLE
Update gcp link to v25.2

### DIFF
--- a/learn/cookbooks/gcp.md
+++ b/learn/cookbooks/gcp.md
@@ -29,7 +29,7 @@ The following guide will walk you through every step to deploy Meilisearch in a 
 - Copy the following URI in the `Cloud Storage file` field.
 
 ```
-meilisearch-image/meilisearch-v0.25.0-debian-10.vmdk
+meilisearch-image/meilisearch-v0.25.2-debian-10.vmdk
 ```
 
 - **The other fields are not required.**


### PR DESCRIPTION
Update GCP deploy version to 25.2

Related to this [Slack community thread](https://meilicommunity.slack.com/archives/CP9DVS1RQ/p1645634376018779)