### PR TITLE
update json responses to add space after `:` + fix typo

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -331,7 +331,7 @@ filtering_guide_2: |-
   curl \
     -X POST 'http://localhost:7700/indexes/movies/search' \
     -H 'Content-Type: application/json' \
-    --data-binary '{ "q": "Batman",  "filter": "release_date > 795484800 AND (director = \"Tim Burton\" OR director = \"Christopher Nolan\")" }'
+    --data-binary '{ "q": "Batman", "filter": "release_date > 795484800 AND (director = \"Tim Burton\" OR director = \"Christopher Nolan\")" }'
 filtering_guide_3: |-
   curl \
     -X POST 'http://localhost:7700/indexes/movies/search' \

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -331,7 +331,7 @@ filtering_guide_2: |-
   curl \
     -X POST 'http://localhost:7700/indexes/movies/search' \
     -H 'Content-Type: application/json' \
-    --data-binary '{ "q":"Batman",  "filter": "release_date > 795484800 AND (director = \"Tim Burton\" OR director = \"Christopher Nolan\")" }'
+    --data-binary '{ "q": "Batman",  "filter": "release_date > 795484800 AND (director = \"Tim Burton\" OR director = \"Christopher Nolan\")" }'
 filtering_guide_3: |-
   curl \
     -X POST 'http://localhost:7700/indexes/movies/search' \

--- a/learn/cookbooks/digitalocean_droplet.md
+++ b/learn/cookbooks/digitalocean_droplet.md
@@ -91,13 +91,13 @@ This should work out of the box. Your domain name should now be linked to your M
 curl -v http://<your-domain-name>/health
 ```
 
-The server should answer with a `200 OK` status code and the following body `{"status":"available"}` as shown in the example below:
+The server should answer with a `200 OK` status code and the following body `{"status": "available"}` as shown in the example below:
 
 ```bash
 ...
 HTTP/1.1 200 OK
 ...
-{"status":"available"}
+{"status": "available"}
 ...
 ```
 
@@ -136,13 +136,13 @@ To check if everything is running smoothly, do an HTTP call to the `/health` rou
 curl -v https://<your-domain-name>/health
 ```
 
-The server should answer with a `200 OK` status code and the following body `{"status":"available"}` as shown in the example below:
+The server should answer with a `200 OK` status code and the following body `{"status": "available"}` as shown in the example below:
 
 ```bash
 ...
 HTTP/1.1 200 OK
 ...
-{"status":"available"}
+{"status": "available"}
 ...
 ```
 

--- a/learn/cookbooks/gcp.md
+++ b/learn/cookbooks/gcp.md
@@ -71,7 +71,7 @@ curl http://<your-external-ip>/health
 The server should answer with a `200 OK` status code as shown in the example below:
 
 ```bash
-{"status":"available"}
+{"status": "available"}
 ```
 
 ## Part 2: Set your instance to a production environment

