### PR TITLE
update primary key sample names

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -754,7 +754,7 @@ primary_field_guide_add_document_primary_key: |-
         "genres": ["comedy","humor"],
         "price": 5.00
      }]'
-primary_field_guide_update_primary_key: |
+primary_field_guide_update_document_primary_key: |
   curl \
     -X PUT 'http://localhost:7700/indexes/books' \
     -H 'Content-Type: application/json' \

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -121,7 +121,7 @@ security_guide_delete_key_1: |-
 security_guide_search_key_1: |-
 primary_field_guide_create_index_primary_key: |-
 primary_field_guide_add_document_primary_key: |-
-primary_field_guide_update_primary_key: |-
+primary_field_guide_update_document_primary_key: |-
 authentication_header_1: |-
 tenant_token_guide_search_no_sdk_1: |-
 tenant_token_guide_generate_sdk_1: |-


### PR DESCRIPTION
The [Changing your primary key with the update index endpoint](https://docs.meilisearch.com/learn/core_concepts/primary_key.html#changing-your-primary-key-with-the-update-index-endpoint) code sample is not displaying because of different code sample ids
Rename  `primary_field_guide_update_primary_key` to `primary_field_guide_update_document_primary_key`