### PR TITLE
API reference template

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -295,6 +295,7 @@ module.exports = {
               title: 'Overview',
               path: '/reference/api/overview',
             },
+            '/reference/api/format',
             '/reference/api/indexes',
             '/reference/api/documents',
             '/reference/api/search',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -296,6 +296,7 @@ module.exports = {
               path: '/reference/api/overview',
             },
             '/reference/api/format',
+            '/reference/format2_listall',
             '/reference/api/indexes',
             '/reference/api/documents',
             '/reference/api/search',

--- a/reference/api/format.md
+++ b/reference/api/format.md
@@ -1,0 +1,202 @@
+# Random API
+
+Explain what  the random API does.
+
+## The random object (simple)
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varA`|string|lalal|
+|`varB`|integer|lall|
+|`varC`|integer|lall|
+
+```json
+{
+    "varA": "Hello",
+    "varB": 10,
+    "varC": "Hi"
+}
+```
+
+## The random object (complex)
+
+**Name**: Complex1
+**Type**: String
+**Description**: lalala
+
+***
+
+**Name**: Complex2
+**Type**: Object
+**Description**: lalala
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varA`|string|lalal|
+|`varB`|integer|lall|
+|`varC`|integer|lall|
+
+***
+
+**Name**: Complex3
+**Type**: Integer
+**Description**: lalala
+
+***
+
+**Name**: Complex4
+**Type**: Object
+**Description**: lalala
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varX`|string|lalal|
+|`varY`|integer|lall|
+|`varZ`|integer|lall|
+
+***
+
+```json
+{
+    "Complex1": "la",
+    "Complex2": {
+          "varA": "Hello",
+          "varB": 10,
+          "varC": "Hi"
+    },
+    "Complex3": 11,
+    "Complex4": {
+        "varX": "Hello",
+        "varY": 10,
+        "varZ": 3
+    }  
+}
+```
+
+## List all
+
+<RouteHighlighter method="GET" route="/random"/>
+
+Returns a list of [random objects](#the-random-object).
+
+### Response: `200 Ok`
+
+```json
+{
+    "results":[
+        {
+            "varA": "Hello",
+            "varB": 10,
+            "varC": "Hi"
+        },
+        {
+            "varA": "Hello",
+            "varB": 10,
+            "varC": "Hi"
+        }
+    ]
+    
+}
+```
+
+## List one
+
+<RouteHighlighter method="GET" route="/random/:random"/>
+
+Returns a [random object](#the-random-object).
+
+### Response: `200 Ok`
+
+```json
+{
+    "varA": "Hello",
+    "varB": 10,
+    "varC": "Hi"
+}
+```
+
+## Create
+
+<RouteHighlighter method="POST" route="/random"/>
+
+Description.
+
+### Request body (simple)
+
+|Name|Type|Description|Default value|
+|---|-----|-----------|-------------|
+|`varA` |string | lala|`null`|
+|`varB` *|integer|lalal|None|
+
+### Example
+
+Code sample
+
+Returns a [random object](#the-random-object).
+
+#### Response: `201 Created`
+
+```json
+{
+    "varA": "Hello",
+    "varB": 10,
+    "varC": "Hi"
+}
+```
+
+### Request body (complex)
+
+
+
+## Update
+
+<RouteHighlighter method="PATCH" route="/random/:random"/>
+
+Description.
+
+### Request body
+
+|Name|Type|Description|Default value|
+|---|-----|-----------|-------------|
+|`varA` |string | lala|`null`|
+|`varB` *|integer|lalal|None|
+
+### Example
+
+Code sample
+
+Returns a [random object](#the-random-object).
+
+#### Response: `201 Created`
+
+```json
+{
+    "varA": "Hello",
+    "varB": 10,
+    "varC": "Hi"
+}
+```
+
+## Delete all
+
+<RouteHighlighter method="DELETE" route="/random"/>
+
+Deletes all [random objects](#the-random-object).
+
+### Example
+
+Code sample
+
+#### Response: `204 No Content`
+
+## Delete one
+
+<RouteHighlighter method="DELETE" route="/random/:random"/>
+
+Deletes the specified [random object](#the-random-object).
+
+### Example
+
+Code sample
+
+#### Response: `204 No Content`

--- a/reference/api/format.md
+++ b/reference/api/format.md
@@ -6,9 +6,9 @@ Explain what  the random API does.
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varA`|string|lalal|
-|`varB`|integer|lall|
-|`varC`|integer|lall|
+|`varA`|string||
+|`varB`|integer||
+|`varC`|integer||
 
 ```json
 {
@@ -23,40 +23,40 @@ Explain what  the random API does.
 ### `Complex1`
 
 **Type**: String
-**Description**: lalala
+**Description**:
 
 ***
 
 ### `Complex2`
 
 **Type**: Object
-**Description**: lalala
+**Description**:
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varA`|string|lalal|
-|`varB`|integer|lall|
-|`varC`|integer|lall|
+|`varA`|string||
+|`varB`|integer||
+|`varC`|integer||
 
 ***
 
 ### `Complex3`
 
 **Type**: Integer
