### PR TITLE
Run CIs / fix scraper 404

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -138,11 +138,11 @@ To learn more about the Windows command prompt, follow this [introductory guide]
 To deploy Meilisearch on a cloud service, follow one of our dedicated guides:
 
 - [AWS](/learn/cookbooks/aws.md)
+- [Azure](/learn/cookbooks/azure.md)
 - [DigitalOcean](/learn/cookbooks/digitalocean_droplet.md)
+- [GCP](/learn/cookbooks/gcp.md)
 - [Koyeb](/learn/cookbooks/koyeb.md)
 - [Qovery](/learn/cookbooks/qovery.md)
-- [GCP](/learn/cookbooks/gcp.md)
-- [Azure](/learn/cookbooks/azure.md)
 
 ### Running Meilisearch
 


### PR DESCRIPTION
This PR re-orders the cloud deploy options in the quick start, but its actual purpose is to re-trigger our build-deploy process and scraper.

The docs Meilisearch instance is currently returning a result belonging to a deleted page. This results in a 404 when the user clicks on it. To resolve this I first tried re-running the scraper, with no success. However this could be due to a problem w/ that specific branch, so I'm retrying with a fresh deploy.