### PR TITLE
Update gcp link to v0.26.0

### DIFF
--- a/learn/cookbooks/gcp.md
+++ b/learn/cookbooks/gcp.md
@@ -29,7 +29,7 @@ The following guide will walk you through every step to deploy Meilisearch in a 
 - Copy the following URI in the `Cloud Storage file` field.
 
 ```
-meilisearch-image/meilisearch-v0.25.2-debian-10.vmdk
+meilisearch-image/meilisearch-v0.26.0-debian-10.vmdk
 ```
 
 - **The other fields are not required.**


### PR DESCRIPTION
Updating the GCP URL on the deploy page for v0.26.0.