### PR TITLE
Update version of docs-scraper

### DIFF
--- a/.github/workflows/gh-pages-scraping.yml
+++ b/.github/workflows/gh-pages-scraping.yml
@@ -42,4 +42,4 @@ jobs:
             -e MEILISEARCH_HOST_URL=$HOST_URL \
             -e MEILISEARCH_API_KEY=$API_KEY \
             -v $CONFIG_FILE_PATH:/docs-scraper/config.json \
-            getmeili/docs-scraper:v0.11.0 pipenv run ./docs_scraper config.json
+            getmeili/docs-scraper:v0.12.1 pipenv run ./docs_scraper config.json


### PR DESCRIPTION
I think this has not been updated since before the whole asynchronous index creation release.

This might be the reason why sometimes scrapping fails.

TODO: Needs to be tested.

The following command needs to be tested locally: 

```bash
          docker run -t --rm \
            -e MEILISEARCH_HOST_URL=$HOST_URL \
            -e MEILISEARCH_API_KEY=$API_KEY \
            -v $CONFIG_FILE_PATH:/Users/XX/documentation/.vuepress/docs-scraper.config.json \
            getmeili/docs-scraper:v0.12.1 pipenv run ./docs_scraper config.json
```

To test it locally update this part in `./vuepress/config.js` line 367

```js
'meilisearch',
      {
        hostUrl: 'localhost?',
        apiKey:
          '...',
        ...
      },

```