### PR TITLE
Update docs scraper to v0.12.2

### DIFF
--- a/.github/workflows/gh-pages-scraping.yml
+++ b/.github/workflows/gh-pages-scraping.yml
@@ -42,4 +42,4 @@ jobs:
             -e MEILISEARCH_HOST_URL=$HOST_URL \
             -e MEILISEARCH_API_KEY=$API_KEY \
             -v $CONFIG_FILE_PATH:/docs-scraper/config.json \
-            getmeili/docs-scraper:v0.12.1 pipenv run ./docs_scraper config.json
+            getmeili/docs-scraper:v0.12.2 pipenv run ./docs_scraper config.json


### PR DESCRIPTION
Should fix scraping bug, but may cause problems since this version targets v0.27, and the docs instance is v0.26. Time will tell but it's worth a try!