### PR TITLE
Update links to remove the duplication of links in the search bar

### DIFF
--- a/learn/advanced/indexation.md
+++ b/learn/advanced/indexation.md
@@ -36,7 +36,7 @@ If you encounter performance issues during the indexation we recommend trying th
 
 - **Meilisearch should not be your main database**. The more documents you add, the longer will indexation and search take, so you should only index documents you want to retrieve when searching.
 
-- By default, all document fields are searchable. We strongly recommend changing this by [updating the `searchableAttributes` list](https://docs.meilisearch.com/reference/api/searchable_attributes.html#update-searchable-attributes) so it only contains fields you want to search in. The fewer fields Meilisearch needs to index, the faster is the indexation process.
+- By default, all document fields are searchable. We strongly recommend changing this by [updating the `searchableAttributes` list](/reference/api/searchable_attributes.md#update-searchable-attributes) so it only contains fields you want to search in. The fewer fields Meilisearch needs to index, the faster is the indexation process.
 
 ```json
 [

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -238,7 +238,7 @@ Once the response to the previous command looks like this (`"status": "done"`), 
 
 ### Step 3: Delete the database folder
 
-To delete the old Meilisearch version, you need to delete the `data.ms` folder. `data.ms` should be at the root of the Meilisearch binary, unless you chose [another location](https://docs.meilisearch.com/reference/features/configuration.html#database-path).
+To delete the old Meilisearch version, you need to delete the `data.ms` folder. `data.ms` should be at the root of the Meilisearch binary, unless you chose [another location](/learn/configuration/instance_options.md#database-path).
 
 ### Step 4: Import the dump
 
@@ -325,7 +325,7 @@ curl -X GET \
 
 ### Step 4: Delete the database folder
 
-To delete the old Meilisearch version, you need to delete the `data.ms` folder. `data.ms` should be at the root of the Meilisearch binary, unless you chose [another location](https://docs.meilisearch.com/reference/features/configuration.html#database-path).
+To delete the old Meilisearch version, you need to delete the `data.ms` folder. `data.ms` should be at the root of the Meilisearch binary, unless you chose [another location](/learn/configuration/instance_options.md#database-path).
 
 ### Step 5: Upload your data to the latest version of Meilisearch
 

--- a/learn/cookbooks/search_bar_for_docs.md
+++ b/learn/cookbooks/search_bar_for_docs.md
@@ -229,7 +229,7 @@ The default behavior of this library fits perfectly for a documentation search b
 
 ::: note
 
-For more concrete examples, you can check out this [basic HTML file](https://github.com/meilisearch/docs-searchbar.js/blob/master/scripts/playground.html) or [this more advanced Vue file](https://github.com/meilisearch/vuepress-plugin-meilisearch/blob/master/MeiliSearchBox.vue).
+For more concrete examples, you can check out this [basic HTML file](https://github.com/meilisearch/docs-searchbar.js/blob/main/scripts/playground.html) or [this more advanced Vue file](https://github.com/meilisearch/vuepress-plugin-meilisearch/blob/master/MeiliSearchBox.vue).
 
 :::
 

--- a/learn/cookbooks/search_bar_for_docs.md
+++ b/learn/cookbooks/search_bar_for_docs.md
@@ -229,7 +229,7 @@ The default behavior of this library fits perfectly for a documentation search b
 
 ::: note
 
-For more concrete examples, you can check out this [basic HTML file](https://github.com/meilisearch/docs-searchbar.js/blob/main/scripts/playground.html) or [this more advanced Vue file](https://github.com/meilisearch/vuepress-plugin-meilisearch/blob/master/MeiliSearchBox.vue).
+For more concrete examples, you can check out this [basic HTML file](https://github.com/meilisearch/docs-searchbar.js/blob/main/scripts/playground.html) or [this more advanced Vue file](https://github.com/meilisearch/vuepress-plugin-meilisearch/blob/main/MeiliSearchBox.vue).
 
 :::
 

--- a/learn/core_concepts/relevancy.md
+++ b/learn/core_concepts/relevancy.md
@@ -56,7 +56,7 @@ Also, note the documents with attributes containing the query words at the begin
 Results are sorted **according to parameters decided at query time**. When the `sort` ranking rule is in a higher position, sorting is exhaustive: results will be less relevant, but follow the user-defined sorting order more closely. When `sort` is in a lower position, sorting is relevant: results will be very relevant, but might not always follow the order defined by the user.
 
 ::: note
-Differently from other ranking rules, sort is only active for queries containing the [`sort` search parameter](https://docs.meilisearch.com/reference/features/search_parameters.html#sort). If a search request does not contain `sort` or if its value is invalid, this rule will be ignored.
+Differently from other ranking rules, sort is only active for queries containing the [`sort` search parameter](/reference/api/search.md#sort). If a search request does not contain `sort` or if its value is invalid, this rule will be ignored.
 :::
 
 #### 6. Exactness
@@ -171,11 +171,11 @@ By default, the built-in rules are executed in the following order.
 
 ```json
 [
-  "words", 
-  "typo", 
-  "proximity", 
-  "attribute", 
-  "sort", 
+  "words",
+  "typo",
+  "proximity",
+  "attribute",
+  "sort",
   "exactness"
 ]
 ```
@@ -194,8 +194,8 @@ For a more detailed look at this subject, see our reference page for [the search
 
 ```json
 [
-  "title", 
-  "overview", 
+  "title",
+  "overview",
   "release_date"
 ]
 ```

--- a/learn/what_is_meilisearch/features.md
+++ b/learn/what_is_meilisearch/features.md
@@ -43,9 +43,9 @@ Meilisearch allows you to define [filters](/learn/advanced/filtering_and_faceted
 
 ## Placeholder search
 
-If you make a search without inputting any query words, Meilisearch will return all the documents in that index sorted by its [custom ranking rules](/learn/configuration/settings.md#custom-ranking-rule) and [sorting rules](https://docs.meilisearch.com/learn/advanced/sorting.html#sorting). This feature is called **placeholder search**.
+If you make a search without inputting any query words, Meilisearch will return all the documents in that index sorted by its [custom ranking rules](/learn/configuration/settings.md#custom-ranking-rule) and [sorting rules](/learn/advanced/sorting.md#sorting). This feature is called **placeholder search**.
 
-Placeholder searches are particularly effective when used with other features such as [faceting or filtering](/learn/advanced/filtering_and_faceted_search.md#filters-or-facets), which allow users to narrow their searches and browse by category. You can read more about this feature in our article on [search parameters](https://docs.meilisearch.com/reference/features/search_parameters.html#placeholder-search).
+Placeholder searches are particularly effective when used with other features such as [faceting or filtering](/learn/advanced/filtering_and_faceted_search.md#filters-or-facets), which allow users to narrow their searches and browse by category. You can read more about this feature in our article on [search parameters](/reference/api/search.md#placeholder-search).
 
 ## Phrase search
 

--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -47,7 +47,7 @@ This is the preferred route to perform search when an API key is required, as it
 
 #### Placeholder search
 
-Placeholder search is a search with an empty `q` parameter. Since there is no query term, the [built-in ranking rules](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#ranking-rules) **do not apply.** Only [sort](/learn/core_concepts/relevancy.md#_5-sort) and [custom ranking rules](/learn/core_concepts/relevancy.md#custom-rules) are taken into account.
+Placeholder search is a search with an empty `q` parameter. Since there is no query term, the [built-in ranking rules](/learn/core_concepts/relevancy.md#ranking-rules) **do not apply.** Only [sort](/learn/core_concepts/relevancy.md#_5-sort) and [custom ranking rules](/learn/core_concepts/relevancy.md#custom-rules) are taken into account.
 
 If the index has no sort or custom ranking rules, the results are returned in the order of their internal database position.
 
@@ -233,7 +233,7 @@ Additionally, keep in mind queries go through a normalization process that strip
 
 #### Placeholder search
 
-When `q` isn't specified, Meilisearch performs a **placeholder search**.  A placeholder search returns all searchable documents in an index, modified by any search parameters used and sorted by that index's [custom ranking rules](/learn/configuration/settings.md#custom-ranking-rule). Since there is no query term, the [built-in ranking rules](https://docs.meilisearch.com/learn/core_concepts/relevancy.html#ranking-rules) **do not apply.**
+When `q` isn't specified, Meilisearch performs a **placeholder search**.  A placeholder search returns all searchable documents in an index, modified by any search parameters used and sorted by that index's [custom ranking rules](/learn/configuration/settings.md#custom-ranking-rule). Since there is no query term, the [built-in ranking rules](/learn/core_concepts/relevancy.md#ranking-rules) **do not apply.**
 
 If the index has no sort or custom ranking rules, the results are returned in the order of their internal database position.
 
@@ -633,7 +633,7 @@ Queries using `_geoPoint` will always include a `geoDistance` field containing t
     "id": 1,
     "name": "Nàpiz' Milano",
     "_geo": {
-      "lat": 45.4777599, 
+      "lat": 45.4777599,
       "lng": 9.1967508
     },
     "_geoDistance": 1532


### PR DESCRIPTION
To remove this:
<img width="598" alt="Capture d’écran 2022-03-24 à 17 46 20" src="https://user-images.githubusercontent.com/20380692/159970033-8cfc51e2-9156-4a8a-96ec-32f500f45959.png">

You should avoid calling page from your own documentation by using the `https://...` that finish by `.html`
Indeed, when the scraper does its job, it will consider two different links are present:
- `https://docs.meilisearch.com/learn/configuration/instance_options#database-path`
- `https://docs.meilisearch.com/learn/configuration/instance_options.html#database-path`

So, it will consider 2 different documents should be added to Meilisearch!

Also, I recommend avoiding merging PRs that let useless whitespaces at the end of lines, so that it prevents other people like me apply changes on their PR that are not directly related to the PR :)
You can set up your editor settings to avoid this kind of error: it will remove automatically the trailing whitespaces when you save your file 🚀 