-**Description**: lalala
+**Description**:
 
 ***
 
 ### `Complex4`
 
 **Type**: Object
-**Description**: lalala
+**Description**:
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varX`|string|lalal|
-|`varY`|integer|lall|
-|`varZ`|integer|lall|
+|`varX`|string||
+|`varY`|integer||
+|`varZ`|integer||
 
 ***
 
@@ -129,8 +129,8 @@ Description.
 
 |Name|Type|Description|Default value|
 |---|-----|-----------|-------------|
-|`varA` |string | lala|`null`|
-|`varB` *|integer|lalal|None|
+|`varA` |string | |`null`|
+|`varB` *|integer||None|
 
 ### Example
 
@@ -154,7 +154,7 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: String
 **Default value**: 10
-**Description**: lalala
+**Description**:
 
 ***
 
@@ -162,13 +162,13 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: Object
 **Default value**: None
-**Description**: lalala
+**Description**:
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varA`|string|lalal|
-|`varB`|integer|lall|
-|`varC`|integer|lall|
+|`varA`|string||
+|`varB`|integer||
+|`varC`|integer||
 
 ***
 
@@ -176,7 +176,7 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: Integer
 **Default value**: 10
-**Description**: lalala
+**Description**:
 
 ***
 
@@ -184,13 +184,13 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: Object
 **Default value**: None
-**Description**: lalala
+**Description**:
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varX`|string|lalal|
-|`varY`|integer|lall|
-|`varZ`|integer|lall|
+|`varX`|string||
+|`varY`|integer||
+|`varZ`|integer||
 
 ***
 
@@ -229,8 +229,8 @@ Description.
 
 |Name|Type|Description|Default value|
 |---|-----|-----------|-------------|
-|`varA` |string | lala|`null`|
-|`varB` *|integer|lalal|None|
+|`varA` |string | |`null`|
+|`varB` *|integer||None|
 
 ### Example
 
@@ -254,7 +254,7 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: String
 **Default value**: 10
-**Description**: lalala
+**Description**:
 
 ***
 
@@ -262,13 +262,13 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: Object
 **Default value**: None
-**Description**: lalala
+**Description**:
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varA`|string|lalal|
-|`varB`|integer|lall|
-|`varC`|integer|lall|
+|`varA`|string||
+|`varB`|integer||
+|`varC`|integer||
 
 ***
 
@@ -276,7 +276,7 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: Integer
 **Default value**: 10
-**Description**: lalala
+**Description**:
 
 ***
 
