### PR TITLE
Apply the direct tag instead of latest alias

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -51,13 +51,13 @@ These commands launch the **latest stable release** of Meilisearch.
 
 ```bash
 # Fetch the latest version of Meilisearch image from DockerHub
-docker pull getmeili/meilisearch:latest
+docker pull getmeili/meilisearch:v0.27.1
 
 # Launch Meilisearch
 docker run -it --rm \
     -p 7700:7700 \
     -v $(pwd)/meili_data:/meili_data \
-    getmeili/meilisearch:latest
+    getmeili/meilisearch:v0.27.1
 ```
 
 Data written to a **Docker container is not persistent** and is wiped every time the container is stopped. We recommend using a shared Docker volume between containers and host machines to provide persistent storage.


### PR DESCRIPTION
I found one good practice about [docker here #6](https://developers.redhat.com/blog/2016/02/24/10-things-to-avoid-in-docker-containers) that mentions the usage of the latest tag. They don’t recommend it because it could be misleading and may not represent the actual state of the image throughout the days.

Since this could avoid some misleading problems for the users, the idea is to update the docs with the correct tag every time.