### PR TITLE
Algolia migration guide

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -103,6 +103,10 @@ module.exports = {
           path: '/learn/getting_started/quick_start/',
           collapsable: false,
           children: [
+            {
+              title: 'Algolia -> Meilisearch',
+              path: '/learn/getting_started/algolia_migration'
+            },
             '/learn/getting_started/quick_start',
             {
               title: 'Meilisearch 101',
@@ -114,7 +118,6 @@ module.exports = {
                 '/learn/getting_started/getting_ready_for_production',
               ],
             },
-            '/learn/getting_started/algolia_migration',
           ],
         },
         {

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -105,7 +105,7 @@ module.exports = {
           children: [
             {
               title: 'Algolia -> Meilisearch',
-              path: '/learn/getting_started/algolia_migration'
+              path: '/learn/getting_started/algolia_migration',
             },
             '/learn/getting_started/quick_start',
             {

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -114,7 +114,7 @@ module.exports = {
                 '/learn/getting_started/getting_ready_for_production',
               ],
             },
-            '/learn/getting_started/algolia_migration'
+            '/learn/getting_started/algolia_migration',
           ],
         },
         {

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -103,10 +103,6 @@ module.exports = {
           path: '/learn/getting_started/quick_start/',
           collapsable: false,
           children: [
-            {
-              title: 'Algolia -> Meilisearch',
-              path: '/learn/getting_started/algolia_migration',
-            },
             '/learn/getting_started/quick_start',
             {
               title: 'Meilisearch 101',
@@ -117,6 +113,10 @@ module.exports = {
                 '/learn/getting_started/customizing_relevancy',
                 '/learn/getting_started/getting_ready_for_production',
               ],
+            },
+            {
+              title: 'Migrating from Algolia',
+              path: '/learn/getting_started/algolia_migration',
             },
           ],
         },

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -114,6 +114,7 @@ module.exports = {
                 '/learn/getting_started/getting_ready_for_production',
               ],
             },
+            '/learn/getting_started/algolia_migration'
           ],
         },
         {

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -1,8 +1,8 @@
 # Migrating from Algolia to Meilisearch
 
-This guide aims to help current users of Algolia make the transition to Meilisearch.
+This page aims to help current users of Algolia make the transition to Meilisearch.
 
-It covers the process of exporting Algolia data and indexing it in Meilisearch using [a Node.js script](#finished-script). It also compares Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
+It includes a guide to exporting Algolia data and indexing it in Meilisearch using [a Node.js script](#finished-script). It also compares Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
 
 If you are looking for a high-level comparison of the two search companies and their products, see [our analysis of the search market](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -12,9 +12,9 @@ Migrating indexes from Algolia to Meilisearch can be done in three steps:
 
 1. Export your data stored in Algolia
 2. Upload your data to Meilisearch
-3. (optional) Configure your settings to approximate the settings of your Algolia index
+3. Configure your index settings (optional)
 
-This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal. If you're unsure, see our [quick start](/learn/getting_started/quick_start.md) for instructions on installing Meilisearch.
+This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. Before continuing, make sure you have both Meilisearch and Node.js installed and have access to a command-line terminal. If you're unsure, see our [quick start](/learn/getting_started/quick_start.md) for instructions on installing Meilisearch.
 
 ::: note
 
@@ -82,7 +82,7 @@ await algoliaIndex.browseObjects({
   });
 ```
 
-On each batch of hits, the `batch` callback method is invoked, and the content is concatenated in the `records` array. This variable will be used later on in the upload process.
+The `batch` callback method is invoked on each batch of hits and the content is concatenated in the `records` array. `records` will be used again later in the upload process.
 
 ### Create Meilisearch client
 
@@ -186,7 +186,7 @@ The below table compares Algolia's **API parameters** with the equivalent Meilis
 
 This section compares Algolia and Meilisearch's respective API methods, using JavaScript for reference.
 
-| Topic | Algolia | Meilisearch |
+| Method | Algolia | Meilisearch |
 | --- | --- | --- |
 | Index Instantiation | `client.initIndex()`<br>Here, client is an Algolia instance. | `client.index()`<br>Here, client is a Meilisearch instance. |
 | Create Index | Users don’t need to create an index explicitly, the engine does it for you the first time you add an object or set settings. | The same applies for Meilisearch but users can also create an index explicitly using: `client.createIndex(string indexName)` |
@@ -212,4 +212,4 @@ This section compares Algolia and Meilisearch's respective API methods, using Ja
 
 [InstantSearch](https://github.com/algolia/instantsearch.js) is a collection of open-source tools maintained by Algolia and used to generate front-end search UI components.
 
-[Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. Here is [an up-to-date list of components compatible with Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch/#-api-resources).
+[Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. You can find an up-to-date list of [the components supported by Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch/#-api-resources) in its GitHub repository.

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -172,61 +172,61 @@ Some Meilisearch parameters require index settings to be configured beforehand; 
 
 The below table compares Algolia's **API parameters** with the equivalent Meilisearch **setting** or **search parameter**.
 
-| Algolia | Meilisearch |
-| --- | --- |
-| `query` | `q` |
-| `attributesToRetrieve` | `attributesToRetrieve` |
-| `filters` | `filter` |
-| `facets` | `facetsDistribution` |
-| `attributesToHighlight` | `attributesToHighlight` |
-| `offset` | `offset` |
-| `length` | `limit` |
-| `typoTolerance` | `typoTolerance` |
-| `snippetEllipsisText` | `cropMarker` |
-| `searchableAttributes` | `searchableAttributes` |
-| `attributesForFaceting` | `filterableAttributes` |
-| `unretrievableAttributes` | No direct equivalent; achieved by removing attributes from displayedAttributes |
-| `attributesToRetrieve` | `displayedAttributes` |
-| `attributeForDistinct` | `distinctAttribute` |
-| `ranking` | `rankingRules` |
-| `customRanking` | Integrated within `rankingRules` |
-| `removeStopWords` | `stopWords` |
-| `synonyms` | `synonyms` |
-| Sorting(using replicas) | `sortableAttributes` (no replicas required) |
-| `removeWordsIfNoResults` | Automatically supported, but not customizable |
-| `disableTypoToleranceOnAttributes` | `typoTolerance.disableOnAttributes` |
-| `separatorsToIndex` | Not Supported |
-| `disablePrefixOnAttributes` | Not Supported |
-| `relevancyStrictness` | Not Supported |
-| `maxValuesPerFacet` | Not Supported |
-| `sortFacetValuesBy` | Not Supported |
-| `restrictHighlightAndSnippetArrays` | Not Supported |
+| Algolia                             | Meilisearch                                                                    |
+|-------------------------------------|--------------------------------------------------------------------------------|
+| `query`                             | `q`                                                                            |
+| `attributesToRetrieve`              | `attributesToRetrieve`                                                         |
+| `filters`                           | `filter`                                                                       |
+| `facets`                            | `facetsDistribution`                                                           |
+| `attributesToHighlight`             | `attributesToHighlight`                                                        |
+| `offset`                            | `offset`                                                                       |
+| `length`                            | `limit`                                                                        |
+| `typoTolerance`                     | `typoTolerance`                                                                |
+| `snippetEllipsisText`               | `cropMarker`                                                                   |
+| `searchableAttributes`              | `searchableAttributes`                                                         |
+| `attributesForFaceting`             | `filterableAttributes`                                                         |
+| `unretrievableAttributes`           | No direct equivalent; achieved by removing attributes from displayedAttributes |
+| `attributesToRetrieve`              | `displayedAttributes`                                                          |
+| `attributeForDistinct`              | `distinctAttribute`                                                            |
+| `ranking`                           | `rankingRules`                                                                 |
+| `customRanking`                     | Integrated within `rankingRules`                                               |
+| `removeStopWords`                   | `stopWords`                                                                    |
+| `synonyms`                          | `synonyms`                                                                     |
+| Sorting(using replicas)             | `sortableAttributes` (no replicas required)                                    |
+| `removeWordsIfNoResults`            | Automatically supported, but not customizable                                  |
+| `disableTypoToleranceOnAttributes`  | `typoTolerance.disableOnAttributes`                                            |
+| `separatorsToIndex`                 | Not Supported                                                                  |
+| `disablePrefixOnAttributes`         | Not Supported                                                                  |
+| `relevancyStrictness`               | Not Supported                                                                  |
+| `maxValuesPerFacet`                 | Not Supported                                                                  |
+| `sortFacetValuesBy`                 | Not Supported                                                                  |
+| `restrictHighlightAndSnippetArrays` | Not Supported                                                                  |
 
 ## API methods
 
 This section compares Algolia and Meilisearch's respective API methods, using JavaScript for reference.
 
-| Method | Algolia | Meilisearch |
-| --- | --- | --- |
-| Index Instantiation | `client.initIndex()`<br>Here, client is an Algolia instance. | `client.index()`<br>Here, client is a Meilisearch instance. |
-| Create Index | Users don’t need to create an index explicitly, the engine does it for you the first time you add an object or set settings. | The same applies for Meilisearch but users can also create an index explicitly using: `client.createIndex(string indexName)` |
-| Get All Indexes | `client.listIndices()` | `client.getIndexes()` |
-| Get Single Index | No method available | `client.getIndex(string indexName)` |
-| Delete Index | `index.delete()` | `client.deleteIndex(string indexName)` |
-| Get Index Settings | `index.getSettings()` | `index().getSettings()` |
-| Update Index Settings | `index.setSettings(object settings)` | `index().updateSettings(object settings)` |
-| Search Method | `index.search(string query, { searchParameters, requestOptions })` | `index.search(string query, object searchParameters)` |
-| Add Object | `index.saveObjects(array objects)` | `index.addDocuments(array objects)` |
-| Partial Update Object | `index.partialUpdateObjects(array objects)` | `index.updateDocuments(array objects)` |
-| Delete All Objects | `index.deleteObjects(array objectIDs)` | `index.deleteAllDocuments()` |
-| Delete One Object | `index.deleteObject(string objectID)` | `index.deleteDocument(string id)` |
-| Get All Objects | `index.getObjects(array objectIDs)` | `index.getDocuments(object params)` |
-| Get Single Object | `index.getObject(str objectID)` | `index.getDocument(string id)` |
-| Get API Keys | `client.listApiKeys()` | `client.getKeys()` |
-| Get API Key Info | `client.getApiKey(string apiKey)` | `client.getKey(string apiKey)` |
-| Create API Key | `client.addApiKey(array acl)` | `client.createKey(object configuration)` |
-| Update API Key | `client.updateApiKey(string apiKey, object configuration)` | `client.updateKey(string apiKey, object configuration)` |
-| Delete API Key | `client.deleteApiKey(string apiKey)` | `client.deleteKey(string apiKey)` |
+| Method                | Algolia                                                                             | Meilisearch                                                                                                            |
+|-----------------------|-------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------|
+| Index Instantiation   | `client.initIndex()`<br>Here, client is an Algolia instance.                        | `client.index()`<br>Here, client is a Meilisearch instance.                                                            |
+| Create Index          | Algolia automatically creates an index the first time you add a record or settings. | The same applies to Meilisearch, but users can also create an index explicitly: `client.createIndex(string indexName)` |
+| Get All Indexes       | `client.listIndices()`                                                              | `client.getIndexes()`                                                                                                  |
+| Get Single Index      | No method available                                                                 | `client.getIndex(string indexName)`                                                                                    |
+| Delete Index          | `index.delete()`                                                                    | `client.deleteIndex(string indexName)`                                                                                 |
+| Get Index Settings    | `index.getSettings()`                                                               | `index().getSettings()`                                                                                                |
+| Update Index Settings | `index.setSettings(object settings)`                                                | `index().updateSettings(object settings)`                                                                              |
+| Search Method         | `index.search(string query, { searchParameters, requestOptions })`                  | `index.search(string query, object searchParameters)`                                                                  |
+| Add Object            | `index.saveObjects(array objects)`                                                  | `index.addDocuments(array objects)`                                                                                    |
+| Partial Update Object | `index.partialUpdateObjects(array objects)`                                         | `index.updateDocuments(array objects)`                                                                                 |
+| Delete All Objects    | `index.deleteObjects(array objectIDs)`                                              | `index.deleteAllDocuments()`                                                                                           |
+| Delete One Object     | `index.deleteObject(string objectID)`                                               | `index.deleteDocument(string id)`                                                                                      |
+| Get All Objects       | `index.getObjects(array objectIDs)`                                                 | `index.getDocuments(object params)`                                                                                    |
+| Get Single Object     | `index.getObject(str objectID)`                                                     | `index.getDocument(string id)`                                                                                         |
+| Get API Keys          | `client.listApiKeys()`                                                              | `client.getKeys()`                                                                                                     |
+| Get API Key Info      | `client.getApiKey(string apiKey)`                                                   | `client.getKey(string apiKey)`                                                                                         |
+| Create API Key        | `client.addApiKey(array acl)`                                                       | `client.createKey(object configuration)`                                                                               |
+| Update API Key        | `client.updateApiKey(string apiKey, object configuration)`                          | `client.updateKey(string apiKey, object configuration)`                                                                |
+| Delete API Key        | `client.deleteApiKey(string apiKey)`                                                | `client.deleteKey(string apiKey)`                                                                                      |
 
 ## Front-end components
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -131,10 +131,10 @@ Replace `MEILI_HOST`,`MEILI_API_KEY`, and `MEILI_INDEX_NAME` with your Meilisear
 
 ### Upload data to Meilisearch
 
-Next, use the Meilisearch [`addDocumentsInBatches`](/learn/core_concepts/documents.md#primary-field) method to upload all your records in batches of 1000 at a time.
+Next, use the Meilisearch JavaScript method [`addDocumentsInBatches`]([/learn/core_concepts/documents.md#primary-field](https://github.com/meilisearch/meilisearch-js#documents-)) to upload all your records in batches of 100,000 at a time.
 
 ```js
-const BATCH_SIZE = 1000;
+const BATCH_SIZE = 100000;
 await meiliIndex.addDocumentsInBatches(records, BATCH_SIZE);
 ```
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -14,9 +14,13 @@ Migrating indexes from Algolia to Meilisearch is a straightforward process:
 2. Upload your data to Meilisearch
 3. (optional) Configure your settings to approximate the settings of your Algolia index
 
-This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. If you would like to write this script in another language, we provide [SDKs for most common languages](/learn/what_is_meilisearch/sdks.md) and [welcome contributions to this guide](https://github.com/meilisearch/documentation/edit/master/learn/getting_started/algolia_migration.md).
+This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal. If you're unsure, see our [quick start](/learn/getting_started/quick_start.md) for instructions on installing Meilisearch.
 
-Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal. If you're unsure, see our [quick start](/learn/getting_started/quick_start.md) for instructions on installing Meilisearch.
+::: note
+
+Older Meilisearch versions (prior to v0.27.0) have limited support for nested objects. If your data set contains nested fields, we strongly recommend installing the [latest version](https://github.com/meilisearch/MeiliSearch/releases) before continuing.
+
+:::
 
 ### Initialize project
 
@@ -79,40 +83,6 @@ await algoliaIndex.browseObjects({
 ```
 
 On each batch of hits, the `batch` callback method is invoked, and the content is concatenated in the `records` array. This variable will be used later on in the upload process.
-
-#### Nested objects
-
-Meilisearch versions prior to v0.27.0 have limited support for nested fields, meaning that **nested objects must be flattened manually**. This can be avoided entirely by using [the latest version of Meilisearch](https://github.com/meilisearch/MeiliSearch/releases). If this is impossible for some reason, try the modified data retrieval process below.
-
-Let's say your document structure looks like this:
-
-```json
-{
-    "objectID": 1,
-    "name": "John",
-    "age": 20,
-    "address": {
-        "country": "Spain"
-    }
-}
-```
-
-To export this data from Algolia and simultaneously flatten it, use the same `browseObjects` method as described above. However, before concatenation, flatten the `address` object into `address.country`, and perform the same operation for other subfields:
-
-```js
-let records = [];
-await algoliaIndex.browseObjects({
- batch: (recordsArr) => {
-        records = recordsArr.reduce((acc, record) => {
-          const { address, ...rest } = record;
-          acc.push({ "address.country": address.country, ...rest });
-          return acc;
-        }, records);
-      }
-});
-```
-
-Adapt this principle to your own dataset by replacing `address` and `address.country` with a parent object and nested field, respectively.
 
 ### Create Meilisearch client
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -2,25 +2,27 @@
 
 This page aims to help current users of Algolia make the transition to Meilisearch.
 
-It includes a guide to exporting Algolia data and indexing it in Meilisearch using [a Node.js script](#finished-script). It also compares Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
+For a high-level comparison of the two search companies and their products, see [our analysis of the search market](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
 
-If you are looking for a high-level comparison of the two search companies and their products, see [our analysis of the search market](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
+## Overview
 
-## Migration script
+This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. The migration process consists of three steps:
 
-Migrating indexes from Algolia to Meilisearch can be done in three steps:
+1. [Export your data stored in Algolia](#export-your-algolia-data)
+2. [Import your data into Meilisearch](#import-your-data-into-meilisearch)
+3. [Configure your index settings (optional)](#configure-your-index-settings)
 
-1. Export your data stored in Algolia
-2. Upload your data to Meilisearch
-3. Configure your index settings (optional)
+To ease the transition, this page also includes a comparison of Meilisearch and Algolia's respective [API methods](#api-methods) and [front-end components](#front-end-components).
 
-This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. Before continuing, make sure you have both Meilisearch and Node.js installed and have access to a command-line terminal. If you're unsure, see our [quick start](/learn/getting_started/quick_start.md) for instructions on installing Meilisearch.
+Before continuing, make sure you have both Meilisearch and Node.js installed and have access to a command-line terminal. If you're unsure how to install Meilisearch, see our [quick start](/learn/getting_started/quick_start.md).
 
 ::: note
 
 Older Meilisearch versions (prior to v0.27.0) have limited support for nested objects. If your data set contains nested fields, we strongly recommend installing the [latest version](https://github.com/meilisearch/MeiliSearch/releases) before continuing.
 
 :::
+
+## Export your Algolia data
 
 ### Initialize project
 
@@ -84,6 +86,8 @@ await algoliaIndex.browseObjects({
 
 The `batch` callback method is invoked on each batch of hits and the content is concatenated in the `records` array. `records` will be used again later in the upload process.
 
+## Import your data into Meilisearch
+
 ### Create Meilisearch client
 
 Create a Meilisearch client by passing the host URL and API key of your Meilisearch instance. The easiest option is to use the automatically generated [admin API key](/learn/security/master_api_keys.md#listing-api-keys).
@@ -101,7 +105,7 @@ Replace `MEILI_HOST`,`MEILI_API_KEY`, and `MEILI_INDEX_NAME` with your Meilisear
 
 ### Upload data to Meilisearch
 
-Next, use the Meilisearch JavaScript method [`addDocumentsInBatches`]([/learn/core_concepts/documents.md#primary-field](https://github.com/meilisearch/meilisearch-js#documents-)) to upload all your records in batches of 100,000 at a time.
+Next, use the Meilisearch JavaScript method [`addDocumentsInBatches`](https://github.com/meilisearch/meilisearch-js#documents-) to upload all your records in batches of 100,000 at a time.
 
 ```js
 const BATCH_SIZE = 100000;
@@ -142,13 +146,23 @@ const BATCH_SIZE = 1000;
 })();
 ```
 
-## Settings and parameters
+## Configure your index settings
 
-One of the key usage differences between Algolia and Meilisearch is how they approach search customization.
+Meilisearch's default settings are designed to deliver a fast and relevant search experience that works for most use-cases.
 
-In Algolia, [API parameters](https://www.algolia.com/doc/api-reference/api-parameters/) are a flexible category that can be used either at indexing time—to set default behavior—or at search time—to override that behavior.
+To customize your index settings, we recommend following [this guide](/learn/configuration/settings.md). To learn more about the differences between settings in Algolia and Meilisearch, read on.
 
-In Meilisearch, these are split into two distinct categories. [Index settings](/learn/configuration/settings.md) affect all searches on an index; [search parameters](/reference/api/search.md#search-parameters) affect only a single search. Some search parameters depend on index settings; for example, the search parameter `sort` can't be used without first configuring the index setting `sortableAttributes`. However, an index setting cannot be given as a parameter at search time, and a parameter cannot override a setting.
+### Index settings vs. search parameters
+
+One of the key usage differences between Algolia and Meilisearch is how they approach index settings and search parameters.
+
+**In Algolia,** [API parameters](https://www.algolia.com/doc/api-reference/api-parameters/) is a flexible category that includes both index settings and search parameters. Many API parameters can be used both at indexing time—to set default behavior—or at search time—to override that behavior.
+
+**In Meilisearch,** [index settings](/learn/configuration/settings.md) and [search parameters](/reference/api/search.md#search-parameters) are two distinct categories. Settings affect all searches on an index, while parameters affect the results of a single search.
+
+Some Meilisearch parameters require index settings to be configured beforehand; for example, to use the search parameter `sort` you must first configure the index setting `sortableAttributes`. However, unlike in Algolia, an index setting can never be used as a parameter and vice versa.
+
+### Settings and parameters comparison
 
 The below table compares Algolia's **API parameters** with the equivalent Meilisearch **setting** or **search parameter**.
 
@@ -182,7 +196,7 @@ The below table compares Algolia's **API parameters** with the equivalent Meilis
 | `sortFacetValuesBy` | Not Supported |
 | `restrictHighlightAndSnippetArrays` | Not Supported |
 
-## APIs
+## API methods
 
 This section compares Algolia and Meilisearch's respective API methods, using JavaScript for reference.
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -60,7 +60,7 @@ npm install -s algoliasearch meilisearch
 
 ### Create Algolia client
 
-You'll need your **Application ID** and **API Key** to start the Algolia client. Both can be found in your [Algolia account](https://www.algolia.com/api-keys).
+You'll need your **Application ID** and **Admin API Key** to start the Algolia client. Both can be found in your [Algolia account](https://www.algolia.com/api-keys).
 
 Paste the below code in `script.js`:
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -174,7 +174,7 @@ The below table compares Algolia's **API parameters** with the equivalent Meilis
 | `synonyms` | `synonyms` |
 | Sorting(using replicas) | `sortableAttributes` (no replicas required) |
 | `removeWordsIfNoResults` | Automatically supported, but not customizable |
-| `disableTypoToleranceOnAttributes` | `typoTolerance.enabled` |
+| `disableTypoToleranceOnAttributes` | `typoTolerance.disableOnAttributes` |
 | `separatorsToIndex` | Not Supported |
 | `disablePrefixOnAttributes` | Not Supported |
 | `relevancyStrictness` | Not Supported |
@@ -213,9 +213,3 @@ This section compares Algolia and Meilisearch's respective API methods, using Ja
 [InstantSearch](https://github.com/algolia/instantsearch.js) is a collection of open-source tools maintained by Algolia and used to generate front-end search UI components.
 
 [Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. Here is [an up-to-date list of components compatible with Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch/#-api-resources).
-
-## Conclusion
-
-You now know how to migrate your data from Algolia to Melisearch and some of the similarities between their respective APIs.
-
-Please don't hesitate to [let us know how you think this guide can be improved](https://github.com/meilisearch/documentation/issues/new), and if you have any questions, we're always available to help [on Slack](https://meilicommunity.slack.com/join/shared_invite/zt-c4rs8tpi-ZId_q3fw~7cqeuzFG4XHaA#/shared-invite/email).

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -4,7 +4,7 @@ If you are a current user of Algolia and are looking for a practical guide to mi
 
 This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. If you would prefer to skip directly to the finished script, [click here](#finished-script).
 
-We also provide a comparison of Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [front-end components](#front-end-components) to help make your transition as seamless as possible.
+After the script, you will find a comparison of Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [front-end components](#front-end-components) to help make your transition as seamless as possible.
 
 ## Migration script
 
@@ -14,7 +14,7 @@ Migrating indexes from Algolia to Meilisearch is a straightforward process:
 2. Upload your data to Meilisearch
 3. (optional) Configure your settings to approximate the settings of your Algolia index
 
-We provide a [Node.js](https://nodejs.org/en/) script for uploading Algolia index data to Meilisearch. This script is not limited to JavaScript developers and has no impact on the programming language that will be used with Meilisearch in the future.
+This guide will use a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. This script is not limited to JavaScript developers and has no impact on the programming language used with Meilisearch in the future.
 
 Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal.
 
@@ -36,11 +36,11 @@ Next, create a `script.js` file:
 touch script.js
 ```
 
-This is where we will add the migration code.
+This file will hold the migration code.
 
 ### Install required packages
 
-To get started, we'll need two different packages. The first is `algoliasearch`, the JavaScript client for the Algolia API, and the second is `meilisearch`, the JavaScript client for the Meilisearch API.
+To get started, you'll need two different packages. The first is `algoliasearch`, the JavaScript client for the Algolia API, and the second is `meilisearch`, the JavaScript client for the Meilisearch API.
 
 ```bash
 npm install algoliasearch meilisearch
@@ -67,7 +67,7 @@ Replace `INDEX_NAME` with the name of the Algolia index you would like to migrat
 
 ### Fetch data from Algolia
 
-To fetch all index data at once we can use Algolia's [`browseObjects`](https://www.algolia.com/doc/api-reference/api-methods/browse/) method.
+To fetch all Algolia index data at once, use Algolia's [`browseObjects`](https://www.algolia.com/doc/api-reference/api-methods/browse/) method.
 
 ```jsx
 let records = [];
@@ -82,7 +82,7 @@ On each batch of hits, the `batch` callback method is invoked, and the content i
 
 #### Nested objects
 
-Meilisearch versions prior to v0.27.0 have limited support for nested fields, meaning that nested objects must be flattened manually. For this reason we recommend using [the latest version of Meilisearch](https://github.com/meilisearch/MeiliSearch/releases). If this is impossible, try the modified data retrieval process below.
+Meilisearch versions prior to v0.27.0 have limited support for nested fields, meaning that **nested objects must be flattened manually**. This can be avoided entirely by using [the latest version of Meilisearch](https://github.com/meilisearch/MeiliSearch/releases). If this is impossible for some reason, try the modified data retrieval process below.
 
 Let's say your document structure looks like this:
 
@@ -97,7 +97,7 @@ Let's say your document structure looks like this:
 }
 ```
 
-To export this data from Algolia and simultaneously flatten it, we will use the same `browseObjects` method as described above. However, before concatenation, we will modify the object to flatten `address` into `address.country`:
+To export this data from Algolia and simultaneously flatten it, use the same `browseObjects` method as described above. However, before concatenation, modify the object to flatten `address` into `address.country`:
 
 ```jsx
 let records = [];
@@ -112,7 +112,7 @@ await algoliaIndex.browseObjects({
 });
 ```
 
-A similar process can be applied to all nested objects.
+Adapt this principle to your own dataset by replacing `address` and `address.country` with a parent object and nested field, respectively.
 
 ### Create Meilisearch client
 
@@ -212,7 +212,7 @@ In Meilisearch, [index settings](/learn/configuration/settings.md) and [search p
 
 ## APIs
 
-This section compares Algolia and Meilisearch's respective API methods. We have used JavaScript for reference.
+This section compares Algolia and Meilisearch's respective API methods, using JavaScript for reference.
 
 | Topic | Algolia | Meilisearch |
 | --- | --- | --- |

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -1,10 +1,10 @@
 # Migrating from Algolia to Meilisearch
 
-If you are a current user of Algolia and are looking for a practical guide to migrate to Meilisearch, you are in the right place. If you would prefer to read a high-level comparison of the two search solutions, you can find that [here](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
+If you are a current user of Algolia and are looking for a practical guide to migrate to Meilisearch, you are in the right place. If you would prefer a high-level comparison of the two search companies and their products, you can find that [here](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
 
-This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. If you would prefer to skip directly to the finished script, [click here](#finished-script).
+This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. To skip directly to the finished script, [click here](#finished-script).
 
-After the script, you will find a comparison of Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [front-end components](#front-end-components) to help make your transition as seamless as possible.
+This guide also includes comparisons of Meilisearch and Algolia's [APIs](#apis), [index settings, parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
 
 ## Migration script
 
@@ -14,9 +14,9 @@ Migrating indexes from Algolia to Meilisearch is a straightforward process:
 2. Upload your data to Meilisearch
 3. (optional) Configure your settings to approximate the settings of your Algolia index
 
-This guide will use a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. This script is not limited to JavaScript developers and has no impact on the programming language used with Meilisearch in the future.
+This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. If you would like to write this script in another language, we provide [SDKs for most common languages](/learn/what_is_meilisearch/sdks.md) and [welcome contributions to this guide](https://github.com/meilisearch/documentation/edit/master/learn/getting_started/algolia_migration.md).
 
-Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal.
+Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal. If you're unsure, see our [quick start](/learn/getting_started/quick_start.md) for instructions on installing Meilisearch.
 
 ### Initialize project
 
@@ -25,10 +25,10 @@ Start by creating a directory `algolia-meilisearch-migration` and initializing i
 ```bash
 mkdir algolia-meilisearch-migration
 cd algolia-meilisearch-migration
-npm init
+npm init -y
 ```
 
-The `npm init` command should walk you through creating a `package.json` file within your project. This file contains details about the project's packages and dependencies, plus some basic metadata. You can press `^C` at any time to exit.
+This will set up the environment we need to install dependencies.
 
 Next, create a `script.js` file:
 
@@ -36,7 +36,7 @@ Next, create a `script.js` file:
 touch script.js
 ```
 
-This file will hold the migration code.
+This file will contain our migration script.
 
 ### Install required packages
 
@@ -52,7 +52,7 @@ You'll need your **Application ID** and **API Key** to start the Algolia client.
 
 Paste the below code in `script.js`:
 
-```jsx
+```js
 const AlgoliaSearch = require("algoliasearch");
 const algoliaClient = AlgoliaSearch(
   "APPLICATION_ID",
@@ -69,7 +69,7 @@ Replace `INDEX_NAME` with the name of the Algolia index you would like to migrat
 
 To fetch all Algolia index data at once, use Algolia's [`browseObjects`](https://www.algolia.com/doc/api-reference/api-methods/browse/) method.
 
-```jsx
+```js
 let records = [];
 await algoliaIndex.browseObjects({
     batch: (hits) => {
@@ -97,9 +97,9 @@ Let's say your document structure looks like this:
 }
 ```
 
-To export this data from Algolia and simultaneously flatten it, use the same `browseObjects` method as described above. However, before concatenation, modify the object to flatten `address` into `address.country`:
+To export this data from Algolia and simultaneously flatten it, use the same `browseObjects` method as described above. However, before concatenation, flatten the `address` object into `address.country`, and perform the same operation for other subfields:
 
-```jsx
+```js
 let records = [];
 await algoliaIndex.browseObjects({
  batch: (recordsArr) => {
@@ -118,7 +118,7 @@ Adapt this principle to your own dataset by replacing `address` and `address.cou
 
 Create a Meilisearch client by passing the host URL and API key of your Meilisearch instance. The easiest option is to use the automatically generated [admin API key](/learn/security/master_api_keys.md#listing-api-keys).
 
-```jsx
+```js
 const { MeiliSearch } = require("meilisearch");
 const meiliClient = new MeiliSearch({
   host: "MEILI_HOST",
@@ -133,7 +133,7 @@ Replace `MEILI_HOST`,`MEILI_API_KEY`, and `MEILI_INDEX_NAME` with your Meilisear
 
 Next, use the Meilisearch [`addDocumentsInBatches`](/learn/core_concepts/documents.md#primary-field) method to upload all your records in batches of 1000 at a time.
 
-```jsx
+```js
 const BATCH_SIZE = 1000;
 await meiliIndex.addDocumentsInBatches(records, BATCH_SIZE);
 ```
@@ -146,7 +146,7 @@ node script.js
 
 ### Finished script
 
-```jsx
+```js
 const AlgoliaSearch = require("algoliasearch");
 const { MeiliSearch } = require("meilisearch");
 const BATCH_SIZE = 1000;
@@ -240,50 +240,7 @@ This section compares Algolia and Meilisearch's respective API methods, using Ja
 
 [InstantSearch](https://github.com/algolia/instantsearch.js) is a collection of open-source tools maintained by Algolia and used to generate front-end search UI components.
 
-[Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin for connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. The compatibilities are detailed in the tables below.
-
-### ✅ Compatible Features
-
-- `instantsearch`
-- `highlight`
-- `snippet`
-- `menu`
-- `searchBox`
-- `middleware`
-- `geoSearch`
-- `currentRefinements`
-- `ratingMenu`
-- `configure`
-- `renderState`
-- `refinementList`
-- `rangeInput`
-- `clearRefinements`
-- `voiceSearch`
-- `hits`
-- `hierarchicalMenu`
-- `menuSelect`
-- `pagination`
-- `insights`
-- `infiniteHits`
-- `rangeSlider`
-- `toggleRefinement`
-- `hitsPerPage`
-- `breadcrumb`
-- `stats`
-- `sortBy`
-- `routing`
-
-### ❌ Incompatible Features
-
-- `index`
-- `autocomplete`
-- `answers`
-- `queryRuleCustomData`
-- `queryRuleContext`
-- `relevantSort`
-- `analytics`
-
-Check out [Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch#readme) for more detailed explanations.
+[Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. Here is [an up-to-date list of components compatible with Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch/#-api-resources).
 
 ## Conclusion
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -1,10 +1,10 @@
 # Migrating from Algolia to Meilisearch
 
-If you are a current user of Algolia and are looking for a practical guide to migrate to Meilisearch, you are in the right place. If you would prefer a high-level comparison of the two search companies and their products, you can find that [here](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
-
 This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. To skip directly to the finished script, [click here](#finished-script).
 
 This guide also includes comparisons of Meilisearch and Algolia's [APIs](#apis), [index settings, parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
+
+This is a practical guide for current Algolia users making the transition to Meilisearch. We also provide [a high-level comparison of the two search companies and their products](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia) elsewhere.
 
 ## Migration script
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -8,7 +8,7 @@ This is a practical guide for current Algolia users making the transition to Mei
 
 ## Migration script
 
-Migrating indexes from Algolia to Meilisearch is a straightforward process:
+Migrating indexes from Algolia to Meilisearch can be done in three steps:
 
 1. Export your data stored in Algolia
 2. Upload your data to Meilisearch
@@ -144,41 +144,43 @@ const BATCH_SIZE = 1000;
 
 ## Settings and parameters
 
-One of the key aspects of making a seamless transition from Algolia to Meilisearch is understanding the index settings and search parameters that are available in both.
+One of the key usage differences between Algolia and Meilisearch is how they approach search customization.
 
-In Algolia, index settings and search parameters fall under one umbrella: [API parameters](https://www.algolia.com/doc/api-reference/api-parameters/). Certain settings can be used both at indexing time to configure the default behavior and again at search time to override that behavior.
+In Algolia, [API parameters](https://www.algolia.com/doc/api-reference/api-parameters/) are a flexible category that can be used either at indexing time—to set default behavior—or at search time—to override that behavior.
 
-In Meilisearch, [index settings](/learn/configuration/settings.md) and [search parameters](/reference/api/search.md#search-parameters) are distinct from one another. Some parameters require index settings to be configured beforehand, but an index setting cannot be given as a parameter at search time, and a parameter cannot override a setting.
+In Meilisearch, these are split into two distinct categories. [Index settings](/learn/configuration/settings.md) affect all searches on an index; [search parameters](/reference/api/search.md#search-parameters) affect only a single search. Some search parameters depend on index settings; for example, the search parameter `sort` can't be used without first configuring the index setting `sortableAttributes`. However, an index setting cannot be given as a parameter at search time, and a parameter cannot override a setting.
+
+The below table compares Algolia's **API parameters** with the equivalent Meilisearch **setting** or **search parameter**.
 
 | Algolia | Meilisearch |
 | --- | --- |
-| query | q |
-| attributesToRetrieve | attributesToRetrieve |
-| filters | filter |
-| facets | facetsDistribution |
-| attributesToHighlight | attributesToHighlight |
-| offset | offset |
-| length | limit |
-| typoTolerance | Coming in Meilisearch v0.27. It will also support Algolia’s  minWordSizefor1Typo and minWordSizefor2Typos options. |
-| snippetEllipsisText | Coming in Meilisearch v0.27 |
-| searchableAttributes | searchableAttributes |
-| attributesForFaceting | filterableAttributes |
-| unretrievableAttributes | No direct equivalent; is achieved by removing attributes from displayedAttributes. |
-| attributesToRetrieve | displayedAttributes |
-| attributeForDistinct | distinctAttribute |
-| ranking | rankingRules |
-| Custom Ranking | Custom Ranking |
-| removeStopWords | stopWords |
-| synonyms | synonyms |
-| Sorting(using replicas) | sortableAttributes(no replicas required)  |
-| removeWordsIfNoResults | Meilisearch automatically supports it. However, it isn't customizable. |
-| disableTypoToleranceOnAttributes | Coming in Meilisearch v0.27 |
-| separatorsToIndex | Not Supported |
-| disablePrefixOnAttributes | Not Supported |
-| relevancyStrictness | Not Supported |
-| maxValuesPerFacet | Not Supported |
-| sortFacetValuesBy | Not Supported |
-| restrictHighlightAndSnippetArrays | Not Supported |
+| `query` | `q` |
+| `attributesToRetrieve` | `attributesToRetrieve` |
+| `filters` | `filter` |
+| `facets` | `facetsDistribution` |
+| `attributesToHighlight` | `attributesToHighlight` |
+| `offset` | `offset` |
+| `length` | `limit` |
+| `typoTolerance` | `typoTolerance` |
+| `snippetEllipsisText` | `cropMarker` |
+| `searchableAttributes` | `searchableAttributes` |
+| `attributesForFaceting` | `filterableAttributes` |
+| `unretrievableAttributes` | No direct equivalent; achieved by removing attributes from displayedAttributes |
+| `attributesToRetrieve` | `displayedAttributes` |
+| `attributeForDistinct` | `distinctAttribute` |
+| `ranking` | `rankingRules` |
+| `customRanking` | Integrated within `rankingRules` |
+| `removeStopWords` | `stopWords` |
+| `synonyms` | `synonyms` |
+| Sorting(using replicas) | `sortableAttributes` (no replicas required) |
+| `removeWordsIfNoResults` | Automatically supported, but not customizable |
+| `disableTypoToleranceOnAttributes` | `typoTolerance.enabled` |
+| `separatorsToIndex` | Not Supported |
+| `disablePrefixOnAttributes` | Not Supported |
+| `relevancyStrictness` | Not Supported |
+| `maxValuesPerFacet` | Not Supported |
+| `sortFacetValuesBy` | Not Supported |
+| `restrictHighlightAndSnippetArrays` | Not Supported |
 
 ## APIs
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -4,7 +4,7 @@ If you are a current user of Algolia and are looking for a practical guide to mi
 
 This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. If you would prefer to skip directly to the finished script, [click here](#finished-script).
 
-We also provide a comparison of Meilisearch and Algolia's [APIs](#apis) and [index settings and parameters](#settings-and-parameters) to help you get Meilisearch set up with similar settings.
+We also provide a comparison of Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [front-end components](#front-end-components) to help you get Meilisearch set up with similar settings.
 
 ## Migration script
 
@@ -235,6 +235,55 @@ This section compares Algolia and Meilisearch's respective API methods. We have 
 | Create API Key | `client.addApiKey(array acl)` | `client.createKey(object configuration)` |
 | Update API Key | `client.updateApiKey(string apiKey, object configuration)` | `client.updateKey(string apiKey, object configuration)` |
 | Delete API Key | `client.deleteApiKey(string apiKey)` | `client.deleteKey(string apiKey)` |
+
+## Front-end components
+
+[InstantSearch](https://github.com/algolia/instantsearch.js) is a collection of open-source tools maintained by Algolia and used to generate front-end search UI components.
+
+[Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin for connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. The compatibilities are detailed in the tables below.
+
+### ✅ Compatible Features
+
+- `instantsearch`
+- `highlight`
+- `snippet`
+- `menu`
+- `searchBox`
+- `middleware`
+- `geoSearch`
+- `currentRefinements`
+- `ratingMenu`
+- `configure`
+- `renderState`
+- `refinementList`
+- `rangeInput`
+- `clearRefinements`
+- `voiceSearch`
+- `hits`
+- `hierarchicalMenu`
+- `menuSelect`
+- `pagination`
+- `insights`
+- `infiniteHits`
+- `rangeSlider`
+- `toggleRefinement`
+- `hitsPerPage`
+- `breadcrumb`
+- `stats`
+- `sortBy`
+- `routing`
+
+### ❌ Incompatible Features
+
+- `index`
+- `autocomplete`
+- `answers`
+- `queryRuleCustomData`
+- `queryRuleContext`
+- `relevantSort`
+- `analytics`
+
+Check out [Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch#readme) for more detailed explanations.
 
 ## Conclusion
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -1,0 +1,256 @@
+# Migrating from Algolia to Meilisearch
+
+If you are a current user of Algolia and are looking for a practical guide to migrate to Meilisearch, you are in the right place. If you would prefer to read a qualitative comparison of the two search solutions, you can find that [here](insert link later).
+
+This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. If you would prefer to skip directly to the finished script, [click here](#finished-script).
+
+We also provide a comparison of Meilisearch and Algolia's [APIs](#apis) and [index settings and parameters](#settings-and-parameters) to help you get Meilisearch set up with similar settings.
+
+## Migration script
+
+Migrating indexes from Algolia to Meilisearch is a straightforward process:
+
+1. Export your data stored in Algolia
+2. Upload your data to Meilisearch
+3. (optional) Configure your settings to approximate the settings of your Algolia index
+
+We provide a [Node.js](https://nodejs.org/en/) script for uploading Algolia index data to Meilisearch. This script is not limited to JavaScript developers and has no impact on the programming language that will be used with Meilisearch in the future.
+
+Before continuing, make sure you have both Meilisearch and Node.js installed, and access to a command-line terminal.
+
+### Initialize project
+
+Start by creating a directory `algolia-meilisearch-migration` and initializing it as an npm package:
+
+```bash
+mkdir algolia-meilisearch-migration
+cd algolia-meilisearch-migration
+npm init
+```
+
+The `npm init` command should walk you through creating a `package.json` file within your project. This file contains details about the project's packages and dependencies, plus some basic metadata. You can press `^C` at any time to exit.
+
+Next, create a `script.js` file:
+
+```bash
+touch script.js
+```
+
+This is where we will add the migration code.
+
+### Install required packages
+
+To get started, we'll need two different packages. The first is `algoliasearch`, the JavaScript client for the Algolia API, and the second is `meilisearch`, the JavaScript client for the Meilisearch API.
+
+```bash
+npm install algoliasearch meilisearch
+```
+
+### Create Algolia client
+
+You'll need your **Application ID** and **API Key** to start the Algolia client. Both can be found in your [Algolia account](https://www.algolia.com/api-keys).
+
+Paste the below code in `script.js`:
+
+```jsx
+const AlgoliaSearch = require("algoliasearch");
+const algoliaClient = AlgoliaSearch(
+  "APPLICATION_ID",
+  "ADMIN_API_KEY"
+);
+const algoliaIndex = algoliaClient.initIndex("INDEX_NAME");
+```
+
+Replace `APPLICATION_ID` and `ADMIN_API_KEY`with your Algolia application ID and admin API key respectively.
+
+Replace `INDEX_NAME` with the name of the Algolia index you would like to migrate to Meilisearch.
+
+### Fetch data from Algolia
+
+To fetch all index data at once we can use Algolia's [`browseObjects`](https://www.algolia.com/doc/api-reference/api-methods/browse/) method.
+
+```jsx
+let records = [];
+await algoliaIndex.browseObjects({
+ batch: (recordsArr) => {
+        records = recordsArr.reduce((acc, record) => {
+          const { address, ...rest } = record;
+          acc.push({ "address.country": address.country, ...rest });
+          return acc;
+        }, records);
+      }
+});
+```
+
+On each batch of hits, the `batch` callback method is invoked, and the content is concatenated in the `records` array. This variable will be used later on in the upload process.
+
+#### Nested objects
+
+Meilisearch versions prior to v0.27.0 have limited support for nested fields, meaning that nested objects must be flattened manually.
+
+The easiest option is to use the [most recent version of Meilisearch](https://github.com/meilisearch/meilisearch/releases), which handles flattening internally. If this is impossible for whatever reason, we recommend following a slightly modified process:
+
+Suppose your document structure has a single nested object, `address`:
+
+```json
+{
+    "objectID": 1,
+    "name": "John",
+    "age": 20,
+    "address": {
+        "country": "Spain"
+    }
+}
+```
+
+To export this data from Algolia and simultaneously flatten it, we will use the same `browseObjects` method as described above. However, before concatenation, we will modify the object to flatten `address` into `address.country`.
+
+```jsx
+let records = [];
+await algoliaIndex.browseObjects({
+ batch: (recordsArr) => {
+        records = recordsArr.reduce((acc, record) => {
+          const { address, ...rest } = record;
+          acc.push({ "address.country": address.country, ...rest });
+          return acc;
+        }, records);
+      }
+});
+```
+
+A similar process can be applied to all nested objects.
+
+### Create Meilisearch client
+
+Create a Meilisearch client by passing the host URL and API key of your Meilisearch instance. The easiest option is to use the automatically generated [admin API key](/learn/security/master_api_keys.md#listing-api-keys).
+
+```jsx
+const { MeiliSearch } = require("meilisearch");
+const meiliClient = new MeiliSearch({
+  host: "MEILI_HOST",
+  apiKey: "MEILI_API_KEY",
+});
+const meiliIndex = meiliClient.index("MEILI_INDEX_NAME");
+```
+
+Replace `MEILI_HOST`,`MEILI_API_KEY`, and `MEILI_INDEX_NAME` with your Meilisearch host URL, Meilisearch API key, and the index name where you would like documents to be added. Meilisearch will create the index if it doesn't already exist.
+
+### Upload data to Meilisearch
+
+Next, use the Meilisearch [`addDocumentsInBatches`](/learn/core_concepts/documents.md#primary-field) method to upload all your records in batches of 1000 at a time.
+
+```jsx
+const BATCH_SIZE = 1000;
+await meiliIndex.addDocumentsInBatches(records, BATCH_SIZE);
+```
+
+That's all! When you're ready to run the script, enter the below command:
+
+```bash
+node script.js
+```
+
+### Finished script
+
+```jsx
+const AlgoliaSearch = require("algoliasearch");
+const { MeiliSearch } = require("meilisearch");
+const BATCH_SIZE = 1000;
+
+(async () => {
+  const algoliaClient = AlgoliaSearch("APPLICATION_ID", "ADMIN_API_KEY");
+  const algoliaIndex = algoliaClient.initIndex("INDEX_NAME");
+
+  let records = [];
+  await algoliaIndex.browseObjects({
+    batch: (recordsArr) => {
+      records = recordsArr.reduce((acc, record) => {
+        const { address, ...rest } = record;
+        acc.push({ "address.country": address.country, ...rest });
+        return acc;
+      }, records);
+    },
+  });
+  const meiliClient = new MeiliSearch({
+    host: "MEILI_HOST",
+    apiKey: "MEILI_API_KEY",
+  });
+  const meiliIndex = meiliClient.index("MEILI_INDEX_NAME");
+  meiliIndex.updateSettings({
+    searchableAttributes: ["name", "address.country"],
+    displayedAttributes: ["name", "age"],
+  });
+
+  await meiliIndex.addDocumentsInBatches(records, BATCH_SIZE);
+})();
+```
+
+## Settings and parameters
+
+One of the key aspects of making a seamless transition from Algolia to Meilisearch is understanding the index settings and search parameters that are available in both.
+
+In Algolia, index settings and search parameters fall under one umbrella: [API parameters](https://www.algolia.com/doc/api-reference/api-parameters/). Certain settings can be used both at indexing time to configure the default behavior and again at search time to override that behavior.
+
+In Meilisearch, [index settings](/learn/configuration/settings.md) and [search parameters](/reference/api/search.md#search-parameters) are distinct from one another. Some parameters require index settings to be configured beforehand, but an index setting cannot be given as a parameter at search time, and a parameter cannot override a setting.
+
+| Algolia | Meilisearch |
+| --- | --- |
+| query | q |
+| attributesToRetrieve | attributesToRetrieve |
+| filters | filter |
+| facets | facetsDistribution |
+| attributesToHighlight | attributesToHighlight |
+| offset | offset |
+| length | limit |
+| typoTolerance | Coming in Meilisearch v0.27. It will also support Algolia’s  minWordSizefor1Typo and minWordSizefor2Typos options. |
+| snippetEllipsisText | Coming in Meilisearch v0.27 |
+| searchableAttributes | searchableAttributes |
+| attributesForFaceting | filterableAttributes |
+| unretrievableAttributes | No direct equivalent; is achieved by removing attributes from displayedAttributes. |
+| attributesToRetrieve | displayedAttributes |
+| attributeForDistinct | distinctAttribute |
+| ranking | rankingRules |
+| Custom Ranking | Custom Ranking |
+| removeStopWords | stopWords |
+| synonyms | synonyms |
+| Sorting(using replicas) | sortableAttributes(no replicas required)  |
+| removeWordsIfNoResults | Meilisearch automatically supports it. However, it isn't customizable. |
+| disableTypoToleranceOnAttributes | Coming in Meilisearch v0.27 |
+| separatorsToIndex | Not Supported |
+| disablePrefixOnAttributes | Not Supported |
+| relevancyStrictness | Not Supported |
+| maxValuesPerFacet | Not Supported |
+| sortFacetValuesBy | Not Supported |
+| restrictHighlightAndSnippetArrays | Not Supported |
+
+## APIs
+
+This section compares Algolia and Meilisearch's respective API methods. We have used JavaScript for reference.
+
+| Topic | Algolia | Meilisearch |
+| --- | --- | --- |
+| Index Instantiation | `client.initIndex()`<br>Here, client is an Algolia instance. | `client.index()`<br>Here, client is a Meilisearch instance. |
+| Create Index | Users don’t need to create an index explicitly, the engine does it for you the first time you add an object or set settings. | The same applies for Meilisearch but users can also create an index explicitly using: `client.createIndex(string indexName)` |
+| Get All Indexes | `client.listIndices()` | `client.getIndexes()` |
+| Get Single Index | No method available | `client.getIndex(string indexName)` |
+| Delete Index | `index.delete()` | `client.deleteIndex(string indexName)` |
+| Get Index Settings | `index.getSettings()` | `index().getSettings()` |
+| Update Index Settings | `index.setSettings(object settings)` | `index().updateSettings(object settings)` |
+| Search Method | `index.search(string query, { searchParameters, requestOptions })` | `index.search(string query, object searchParameters)` |
+| Add Object | `index.saveObjects(array objects)` | `index.addDocuments(array objects)` |
+| Partial Update Object | `index.partialUpdateObjects(array objects)` | `index.updateDocuments(array objects)` |
+| Delete All Objects | `index.deleteObjects(array objectIDs)` | `index.deleteAllDocuments()` |
+| Delete One Object | `index.deleteObject(string objectID)` | `index.deleteDocument(string id)` |
+| Get All Objects | `index.getObjects(array objectIDs)` | `index.getDocuments(object params)` |
+| Get Single Object | `index.getObject(str objectID)` | `index.getDocument(string id)` |
+| Get API Keys | `client.listApiKeys()` | `client.getKeys()` |
+| Get API Key Info | `client.getApiKey(string apiKey)` | `client.getKey(string apiKey)` |
+| Create API Key | `client.addApiKey(array acl)` | `client.createKey(object configuration)` |
+| Update API Key | `client.updateApiKey(string apiKey, object configuration)` | `client.updateKey(string apiKey, object configuration)` |
+| Delete API Key | `client.deleteApiKey(string apiKey)` | `client.deleteKey(string apiKey)` |
+
+## Conclusion
+
+You now know how to migrate your data from Algolia to Melisearch and some of the similarities between their respective APIs.
+
+Please don't hesitate to [let us know how you think this guide can be improved](https://github.com/meilisearch/documentation/issues/new), and if you have any questions, we're always available to help [on Slack](https://meilicommunity.slack.com/join/shared_invite/zt-c4rs8tpi-ZId_q3fw~7cqeuzFG4XHaA#/shared-invite/email).

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -61,7 +61,7 @@ const algoliaClient = AlgoliaSearch(
 const algoliaIndex = algoliaClient.initIndex("INDEX_NAME");
 ```
 
-Replace `APPLICATION_ID` and `ADMIN_API_KEY`with your Algolia application ID and admin API key respectively.
+Replace `APPLICATION_ID` and `ADMIN_API_KEY` with your Algolia application ID and admin API key respectively.
 
 Replace `INDEX_NAME` with the name of the Algolia index you would like to migrate to Meilisearch.
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -1,10 +1,10 @@
 # Migrating from Algolia to Meilisearch
 
-If you are a current user of Algolia and are looking for a practical guide to migrate to Meilisearch, you are in the right place. If you would prefer to read a high-level comparison of the two search solutions, you can find that [here](insert link later).
+If you are a current user of Algolia and are looking for a practical guide to migrate to Meilisearch, you are in the right place. If you would prefer to read a high-level comparison of the two search solutions, you can find that [here](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
 
 This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. If you would prefer to skip directly to the finished script, [click here](#finished-script).
 
-We also provide a comparison of Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [front-end components](#front-end-components) to help you get Meilisearch set up with similar settings.
+We also provide a comparison of Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [front-end components](#front-end-components) to help make your transition as seamless as possible.
 
 ## Migration script
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -6,19 +6,25 @@ For a high-level comparison of the two search companies and their products, see 
 
 ## Overview
 
-This guide uses a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. The migration process consists of three steps:
+This guide will take you step-by-step through the creation of a [Node.js](https://nodejs.org/en/) script to upload Algolia index data to Meilisearch. [You can also skip directly to the finished script](#finished-script).
+
+The migration process consists of three steps:
 
 1. [Export your data stored in Algolia](#export-your-algolia-data)
 2. [Import your data into Meilisearch](#import-your-data-into-meilisearch)
-3. [Configure your index settings (optional)](#configure-your-index-settings)
+3. [Configure your Meilisearch index settings (optional)](#configure-your-index-settings)
 
-To ease the transition, this page also includes a comparison of Meilisearch and Algolia's respective [API methods](#api-methods) and [front-end components](#front-end-components).
+To help with the transition, we have also included a comparison of Meilisearch and Algolia's [API methods](#api-methods) and [front-end components](#front-end-components).
 
 Before continuing, make sure you have both Meilisearch and Node.js installed and have access to a command-line terminal. If you're unsure how to install Meilisearch, see our [quick start](/learn/getting_started/quick_start.md).
 
 ::: note
 
-Older Meilisearch versions (prior to v0.27.0) have limited support for nested objects. If your data set contains nested fields, we strongly recommend installing the [latest version](https://github.com/meilisearch/MeiliSearch/releases) before continuing.
+This guide was tested with the following package versions:
+
+`Node`: `16.14`
+`algoliasearch`: `4.13`
+`meilisearch`: `0.27`
 
 :::
 
@@ -26,7 +32,7 @@ Older Meilisearch versions (prior to v0.27.0) have limited support for nested ob
 
 ### Initialize project
 
-Start by creating a directory `algolia-meilisearch-migration` and initializing it as an npm package:
+Start by creating a directory `algolia-meilisearch-migration` and generating a `package.json` file with `npm`:
 
 ```bash
 mkdir algolia-meilisearch-migration
@@ -44,12 +50,12 @@ touch script.js
 
 This file will contain our migration script.
 
-### Install required packages
+### Install dependencies
 
 To get started, you'll need two different packages. The first is `algoliasearch`, the JavaScript client for the Algolia API, and the second is `meilisearch`, the JavaScript client for the Meilisearch API.
 
 ```bash
-npm install algoliasearch meilisearch
+npm install -s algoliasearch meilisearch
 ```
 
 ### Create Algolia client
@@ -59,8 +65,8 @@ You'll need your **Application ID** and **API Key** to start the Algolia client.
 Paste the below code in `script.js`:
 
 ```js
-const AlgoliaSearch = require("algoliasearch");
-const algoliaClient = AlgoliaSearch(
+const algoliaSearch = require("algoliasearch");
+const algoliaClient = algoliaSearch(
   "APPLICATION_ID",
   "ADMIN_API_KEY"
 );
@@ -79,12 +85,12 @@ To fetch all Algolia index data at once, use Algolia's [`browseObjects`](https:/
 let records = [];
 await algoliaIndex.browseObjects({
     batch: (hits) => {
-      records=records.concat(hits)
+      records = records.concat(hits);
     }
   });
 ```
 
-The `batch` callback method is invoked on each batch of hits and the content is concatenated in the `records` array. `records` will be used again later in the upload process.
+The `batch` callback method is invoked on each batch of hits and the content is concatenated in the `records` array. We will use `records` again later in the upload process.
 
 ## Import your data into Meilisearch
 
@@ -101,11 +107,11 @@ const meiliClient = new MeiliSearch({
 const meiliIndex = meiliClient.index("MEILI_INDEX_NAME");
 ```
 
-Replace `MEILI_HOST`,`MEILI_API_KEY`, and `MEILI_INDEX_NAME` with your Meilisearch host URL, Meilisearch API key, and the index name where you would like documents to be added. Meilisearch will create the index if it doesn't already exist.
+Replace `MEILI_HOST`,`MEILI_API_KEY`, and `MEILI_INDEX_NAME` with your Meilisearch host URL, Meilisearch API key, and the index name where you would like to add documents. Meilisearch will create the index if it doesn't already exist.
 
 ### Upload data to Meilisearch
 
-Next, use the Meilisearch JavaScript method [`addDocumentsInBatches`](https://github.com/meilisearch/meilisearch-js#documents-) to upload all your records in batches of 100,000 at a time.
+Next, use the Meilisearch JavaScript method [`addDocumentsInBatches`](https://github.com/meilisearch/meilisearch-js#documents-) to upload all your records in batches of 100,000.
 
 ```js
 const BATCH_SIZE = 100000;
@@ -121,18 +127,18 @@ node script.js
 ### Finished script
 
 ```js
-const AlgoliaSearch = require("algoliasearch");
+const algoliaSearch = require("algoliasearch");
 const { MeiliSearch } = require("meilisearch");
 const BATCH_SIZE = 1000;
 
 (async () => {
-  const algoliaClient = AlgoliaSearch("APPLICATION_ID", "ADMIN_API_KEY");
+  const algoliaClient = algoliaSearch("APPLICATION_ID", "ADMIN_API_KEY");
   const algoliaIndex = algoliaClient.initIndex("INDEX_NAME");
 
   let records = [];
   await algoliaIndex.browseObjects({
     batch: (hits) => {
-      records = records.concat(hits)
+      records = records.concat(hits);
     }
   });
 
@@ -224,6 +230,6 @@ This section compares Algolia and Meilisearch's respective API methods, using Ja
 
 ## Front-end components
 
-[InstantSearch](https://github.com/algolia/instantsearch.js) is a collection of open-source tools maintained by Algolia and used to generate front-end search UI components.
+[InstantSearch](https://github.com/algolia/instantsearch.js) is a collection of open-source tools maintained by Algolia and used to generate front-end search UI components. To use InstantSearch with Meilisearch, you must use [Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch).
 
-[Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch) is a plugin connecting your Meilisearch instance with InstantSearch, giving you access to many (but not all) of the same front-end components as Algolia users. You can find an up-to-date list of [the components supported by Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch/#-api-resources) in its GitHub repository.
+Instant Meilisearch is a plugin connecting your Meilisearch instance with InstantSearch, giving you access to many of the same front-end components as Algolia users. You can find an up-to-date list of [the components supported by Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch/#-api-resources) in the GitHub project's README.

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -1,10 +1,10 @@
 # Migrating from Algolia to Meilisearch
 
-This guide will walk you through exporting your Algolia data and indexing it in Meilisearch using a Node.js script. To skip directly to the finished script, [click here](#finished-script).
+This guide aims to help current users of Algolia make the transition to Meilisearch.
 
-This guide also includes comparisons of Meilisearch and Algolia's [APIs](#apis), [index settings, parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
+It covers the process of exporting Algolia data and indexing it in Meilisearch using [a Node.js script](#finished-script). It also compares Meilisearch and Algolia's [APIs](#apis), [index settings and parameters](#settings-and-parameters), and [support for the `instantsearch.js` library](#front-end-components).
 
-This is a practical guide for current Algolia users making the transition to Meilisearch. We also provide [a high-level comparison of the two search companies and their products](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia) elsewhere.
+If you are looking for a high-level comparison of the two search companies and their products, see [our analysis of the search market](/learn/what_is_meilisearch/comparison_to_alternatives.md#meilisearch-vs-algolia).
 
 ## Migration script
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -165,6 +165,8 @@ Meilisearch was inspired by Algolia's product and the algorithms behind it. We i
 
 Meilisearch provides similar features and reaches the same level of relevance just as quickly as its predecessor.
 
+If you are a current Algolia user considering a switch to Meilisearch, you may be interested in our [migration guide](/learn/getting_started/algolia_migration.md).
+
 #### Key similarities
 
 Some of the most significant similarities between Algolia and Meilisearch are listed below:
@@ -178,16 +180,16 @@ Some of the most significant similarities between Algolia and Meilisearch are li
 
 #### Key differences
 
-Contrary to Algolia, Meilisearch is open-source and written in Rust, a systems-level and modern programming language, that allows to rapidly build features. Rust also enables portability and flexibility, which makes the deployment of our search engines inside Virtual Machines, containers, or even Lambda@Edge, a seamless operation.
+Contrary to Algolia, Meilisearch is open-source and written in Rust, a modern systems-level programming language. Rust provides speed, portability, and flexibility, which makes the deployment of our search engine inside Virtual Machines, containers, or even Lambda@Edge a seamless operation.
 
 One of Algolia's major assets is the robust worldwide infrastructure that they offer to their customers.
-Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet. However, we aim it to be much more simple to deploy and maintain than Algolia's.
+Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet, but we hope one day to offer a highly available cloud solution that is simpler to deploy and maintain than Algolia's.
 
 #### Pricing
 
-The [pricing model for Algolia](https://www.algolia.com/pricing/) is based on the number of records kept and the number of API operations performed. It is prohibitively expensive for small and medium-sized businesses. Meilisearch, on the other hand, is **open-source** and can be **self-hosted**.
+The [pricing model for Algolia](https://www.algolia.com/pricing/) is based on the number of records kept and the number of API operations performed. It can be prohibitively expensive for small and medium-sized businesses.
 
-Meilisearch also offers a cloud-hosted option. Like with other cloud providers, pricing follows a set hourly rate based on the computing resources chosen. Unlike Algolia, there are no per-record or per-search fees. You can send your cluster as much traffic or data as it can manage. See [Meilisearch Cloud pricing](https://www.meilisearch.com/pricing).
+Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: Meilisearch Cloud. Unlike Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing) follows a set hourly rate based on the computing resources chosen, with no per-record or per-search fees. You can send your cluster as much traffic or data as it can manage.
 
 ## A quick look at the search engine landscape
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -182,7 +182,7 @@ Some of the most significant similarities between Algolia and Meilisearch are:
 
 Contrary to Algolia, Meilisearch is open-source and written in Rust, a modern systems-level programming language. Rust provides speed, portability, and flexibility, which makes the deployment of our search engine inside virtual machines, containers, or even [Lambda@Edge](https://aws.amazon.com/lambda/edge/) a seamless operation.
 
-One of Algolia's major assets is the robust worldwide infrastructure that they offer to their customers. Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet, but we hope one day to offer a highly available cloud solution that is simpler to deploy and maintain than Algolia's.
+One of Algolia's major assets is the robust worldwide infrastructure that they offer to their customers. Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet. However, it is our goal to one day offer a highly available cloud solution that is simpler to deploy and maintain than Algolia's.
 
 #### Pricing
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -171,7 +171,7 @@ If you are a current Algolia user considering a switch to Meilisearch, you may b
 
 Some of the most significant similarities between Algolia and Meilisearch are:
 
-- [Features](https://docs.meilisearch.com/learn/what_is_meilisearch/overview.html#features) such as search-as-you-type, typo tolerance, faceting, etc.
+- [Features](/learn/what_is_meilisearch/overview.md#features) such as search-as-you-type, typo tolerance, faceting, etc.
 - Fast results targeting an instant search experience (answers < 50 milliseconds)
 - Schemaless indexation
 - Support for all JSON data types

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -6,13 +6,11 @@ sidebarDepth: 2
 
 # Comparison to alternatives
 
-## About Meilisearch
-
 There are many search engines on the web, both open-source and otherwise. Deciding which search solution is the best fit for your project is very important, but also difficult. In this article, we'll go over the differences between Meilisearch and other search engines:
 
 - In the [comparison table](#comparison-table), we present a general overview of the differences between Meilisearch and other search engines
 
-- In the [approach comparison](#approach-comparison), instead, we focus on how Meilisearch measures against [ElasticSearch](#meilisearch-vs-elasticsearch) and [Algolia](#meilisearch-vs-algolia), currently two of the biggest solutions available in the market
+- In the [approach comparison](#approach-comparison), instead, we focus on how Meilisearch measures up against [ElasticSearch](#meilisearch-vs-elasticsearch) and [Algolia](#meilisearch-vs-algolia), currently two of the biggest solutions available in the market
 
 - Finally, we end this article with [an in-depth analysis of the broader search engine landscape](#a-quick-look-at-the-search-engine-landscape)
 
@@ -164,12 +162,32 @@ Meilisearch is a perfect choice if you need a simple and easy tool to deploy a t
 ### Meilisearch vs Algolia
 
 Meilisearch was inspired by Algolia's product and the algorithms behind it. We indeed studied most of the algorithms and data structures described in their blog posts in order to implement our own. Meilisearch is thus a new search engine based on the work of Algolia and recent research papers.
-It provides similar features and reaches the same level of relevance just as quickly as its predecessor.
+
+Meilisearch provides similar features and reaches the same level of relevance just as quickly as its predecessor.
+
+#### Key similarities
+
+Some of the most significant similarities between Algolia and Meilisearch are listed below:
+
+- [Features](https://docs.meilisearch.com/learn/what_is_meilisearch/overview.html#features) such as search-as-you-type, typo tolerance, faceting, etc.
+- Fast results targeting an instant search experience (answers < 50 milliseconds)
+- Objects you index are schemaless
+- Support all JSON data types
+- Operate asynchronously
+- Provide a similar query response
+
+#### Key differences
 
 Contrary to Algolia, Meilisearch is open-source and written in Rust, a systems-level and modern programming language, that allows to rapidly build features. Rust also enables portability and flexibility, which makes the deployment of our search engines inside Virtual Machines, containers, or even Lambda@Edge, a seamless operation.
 
 One of Algolia's major assets is the robust worldwide infrastructure that they offer to their customers.
 Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet. However, we aim it to be much more simple to deploy and maintain than Algolia's.
+
+#### Pricing
+
+The [pricing model for Algolia](https://www.algolia.com/pricing/) is based on the number of records kept and the number of API operations performed. It is prohibitively expensive for small and medium-sized businesses. Meilisearch, on the other hand, is **open-source** and can be **self-hosted**.
+
+Meilisearch also offers a cloud-hosted option. Like with other cloud providers, pricing follows a set hourly rate based on the computing resources chosen. Unlike Algolia, there are no per-record or per-search fees. You can send your cluster as much traffic or data as it can manage. See [Meilisearch Cloud pricing](https://www.meilisearch.com/pricing).
 
 ## A quick look at the search engine landscape
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -163,33 +163,32 @@ Meilisearch is a perfect choice if you need a simple and easy tool to deploy a t
 
 Meilisearch was inspired by Algolia's product and the algorithms behind it. We indeed studied most of the algorithms and data structures described in their blog posts in order to implement our own. Meilisearch is thus a new search engine based on the work of Algolia and recent research papers.
 
-Meilisearch provides similar features and reaches the same level of relevance just as quickly as its predecessor.
+Meilisearch provides similar features and reaches the same level of relevance just as quickly as its competitor.
 
 If you are a current Algolia user considering a switch to Meilisearch, you may be interested in our [migration guide](/learn/getting_started/algolia_migration.md).
 
 #### Key similarities
 
-Some of the most significant similarities between Algolia and Meilisearch are listed below:
+Some of the most significant similarities between Algolia and Meilisearch are:
 
 - [Features](https://docs.meilisearch.com/learn/what_is_meilisearch/overview.html#features) such as search-as-you-type, typo tolerance, faceting, etc.
 - Fast results targeting an instant search experience (answers < 50 milliseconds)
-- Objects you index are schemaless
-- Support all JSON data types
-- Operate asynchronously
-- Provide a similar query response
+- Schemaless indexation
+- Support for all JSON data types
+- Asynchronous API
+- Similar query response
 
 #### Key differences
 
-Contrary to Algolia, Meilisearch is open-source and written in Rust, a modern systems-level programming language. Rust provides speed, portability, and flexibility, which makes the deployment of our search engine inside Virtual Machines, containers, or even Lambda@Edge a seamless operation.
+Contrary to Algolia, Meilisearch is open-source and written in Rust, a modern systems-level programming language. Rust provides speed, portability, and flexibility, which makes the deployment of our search engine inside virtual machines, containers, or even [Lambda@Edge](https://aws.amazon.com/lambda/edge/) a seamless operation.
 
-One of Algolia's major assets is the robust worldwide infrastructure that they offer to their customers.
-Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet, but we hope one day to offer a highly available cloud solution that is simpler to deploy and maintain than Algolia's.
+One of Algolia's major assets is the robust worldwide infrastructure that they offer to their customers. Meilisearch currently delivers a search engine and is not in a position to provide a competitive infrastructure yet, but we hope one day to offer a highly available cloud solution that is simpler to deploy and maintain than Algolia's.
 
 #### Pricing
 
 The [pricing model for Algolia](https://www.algolia.com/pricing/) is based on the number of records kept and the number of API operations performed. It can be prohibitively expensive for small and medium-sized businesses.
 
-Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: Meilisearch Cloud. Unlike Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing) follows a set hourly rate based on the computing resources chosen, with no per-record or per-search fees. You can send your cluster as much traffic or data as it can manage.
+Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: [Meilisearch Cloud](https://cloud.meilisearch.com/login). Unlike Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing) follows a set hourly rate based on the computing resources chosen, with no per-record or per-search fees. You can send your server as much traffic or data as it can manage.
 
 ## A quick look at the search engine landscape
 


### PR DESCRIPTION
@shivaylamba wrote an Algolia migration guide which I am now adapting for the docs.

Part 1: practical migration guide in Getting Started
- Migration script
- API comparison
- Settings + parameters comparison
- InstantSearch.js

To do:
- [x] Adjust code samples for v0.27 (no need to flatten nested fields) 
- [x] Add InstantSearch.js comparison table
- [x] Update link to product comparison

Part 2: product comparison in Comparison to Alternatives
- Feature parity
- Pricing

To do:
- [x] Add content to Comparison to Alternatives
- [x] Create link to migration guide
- [x] Smooth out content (no baseless, vague, or highly subjective claims)