### PR TITLE
Create ecosystem dropdown menu in navbar

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -4,7 +4,6 @@ module.exports = {
   description: 'Open source Instant Search Engine',
   theme: 'default-prefers-color-scheme',
   themeConfig: {
-    repo: 'meilisearch/Meilisearch',
     docsRepo: 'meilisearch/documentation',
     editLinks: true,
     lastUpdated: 'Last Updated',
@@ -14,12 +13,11 @@ module.exports = {
 
     nav: [
       { text: 'Learn', link: '/learn/getting_started/quick_start' },
-      { text: 'API Reference', link: '/reference/api/overview' },
+      { text: 'Reference', link: '/reference/api/overview' },
       { text: 'FAQ', link: '/faq' },
       {
         text: 'Integrations',
         items: [
-
           {
             text: 'SDKs',
             items: [
@@ -67,8 +65,14 @@ module.exports = {
           },
         ],
       },
-      { text: 'Slack', link: 'https://slack.meilisearch.com' },
-      { text: 'Blog', link: 'https://blog.meilisearch.com/' },
+      {
+        text: 'Ecosystem',
+        items: [
+          { text: 'GitHub', link: 'https://github.com/meilisearch/meilisearch' },
+          { text: 'Slack', link: 'https://slack.meilisearch.com' },
+          { text: 'Blog', link: 'https://blog.meilisearch.com/' },
+        ]
+      },
     ],
     sidebar: {
       '/learn/': [


### PR DESCRIPTION
Economize horizontal screen space by removing GitHub, Slack, and Blog links from top navbar and placing them in a dropdown called ecosystem. Also 'API Reference' -> 'Reference'

The main questions:

- Is "Ecosystem" a clear enough name for this dropdown? (Idea taken from [Strapi docs](https://docs.strapi.io/developer-docs/latest/getting-started/introduction.html))
- Should the ['landing page'](https://www.meilisearch.com/) be included in this dropdown? If so, how should we refer to it?
  - Will get the opinion of a higher-up on this. May not make sense to direct traffic from the docs back to this product-focused page.

Closes #1495 