### PR TITLE
v0.26: auto-batching (take two)

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -232,9 +232,9 @@ module.exports = {
             },
             {
               title: 'Auto-batching',
-              path: '/learn/experimental/auto-batching'
+              path: '/learn/experimental/auto-batching',
             },
-          ]
+          ],
         },
         {
           title: '👐 Contributing',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -222,6 +222,21 @@ module.exports = {
           ],
         },
         {
+          title: '🧪 Experimental',
+          collapsable: false,
+          path: '/learn/experimental/overview/',
+          children: [
+            {
+              title: 'Overview',
+              path: '/learn/experimental/overview',
+            },
+            {
+              title: 'Auto-batching',
+              path: '/learn/experimental/auto-batching'
+            },
+          ]
+        },
+        {
           title: '👐 Contributing',
           path: '/learn/contributing/',
           collapsable: false,

--- a/learn/advanced/indexation.md
+++ b/learn/advanced/indexation.md
@@ -32,6 +32,8 @@ If you encounter performance issues during the indexation we recommend trying th
 
 - **Bigger HTTP payloads are processed more quickly than smaller payloads**. For example, adding the same 100,000 documents in two batches of 50,000 documents will be quicker than adding them in four batches of 25,000 documents. By default, Meilisearch sets the maximum payload size to 100MB, but [you can change this value if necessary](/learn/configuration/instance_options.md#payload-limit-size). That said, **the bigger the payload is, the higher the memory consumption will be**. An instance may crash if it requires more RAM than is currently available in a machine.
 
+  - If you want to speed up indexation but don't wish to batch documents manually, consider giving our [experimental auto-batcher](/learn/experimental/auto-batching.md) a try.
+
 - **Meilisearch should not be your main database**. The more documents you add, the longer will indexation and search take, so you should only index documents you want to retrieve when searching.
 
 - By default, all document fields are searchable. We strongly recommend changing this by [updating the `searchableAttributes` list](https://docs.meilisearch.com/reference/api/searchable_attributes.html#update-searchable-attributes) so it only contains fields you want to search in. The fewer fields Meilisearch needs to index, the faster is the indexation process.

--- a/learn/experimental/auto-batching.md
+++ b/learn/experimental/auto-batching.md
@@ -1,0 +1,54 @@
+# Auto-batching
+
+::: warning
+
+🚨 This is an experimental feature 🚨
+Using it may result in unexpected crashes, bugs, or holes in the space-time continuum.
+You have been warned.
+
+:::
+
+Auto-batching is an experimental feature designed to improve indexing speed.
+
+When auto-batching is enabled, consecutive document addition requests may be automatically combined into a batch and processed together, significantly speeding up the indexation process.
+
+We would appreciate your feedback on this feature. [Join the discussion](https://github.com/meilisearch/meilisearch/discussions/2070).
+
+## Enable auto-batching
+
+To enable auto-batching, start Meilisearch while supplying the `--enable-auto-batching` CLI flag:
+
+```
+./meilisearch --enable-auto-batching
+```
+
+For document addition requests to be added to the same batch, they need to:
+
+- Target the same index
+- Have the same update method (e.g. [POST](/reference/api/documents.md#add-or-replace-documents) or [PUT](/reference/api/documents.md#add-or-update-documents))
+- Be immediately consecutive
+
+By default, **auto-batching will not delay processing a request in order to batch multiple requests together.** If it can process the request immediately, it will. [This behavior can be altered using a command-line option](#customization-options).
+
+After enabling autobatching, the field `batchUid` will appear in all [Task API](/reference/api/tasks.md) responses.
+
+::: warning
+
+If even a single task in a batch fails, the entire batch will fail.
+
+:::
+
+## Customization options
+
+There are three command-line options allowing you to customize auto-batching behavior:
+
+- `--debounce-duration-sec`: the number of seconds to wait between receiving a document addition task and beginning the batching and indexation process. **Default: `0`**
+- `--max-batch-size`: the maximum number of tasks per batch. **Default: unlimited**
+- `--max-documents-per-batch`: the maximum number of documents in a batch. **Default: unlimited**
+
+::: tip
+
+- Giving a smaller number for `max-documents-per-batch` will reduce memory use, but slow down indexation
+- Giving a larger number for `max-documents-per-batch` will increase memory use, but speed up indexation
+
+:::

--- a/learn/experimental/auto-batching.md
+++ b/learn/experimental/auto-batching.md
@@ -30,7 +30,7 @@ For document addition requests to be added to the same batch, they need to:
 
 By default, **auto-batching will not delay processing a request in order to batch multiple requests together.** If it can process the request immediately, it will. [This behavior can be altered using a command-line option](#customization-options).
 
-After enabling autobatching, the field `batchUid` will appear in all [Task API](/reference/api/tasks.md) responses.
+After enabling autobatching, the field `batchUid` will appear in all [task API](/reference/api/tasks.md) responses.
 
 ::: warning
 

--- a/learn/experimental/overview.md
+++ b/learn/experimental/overview.md
@@ -1,0 +1,15 @@
+# Experimental features
+
+## What is an experimental feature?
+
+Meilisearch maintains a high standard for new features. The process of adding a new feature to our search engine typically begins with a specification, centers around copious unit testing, and ends with the feature's release, barring some minor iteration in subsequent versions.
+
+This is not necessarily the case for experimental features. **Experimental features are features that may not have been tested to our usual standards, and which may be reworked or removed entirely in future versions.** They come with an increased risk of bugs and unforseen behavior, but some users may find the extra functionality to be worth the risk.
+
+## Giving feedback
+
+**Each experimental feature added to Meilisearch has an associated discussion on our [core GitHub repository](https://github.com/meilisearch/meilisearch/discussions/categories/general?discussions_q=category%3AGeneral+experimental).**
+
+The feedback from these discussions helps us to evaluate the success or failure of experimental features, as well as potentially to evolve them into a stable, non-experimental state.
+
+Whether you want to share a bug report, an opinion, or a story about your experience with the feature, we are grateful for your contribution!

--- a/learn/experimental/overview.md
+++ b/learn/experimental/overview.md
@@ -10,6 +10,6 @@ This is not necessarily the case for experimental features. **Experimental featu
 
 **Each experimental feature added to Meilisearch has an associated discussion on our [core GitHub repository](https://github.com/meilisearch/meilisearch/discussions/categories/general?discussions_q=category%3AGeneral+experimental).**
 
-The feedback from these discussions helps us to evaluate the success or failure of experimental features, as well as potentially to evolve them into a stable, non-experimental state.
+The feedback from these discussions helps us evaluate the success or failure of experimental features, as well as potentially evolve them into a stable, non-experimental state.
 
 Whether you want to share a bug report, an opinion, or a story about your experience with the feature, we are grateful for your contribution!


### PR DESCRIPTION
PR replacing #1475 , which was thoroughly mucked up by an ill-timed `pull` and `rebase`.