### PR TITLE
Replace {uid} with {index_uid} or {task_uid} in API reference

### DIFF
--- a/reference/api/indexes.md
+++ b/reference/api/indexes.md
@@ -52,7 +52,7 @@ Get information about an [index](/learn/core_concepts/indexes.md).
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **index_uid** | The index UID |
+| **uid** | The index UID |
 
 ### Example
 
@@ -134,7 +134,7 @@ This is an asynchronous task. [You can read more about asynchronous operations i
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **index_uid** | The index UID |
+| **uid** | The index UID |
 
 ### Body
 
@@ -172,7 +172,7 @@ This is an asynchronous task. [You can read more about asynchronous operations i
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **index_uid** | The index UID |
+| **uid** | The index UID |
 
 ### Example
 

--- a/reference/api/indexes.md
+++ b/reference/api/indexes.md
@@ -44,7 +44,7 @@ List all [indexes](/learn/core_concepts/indexes.md).
 
 ## Get one index
 
-<RouteHighlighter method="GET" route="/indexes/{uid}"/>
+<RouteHighlighter method="GET" route="/indexes/{index_uid}"/>
 
 Get information about an [index](/learn/core_concepts/indexes.md).
 
@@ -52,7 +52,7 @@ Get information about an [index](/learn/core_concepts/indexes.md).
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **uid** | The index UID |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -76,7 +76,7 @@ Get information about an [index](/learn/core_concepts/indexes.md).
 
 Create an [index](/learn/core_concepts/indexes.md). This endpoint accepts two arguments: `uid` and `primaryKey`.
 
-If you do not supply a value for `primaryKey`, Meilisearch will try to infer your dataset's unique identifier from first document you add to the index.
+If you do not supply a value for `primaryKey`, Meilisearch will try to infer your dataset's unique identifier from the first document you add to the index.
 
 ::: note
 If you try to add [documents](/reference/api/documents.md) or [settings](/reference/api/settings.md) to an index that does not exist, Meilisearch will automatically create it for you. This is called implicit index creation.
@@ -118,7 +118,7 @@ You can use the response's `uid` to [track the status of your request](/referenc
 
 ## Update an index
 
-<RouteHighlighter method="PUT" route="/indexes/{uid}"/>
+<RouteHighlighter method="PUT" route="/indexes/{index_uid}"/>
 
 Update an [index's](/learn/core_concepts/indexes.md) [primary key](/learn/core_concepts/documents.md#primary-key).
 
@@ -134,7 +134,7 @@ This is an asynchronous task. [You can read more about asynchronous operations i
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **uid** | The index UID |
+| **index_uid** | The index UID |
 
 ### Body
 
@@ -162,7 +162,7 @@ You can use the response's `uid` to [track the status of your request](/referenc
 
 ## Delete an index
 
-<RouteHighlighter method="DELETE" route="/indexes/{uid}"/>
+<RouteHighlighter method="DELETE" route="/indexes/{index_uid}"/>
 
 Delete an [index](/learn/core_concepts/indexes.md).
 
@@ -172,7 +172,7 @@ This is an asynchronous task. [You can read more about asynchronous operations i
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **uid** | The index UID |
+| **index_uid** | The index UID |
 
 ### Example
 

--- a/reference/api/tasks.md
+++ b/reference/api/tasks.md
@@ -63,7 +63,7 @@ Get a single [task](/learn/advanced/asynchronous_operations.md).
 
 | Variable      | Description           |
 | ------------- | --------------------- |
-| **task_uid**  | The task identifier |
+| **uid**  | The task identifier |
 
 ### Example
 
@@ -106,7 +106,7 @@ List all [tasks](/learn/advanced/asynchronous_operations.md) for a given [index]
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **index_uid** | The index UID |
+| **indexUid** | The index UID |
 
 ### Example
 
@@ -155,8 +155,8 @@ Get a single [task](/learn/advanced/asynchronous_operations.md) in a given [inde
 
 | Variable      | Description           |
 | ------------- | --------------------- |
-| **index_uid** | The index UID         |
-| **task_uid**  | The task identifier |
+| **indexUid** | The index UID         |
+| **uid**  | The task identifier |
 
 ### Example
 

--- a/reference/api/tasks.md
+++ b/reference/api/tasks.md
@@ -55,7 +55,7 @@ Tasks are displayed in descending order by `uid`. This means that **the most rec
 
 ## Get task
 
-<RouteHighlighter method="GET" route="/tasks/{uid}"/>
+<RouteHighlighter method="GET" route="/tasks/{task_uid}"/>
 
 Get a single [task](/learn/advanced/asynchronous_operations.md).
 
@@ -63,7 +63,7 @@ Get a single [task](/learn/advanced/asynchronous_operations.md).
 
 | Variable      | Description           |
 | ------------- | --------------------- |
-| **uid**  | The task identifier |
+| **task_uid**  | The task identifier |
 
 ### Example
 
@@ -98,7 +98,7 @@ Here is an example response representing [a processed task](/learn/advanced/asyn
 
 ## Get all tasks by index
 
-<RouteHighlighter method="GET" route="/indexes/{indexUid}/tasks"/>
+<RouteHighlighter method="GET" route="/indexes/{index_uid}/tasks"/>
 
 List all [tasks](/learn/advanced/asynchronous_operations.md) for a given [index](/learn/core_concepts/indexes.md).
 
@@ -106,7 +106,7 @@ List all [tasks](/learn/advanced/asynchronous_operations.md) for a given [index]
 
 | Variable      | Description   |
 | ------------- | ------------- |
-| **indexUid** | The index UID |
+| **index_uid** | The index UID |
 
 ### Example
 
@@ -147,7 +147,7 @@ List all [tasks](/learn/advanced/asynchronous_operations.md) for a given [index]
 
 ## Get task by index
 
-<RouteHighlighter method="GET" route="/indexes/{indexUid}/tasks/{uid}"/>
+<RouteHighlighter method="GET" route="/indexes/{index_uid}/tasks/{task_uid}"/>
 
 Get a single [task](/learn/advanced/asynchronous_operations.md) in a given [index](/learn/core_concepts/indexes.md).
 
@@ -155,8 +155,8 @@ Get a single [task](/learn/advanced/asynchronous_operations.md) in a given [inde
 
 | Variable      | Description           |
 | ------------- | --------------------- |
-| **indexUid** | The index UID         |
-| **uid**  | The task identifier |
+| **index_uid** | The index UID         |
+| **task_uid**  | The task identifier |
 
 ### Example
 


### PR DESCRIPTION
As we are planning to remove the path variable tables from all API endpoints, and as there are now multiple objects with the `uid` field in Meilisearch, it makes sense to be more specific about which "type" of uid an endpoint is expecting.