@@ -284,13 +284,13 @@ Returns a [random object](#the-random-object-simple).
 
 **Type**: Object
 **Default value**: None
-**Description**: lalala
+**Description**:
 
 |Name|Type|Description|
 |---|-----|-----------|
-|`varX`|string|lalal|
-|`varY`|integer|lall|
-|`varZ`|integer|lall|
+|`varX`|string||
+|`varY`|integer||
+|`varZ`|integer||
 
 ***
 

--- a/reference/api/format.md
+++ b/reference/api/format.md
@@ -1,7 +1,3 @@
----
-sidebarDepth: 2
----
-
 # Random API
 
 Explain what  the random API does.
@@ -24,14 +20,14 @@ Explain what  the random API does.
 
 ## The random object (complex)
 
-#### `Complex1`
+### `Complex1`
 
 **Type**: String
 **Description**:
 
 ***
 
-#### `Complex2`
+### `Complex2`
 
 **Type**: Object
 **Description**:
@@ -44,14 +40,14 @@ Explain what  the random API does.
 
 ***
 
-#### `Complex3`
+### `Complex3`
 
 **Type**: Integer
 **Description**:
 
 ***
 
-#### `Complex4`
+### `Complex4`
 
 **Type**: Object
 **Description**:
@@ -124,7 +120,7 @@ curl \
 
 Returns a [random object](#the-random-object-simple).
 
-#### Example
+### Example
 
 ```bash
 curl \
@@ -366,11 +362,11 @@ Returns a [random object](#the-random-object-complex).
 
 Deletes all [random objects](#the-random-object-simple).
 
-#### Example
+### Example
 
 Code sample
 
-##### Response: `204 No Content`
+#### Response: `204 No Content`
 
 ## Delete one
 
@@ -385,4 +381,4 @@ curl \
   -X DELETE 'http://localhost:7700/random/123'
 ```
 
-### Response: `204 No Content`
+#### Response: `204 No Content`

--- a/reference/api/format.md
+++ b/reference/api/format.md
@@ -20,13 +20,15 @@ Explain what  the random API does.
 
 ## The random object (complex)
 
-**Name**: Complex1
+### `Complex1`
+
 **Type**: String
 **Description**: lalala
 
 ***
 
-**Name**: Complex2
+### `Complex2`
+
 **Type**: Object
 **Description**: lalala
 
@@ -38,13 +40,15 @@ Explain what  the random API does.
 
 ***
 
-**Name**: Complex3
+### `Complex3`
+
 **Type**: Integer
 **Description**: lalala
 
 ***
 
-**Name**: Complex4
+### `Complex4`
+
 **Type**: Object
 **Description**: lalala
 
@@ -77,7 +81,7 @@ Explain what  the random API does.
 
 <RouteHighlighter method="GET" route="/random"/>
 
-Returns a list of [random objects](#the-random-object).
+Returns a list of [random objects](#the-random-object-simple).
 
 ### Response: `200 Ok`
 
@@ -103,7 +107,7 @@ Returns a list of [random objects](#the-random-object).
 
 <RouteHighlighter method="GET" route="/random/:random"/>
 
-Returns a [random object](#the-random-object).
+Returns a [random object](#the-random-object-simple).
 
 ### Response: `200 Ok`
 
@@ -132,7 +136,7 @@ Description.
 
 Code sample
 
-Returns a [random object](#the-random-object).
+Returns a [random object](#the-random-object-simple).
 
 #### Response: `201 Created`
 
@@ -146,7 +150,74 @@ Returns a [random object](#the-random-object).
 
 ### Request body (complex)
 
+#### * `Complex1`
 
+**Type**: String
+**Default value**: 10
+**Description**: lalala
+
+***
+
+#### `Complex2`
+
+**Type**: Object
+**Default value**: None
+**Description**: lalala
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varA`|string|lalal|
+|`varB`|integer|lall|
+|`varC`|integer|lall|
+
+***
+
+#### `Complex3`
+
+**Type**: Integer
+**Default value**: 10
+**Description**: lalala
+
+***
+
+#### `Complex4`
+
+**Type**: Object
+**Default value**: None
+**Description**: lalala
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varX`|string|lalal|
+|`varY`|integer|lall|
+|`varZ`|integer|lall|
+
+***
+
+### Example
+
+Code sample
+
+Returns a [random object](#the-random-object-complex).
+
+#### Response: `201 Created`
+
+```json
+{
+    "Complex1": "la",
+    "Complex2": {
+          "varA": "Hello",
+          "varB": 10,
+          "varC": "Hi"
+    },
+    "Complex3": 11,
+    "Complex4": {
+        "varX": "Hello",
+        "varY": 10,
+        "varZ": 3
+    }  
+}
+```
 
 ## Update
 
@@ -154,7 +225,7 @@ Returns a [random object](#the-random-object).
 
 Description.
 
-### Request body
+### Request body (simple)
 
 |Name|Type|Description|Default value|
 |---|-----|-----------|-------------|
@@ -165,7 +236,7 @@ Description.
 
 Code sample
 
-Returns a [random object](#the-random-object).
+Returns a [random object](#the-random-object-simple).
 
 #### Response: `201 Created`
 
@@ -177,11 +248,82 @@ Returns a [random object](#the-random-object).
 }
 ```
 
+### Request body (complex)
+
+#### * `Complex1`
+
+**Type**: String
+**Default value**: 10
+**Description**: lalala
+
+***
+
+#### `Complex2`
+
+**Type**: Object
+**Default value**: None
+**Description**: lalala
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varA`|string|lalal|
+|`varB`|integer|lall|
+|`varC`|integer|lall|
+
+***
+
+#### `Complex3`
+
+**Type**: Integer
+**Default value**: 10
+**Description**: lalala
+
+***
+
+#### `Complex4`
+
+**Type**: Object
+**Default value**: None
+**Description**: lalala
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varX`|string|lalal|
+|`varY`|integer|lall|
+|`varZ`|integer|lall|
+
+***
+
+### Example
+
+Code sample
+
+Returns a [random object](#the-random-object-complex).
+
+#### Response: `201 Created`
+
+```json
+{
+    "Complex1": "la",
+    "Complex2": {
+          "varA": "Hello",
+          "varB": 10,
+          "varC": "Hi"
+    },
+    "Complex3": 11,
+    "Complex4": {
+        "varX": "Hello",
+        "varY": 10,
+        "varZ": 3
+    }  
+}
+```
+
 ## Delete all
 
 <RouteHighlighter method="DELETE" route="/random"/>
 
-Deletes all [random objects](#the-random-object).
+Deletes all [random objects](#the-random-object-simple).
 
 ### Example
 
@@ -193,7 +335,7 @@ Code sample
 
 <RouteHighlighter method="DELETE" route="/random/:random"/>
 
-Deletes the specified [random object](#the-random-object).
+Deletes the specified [random object](#the-random-object-simple).
 
 ### Example
 

--- a/reference/api/format.md
+++ b/reference/api/format.md
@@ -1,3 +1,7 @@
+---
+sidebarDepth: 2
+---
+
 # Random API
 
 Explain what  the random API does.
@@ -20,14 +24,14 @@ Explain what  the random API does.
 
 ## The random object (complex)
 
-### `Complex1`
+#### `Complex1`
 
 **Type**: String
 **Description**:
 
 ***
 
-### `Complex2`
+#### `Complex2`
 
 **Type**: Object
 **Description**:
@@ -40,14 +44,14 @@ Explain what  the random API does.
 
 ***
 
-### `Complex3`
+#### `Complex3`
 
 **Type**: Integer
 **Description**:
 
 ***
 
-### `Complex4`
+#### `Complex4`
 
 **Type**: Object
 **Description**:
@@ -83,7 +87,14 @@ Explain what  the random API does.
 
 Returns a list of [random objects](#the-random-object-simple).
 
-### Response: `200 Ok`
+#### Example
+
+```bash
+curl \
+  -X GET 'http://localhost:7700/random'
+```
+
+#### Response: `200 Ok`
 
 ```json
 {
@@ -103,13 +114,25 @@ Returns a list of [random objects](#the-random-object-simple).
 }
 ```
 
+### Filtering random
+
+### Paginating random
+
 ## List one
 
 <RouteHighlighter method="GET" route="/random/:random"/>
 
 Returns a [random object](#the-random-object-simple).
 
-### Response: `200 Ok`
+#### Example
+
+```bash
+curl \
+  -X GET 'http://localhost:7700/random/123'
+
+```
+
+#### Response: `200 Ok`
 
 ```json
 {
@@ -125,20 +148,31 @@ Returns a [random object](#the-random-object-simple).
 
 Description.
 
+#### Example
+
+```bash
+  curl \
+  -X POST 'http://localhost:7700/random' \
+  -H 'Content-Type: application/json' \
+  --data-binary '{
+    "varB": 12
+  }'
+```
+
 ### Request body (simple)
 
-|Name|Type|Description|Default value|
-|---|-----|-----------|-------------|
-|`varA` |string | |`null`|
-|`varB` *|integer||None|
+|Name|Type|Description|
+|---|-----|-----------|
+|`varA` |string | |
+|`varB` *|integer||
 
-### Example
+#### Example
 
 Code sample
 
 Returns a [random object](#the-random-object-simple).
 
-#### Response: `201 Created`
+##### Response: `201 Created`
 
 ```json
 {
@@ -232,9 +266,16 @@ Description.
 |`varA` |string | |`null`|
 |`varB` *|integer||None|
 
-### Example
+#### Example
 
-Code sample
+```bash
+  curl \
+  -X POST 'http://localhost:7700/random' \
+  -H 'Content-Type: application/json' \
+  --data-binary '{
+    "varB": 12
+  }'
+```
 
 Returns a [random object](#the-random-object-simple).
 
@@ -294,7 +335,7 @@ Returns a [random object](#the-random-object-simple).
 
 ***
 
-### Example
+#### Example
 
 Code sample
 
@@ -325,11 +366,11 @@ Returns a [random object](#the-random-object-complex).
 
 Deletes all [random objects](#the-random-object-simple).
 
-### Example
+#### Example
 
 Code sample
 
-#### Response: `204 No Content`
+##### Response: `204 No Content`
 
 ## Delete one
 
@@ -339,6 +380,9 @@ Deletes the specified [random object](#the-random-object-simple).
 
 ### Example
 
-Code sample
+```bash
+curl \
+  -X DELETE 'http://localhost:7700/random/123'
+```
 
-#### Response: `204 No Content`
+### Response: `204 No Content`

--- a/reference/format2_listall.md
+++ b/reference/format2_listall.md
@@ -1,4 +1,8 @@
-# Random API
+---
+sidebarDepth: 2
+---
+
+# Random API (List all)
 
 Explain what the random API does.
 
@@ -20,7 +24,7 @@ Explain what the random API does.
 
 ## The random object (complex)
 
-### `Complex1`
+#### `Complex1`
 
 **Type**: String
 **Description**:
@@ -150,13 +154,6 @@ curl \
 
 Description.
 
-### Request body (simple)
-
-|Name|Type|Description|
-|---|-----|-----------|
-|`varA` |string | |
-|`varB` *|integer||
-
 #### Example
 
 ```bash
@@ -167,6 +164,17 @@ Description.
     "varB": 12
   }'
 ```
+
+### Request body (simple)
+
+|Name|Type|Description|
+|---|-----|-----------|
+|`varA` |string | |
+|`varB` *|integer||
+
+#### Example
+
+Code sample
 
 Returns a [random object](#the-random-object-simple).
 
@@ -226,16 +234,9 @@ Returns a [random object](#the-random-object-simple).
 
 ***
 
-#### Example
+### Example
 
-```bash
-  curl \
-  -X POST 'http://localhost:7700/random' \
-  -H 'Content-Type: application/json' \
-  --data-binary '{
-    "varZ": 12
-  }'
-```
+Code sample
 
 Returns a [random object](#the-random-object-complex).
 
@@ -342,14 +343,7 @@ Returns a [random object](#the-random-object-simple).
 
 #### Example
 
-```bash
-  curl \
-  -X POST 'http://localhost:7700/random' \
-  -H 'Content-Type: application/json' \
-  --data-binary '{
-    "varB": 12
-  }'
-```
+Code sample
 
 Returns a [random object](#the-random-object-complex).
 


### PR DESCRIPTION
closes #1351 

Based on the feedback we got on [this Slack thread](https://meilisearch.slack.com/archives/C010VV3SHQF/p1647958051085939), we'll go with [format 3](https://github.com/meilisearch/documentation/pull/1538).

- The format is similar to [Stripe](https://stripe.com/docs/api/balance/balance_object)

<img width="268" alt="Screen Shot 2022-03-30 at 19 30 14" src="https://user-images.githubusercontent.com/90181761/160873139-f489fd0d-39d6-42e0-b4dd-39eda3590766.png">

  - We start by explaining the object returned
    - If it's a simple object (like indexes), we use a table
    - If it's a complex object (like keys), we use a header structure
- We next list all the endpoints 
  - We don’t explain the fields returned for each endpoint but link the response to the object returned
  - This format goes against our H2=endpoint convention
### For reviewing the PR:

- Go to the `reference/api/format.md` page
  - Link for [deploy preview](https://deploy-preview-1549--dreamy-wiles-8fd85b.netlify.app/reference/api/format.html)
- There are two objects used here, simple and complex. The purpose is to have a format for both types. The actual API reference will have one

## To be discussed:
- List all endpoints:
  - Should we have [query parameters and default values](https://docs.meilisearch.com/reference/api/indexes.html#query-parameters) in ``?
  - Should the code sample use all query parameters? For now, we mostly have `offset` and `limit`. Tasks has 5
    - Should we have multiple code samples?
  - How do we make headings like “[Filtering](https://docs.meilisearch.com/reference/api/tasks.html#filtering-tasks)" and “[Pagination](https://docs.meilisearch.com/reference/api/tasks.html#paginating-tasks)” more visible in the API reference?
    - Possible solution: use `sidebarDepth: 2`
    - We will get [too many headings in the sidebar](https://deploy-preview-1549--dreamy-wiles-8fd85b.netlify.app/reference/format2_listall.html). This can be distracting. We could use H4s instead of H3s, but this goes against using headers progressively 
- Get settings endpoint
  - If we follow the new format, will we describe each field, or should we go with the [table](https://docs.meilisearch.com/reference/api/settings.html#response-body) we have now?
    - If we go with adding the [JSON response](https://deploy-preview-1549--dreamy-wiles-8fd85b.netlify.app/reference/api/format.html#the-random-object-simple) in the object heading, we will need to give some context for distinct, displayed, sortable and filterable attributes, stop words, and synonyms 
  - Not all settings are objects; some of them are arrays of strings, e.g., displayed, sortable and filterable attributes, stop words, and synonyms 
  - I think we should go with the current format for the settings routes. We should only use the new format if the object is composed of fields and objects, e.g., typo tolerance
    - The current format:
      - Explain the endpoint
      - Get
      - Update
      - Delete
- Search
  - I think this page should remain as it is; the only change I would like to make is to update the “[Response](https://docs.meilisearch.com/reference/api/search.html#response)” and “Example” headings to H4s so we don’t see them in the sidebar
- Update the router element colors. [Patch](https://docs.meilisearch.com/reference/api/keys.html#update-a-key) and [get](https://docs.meilisearch.com/reference/api/keys.html#get-all-keys) have the same green
  - Put and post mostly use the same color
- How will this format work for endpoints that only have one field? E.g., version and health
- Will we explain the task object for dumps? Or should we link the tasks page?
- Put an * next to all mandatory parameters