### PR TITLE
update docs: '=true' value no longer required

### DIFF
--- a/learn/advanced/snapshots.md
+++ b/learn/advanced/snapshots.md
@@ -9,7 +9,7 @@ Using this feature, it is possible to schedule snapshot creation at custom inter
 For Meilisearch to create snapshots, the feature must be enabled by adding the following flag:
 
 ```bash
-meilisearch --schedule-snapshot=true
+meilisearch --schedule-snapshot
 ```
 
 By default, Meilisearch creates snapshots in a directory called `snapshots/` at the root of your Meilisearch.
@@ -17,7 +17,7 @@ By default, Meilisearch creates snapshots in a directory called `snapshots/` at 
 The destination can be modified with the `--snapshot-dir` flag.
 
 ```bash
-meilisearch --schedule-snapshot=true --snapshot-dir mySnapShots/
+meilisearch --schedule-snapshot --snapshot-dir mySnapShots/
 ```
 
 Now snapshots are created in `mySnapShots/` directory.
@@ -27,7 +27,7 @@ The first snapshot is created on launching Meilisearch. After that, snapshots ar
 The amount of time between each new snapshot can be modified with the `--snapshot-interval-sec` flag.
 
 ```bash
-meilisearch --schedule-snapshot=true --snapshot-interval-sec 3600
+meilisearch --schedule-snapshot --snapshot-interval-sec 3600
 ```
 
 After running the above code, a snapshot is created every hour (3600 seconds).


### PR DESCRIPTION
EDIT: just found its also mentioned in the CLI docs. https://docs.meilisearch.com/learn/configuration/instance_options.html#schedule-snapshot-creation

As tried on v0.26.1, '--schedule-snapshot' doesn't need '=true' & works fine without it.

If included, throws error on below cli features.
1] activating snapshots
2] define snapshots directory
3] define snapshots interval

# Pull Request

## What does this PR do?
Fixes #<issue_number>
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