--- a/learn/core_concepts/indexes.md
+++ b/learn/core_concepts/indexes.md
@@ -40,7 +40,7 @@ The `uid` is set at [index creation time](/reference/api/indexes.md#create-an-in
 ```json
 {
   "uid": "movies",
-  "name":"movies",
+  "name": "movies",
   "createdAt": "2019-11-20T09:40:33.711324Z",
   "updatedAt": "2019-11-20T10:16:42.761858Z"
 }

--- a/learn/getting_started/filtering_and_sorting.md
+++ b/learn/getting_started/filtering_and_sorting.md
@@ -32,21 +32,21 @@ Let's say you only want to view meteorites that weigh less than 200g:
 {
   "hits":[
     {
-      "name":"Aachen",
-      "mass":21
+      "name": "Aachen",
+      "mass": 21
     },
     {
-      "name":"Emmaville",
-      "mass":127
+      "name": "Emmaville",
+      "mass": 127
     },
     …
   ],
-  "nbHits":114,
-  "exhaustiveNbHits":false,
-  "query":"",
-  "limit":20,
-  "offset":0,
-  "processingTimeMs":0
+  "nbHits": 114,
+  "exhaustiveNbHits": false,
+  "query": "",
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 0
 }
 ```
 
@@ -68,22 +68,21 @@ Let's sort the meteorites in the previous example based on mass:
 {
   "hits":[
     {
-      "name":"Silistra",
-      "mass":0.15
+      "name": "Silistra",
+      "mass": 0.15
     },
     {
-      "name":"Hachi-oji",
-      "mass":0.2
+      "name": "Hachi-oji",
+      "mass": 0.2
     },
     …
   ],
-  "nbHits":114,
-  "exhaustiveNbHits":false,
-  "query":"",
-  "limit":20,
-  "offset":0,
-  "processingTimeMs":1
-  }
+  "nbHits": 114,
+  "exhaustiveNbHits": false,
+  "query": "",
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 1
 ```
 
 You will see all meteorites weighing less than 200g sorted by increasing mass. To sort them in the opposite direction, you would use `mass:desc`.
@@ -106,39 +105,39 @@ Let's say you want to find out which meteorites crashed within a 210km radius of
 {
   "hits":[
   {
-    "name":"Ensisheim",
-    "id":"10039",
-    "nametype":"Valid",
-    "recclass":"LL6",
-    "mass":"127000",
-    "fall":"Fell",
-    "year":"1492-01-01T00:00:00.000",
+    "name": "Ensisheim",
+    "id": "10039",
+    "nametype": "Valid",
+    "recclass": "LL6",
+    "mass": "127000",
+    "fall": "Fell",
+    "year": "1492-01-01T00:00:00.000",
     "_geo": {
-        "lat":47.86667,
-        "lng":7.35
+        "lat": 47.86667,
+        "lng": 7.35
         }
   },
   {
-    "name":"Épinal",
-    "id":"10041",
-    "nametype":"Valid",
-    "recclass":"H5",
-    "mass":"277",
-    "fall":"Fell",
-    "year":"1822-01-01T00:00:00.000",
+    "name": "Épinal",
+    "id": "10041",
+    "nametype": "Valid",
+    "recclass": "H5",
+    "mass": "277",
+    "fall": "Fell",
+    "year": "1822-01-01T00:00:00.000",
     "_geo": {
-        "lat":48.18333,
-        "lng":6.46667
+        "lat": 48.18333,
+        "lng": 6.46667
         }
   },
   …
   ],
-  "nbHits":7,
-  "exhaustiveNbHits":false,
-  "query":"",
-  "limit":20,
-  "offset":0,
-  "processingTimeMs":3
+  "nbHits": 7,
+  "exhaustiveNbHits": false,
+  "query": "",
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 3
   }
   ```
 
@@ -152,41 +151,41 @@ The following command sorts meteorites by how close they were to the Taj Mahal:
 {
   "hits":[
   {
-    "name":"Nagaria",
-    "id":"16892",
-    "nametype":"Valid",
-    "recclass":"Eucrite-cm",
-    "mass":"20",
-    "fall":"Fell",
-    "year":"1875-01-01T00:00:00.000",
+    "name": "Nagaria",
+    "id": "16892",
+    "nametype": "Valid",
+    "recclass": "Eucrite-cm",
+    "mass": "20",
+    "fall": "Fell",
+    "year": "1875-01-01T00:00:00.000",
     "_geo": {
-      "lat":26.98333,
-      "lng":78.21667
+      "lat": 26.98333,
+      "lng": 78.21667
       },
-      "_geoDistance":27449
+      "_geoDistance": 27449
   },
   {
-    "name":"Kheragur",
-    "id":"12294",
-    "nametype":"Valid",
-    "recclass":"L6",
-    "mass":"450",
-    "fall":"Fell",
-    "year":"1860-01-01T00:00:00.000",
+    "name": "Kheragur",
+    "id": "12294",
+    "nametype": "Valid",
+    "recclass": "L6",
+    "mass": "450",
+    "fall": "Fell",
+    "year": "1860-01-01T00:00:00.000",
     "_geo": {
-      "lat":26.95,
-      "lng":77.88333
+      "lat": 26.95,
+      "lng": 77.88333
       },
-      "_geoDistance":29558
+      "_geoDistance": 29558
     },
   …
   ]
-  "nbHits":1000,
-  "exhaustiveNbHits":false,
-  "query":"",
-  "limit":20,
-  "offset":0,
-  "processingTimeMs":4
+  "nbHits": 1000,
+  "exhaustiveNbHits": false,
+  "query": "",
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 4
   }
 ```
 

--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -196,18 +196,18 @@ If the document addition is successful, the response should look like this:
 
 ```json
 {
-   "uid":0,
-   "indexUid":"movies",
-   "status":"succeeded",
-   "type":"documentAddition",
+   "uid": 0,
+   "indexUid": "movies",
+   "status": "succeeded",
+   "type": "documentAddition",
    "details":{
-      "receivedDocuments":19547,
-      "indexedDocuments":19547
+      "receivedDocuments": 19547,
+      "indexedDocuments": 19547
    },
-   "duration":"PT0.030750S",
-   "enqueuedAt":"2021-12-20T12:39:18.349288Z",
-   "startedAt":"2021-12-20T12:39:18.352490Z",
-   "finishedAt":"2021-12-20T12:39:18.380038Z"
+   "duration": "PT0.030750S",
+   "enqueuedAt": "2021-12-20T12:39:18.349288Z",
+   "startedAt": "2021-12-20T12:39:18.352490Z",
+   "finishedAt": "2021-12-20T12:39:18.380038Z"
 }
 ```
 
@@ -242,12 +242,12 @@ In the above code sample, the parameter `q` represents the search query. The doc
     },
     …
   ],
-  "nbHits":66,
-  "exhaustiveNbHits":false,
-  "query":"botman",
-  "limit":20,
-  "offset":0,
-  "processingTimeMs":12
+  "nbHits": 66,
+  "exhaustiveNbHits": false,
+  "query": "botman",
+  "limit": 20,
+  "offset": 0,
+  "processingTimeMs": 12
 }
 ```
 

--- a/learn/what_is_meilisearch/search_preview.md
+++ b/learn/what_is_meilisearch/search_preview.md
@@ -18,6 +18,6 @@ You can add a dataset containing many popular movies to an instance:
 
 <CodeSamples id="add_movies_json_1" />
 
-Once indexation is finished, you can access `http://127.0.0.1:7700` and confirm everything is working correcty by searching for "The Truman Show:"
+Once indexation is finished, you can access `http://127.0.0.1:7700` and confirm everything is working correctly by searching for "The Truman Show:"
 
 <MovieGif />

--- a/reference/api/documents.md
+++ b/reference/api/documents.md
@@ -115,7 +115,7 @@ The body is composed of a **JSON array** of documents.
 
 ```json
 {
-    "uid":1,
+    "uid": 1,
     "indexUid": "movies",
     "status": "enqueued",
     "type": "documentAddition",

--- a/reference/api/indexes.md
+++ b/reference/api/indexes.md
@@ -19,25 +19,25 @@ List all [indexes](/learn/core_concepts/indexes.md).
 ```json
 [
   {
-    "uid":"books",
-    "name":"books",
-    "createdAt":"2022-03-08T10:00:27.377346Z",
-    "updatedAt":"2022-03-08T10:00:27.391209Z",
-    "primaryKey":"id"
+    "uid": "books",
+    "name": "books",
+    "createdAt": "2022-03-08T10:00:27.377346Z",
+    "updatedAt": "2022-03-08T10:00:27.391209Z",
+    "primaryKey": "id"
   },
   {
-    "uid":"meteorites",
-    "name":"meteorites",
-    "createdAt":"2022-03-08T10:00:44.518768Z",
-    "updatedAt":"2022-03-08T10:00:44.582083Z",
-    "primaryKey":"id"
+    "uid": "meteorites",
+    "name": "meteorites",
+    "createdAt": "2022-03-08T10:00:44.518768Z",
+    "updatedAt": "2022-03-08T10:00:44.582083Z",
+    "primaryKey": "id"
   },
   {
-    "uid":"movies",
-    "name":"movies",
-    "createdAt":"2022-02-10T07:45:15.628261Z",
-    "updatedAt":"2022-02-21T15:28:43.496574Z",
-    "primaryKey":"id"
+    "uid": "movies",
+    "name": "movies",
+    "createdAt": "2022-02-10T07:45:15.628261Z",
+    "updatedAt": "2022-02-21T15:28:43.496574Z",
+    "primaryKey": "id"
   }
 ]  
 ```
@@ -56,11 +56,11 @@ Get information about an [index](/learn/core_concepts/indexes.md). The index [`u
 
 ```json
 {
-  "uid":"movies",
-  "name":"movies",
-  "createdAt":"2022-02-10T07:45:15.628261Z",
-  "updatedAt":"2022-02-21T15:28:43.496574Z",
-  "primaryKey":"id"
+  "uid": "movies",
+  "name": "movies",
+  "createdAt": "2022-02-10T07:45:15.628261Z",
+  "updatedAt": "2022-02-21T15:28:43.496574Z",
+  "primaryKey": "id"
 }
 ```
 


### PR DESCRIPTION
closes #1596 

Example:

Update:
```
"uid":1,
```
to
```
"uid": 1,
```