### PR TITLE
Remove the remaining MeiliSearch

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -99,7 +99,7 @@ module.exports = {
           children: [
             '/learn/getting_started/quick_start',
             {
-              title: 'MeiliSearch 101',
+              title: 'Meilisearch 101',
               path: '/learn/getting_started/filtering_and_sorting/',
               collapsable: false,
               children: [

--- a/.vuepress/error-pages/index.js
+++ b/.vuepress/error-pages/index.js
@@ -23,7 +23,7 @@ module.exports = {
     const errorsPages = []
     errorsPages.push({
       path: '/errors/', // Cannot be errors. Works in development mode but not production
-      content: `## MeiliSearch Errors
+      content: `## Meilisearch Errors
 ${errors.map(err => `
 <h4 id="${err.code}"><a href="#${err.code}" class="header-anchor">#</a> <code>${err.code}</code></h4>
 

--- a/index.md
+++ b/index.md
@@ -26,5 +26,5 @@ The current version of [Meilisearch](https://github.com/meilisearch/meilisearch)
 
 Meilisearch and its documentation are both completely open source. You can **support the project by starring** [our main GitHub repository](https://github.com/meilisearch/meilisearch) or [contributing to the docs](/learn/contributing/contributing_to_docs.md).
 
-<a class="github-button" href="https://github.com/meilisearch/meilisearch" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star meilisearch/MeiliSearch on GitHub">Star</a><!-- prettier-ignore
+<a class="github-button" href="https://github.com/meilisearch/meilisearch" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star meilisearch/meilisearch on GitHub">Star</a><!-- prettier-ignore
 --><script async defer src="https://buttons.github.io/buttons.js"></script>

--- a/learn/cookbooks/aws.md
+++ b/learn/cookbooks/aws.md
@@ -149,7 +149,7 @@ Open a terminal window and navigate to wherever you saved your [key pair](#_8-se
 Run the following command to secure your key pair.
 
 ```bash
-chmod 400 <YourMeiliSearchKeyPair>.pem
+chmod 400 <YourMeilisearchKeyPair>.pem
 ```
 
 ### 2.2. Run the configuration script

--- a/learn/cookbooks/qovery.md
+++ b/learn/cookbooks/qovery.md
@@ -32,7 +32,7 @@ Visit [the Qovery dashboard](https://start.qovery.com) to create an account if y
 
 - Click on the "use a template" button.
 - Select "Meilisearch".
-- Select your Github or Gitlab repository where Qovery will save your configuration files (Qovery uses Git as the source of truth).
+- Select your GitHub or GitLab repository where Qovery will save your configuration files (Qovery uses Git as the source of truth).
 - Click on "deploy".
 
 Congrats 🔥 - Your Meilisearch instance is deployed and ready to be used 🎉

--- a/learn/what_is_meilisearch/features.md
+++ b/learn/what_is_meilisearch/features.md
@@ -62,4 +62,4 @@ API keys are managed by the master key. When you set a master key on your first 
 
 ## Comprehensive language support
 
-[MeiliSearch is multilingual](/learn/what_is_meilisearch/language.md)! We aim to support every language represented in our global community.
+[Meilisearch is multilingual](/learn/what_is_meilisearch/language.md)! We aim to support every language represented in our global community.


### PR DESCRIPTION
- Rename the missing `MeiliSearch` into `Meilisearch` or `meilisearch`, depending on the case
- Also, fix typo on GitLab and GitHub