### PR TITLE
update authorization headers for updating.md

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -861,15 +861,24 @@ updating_guide_check_version: |-
   curl \
     -X GET 'http://127.0.0.1:7700/version' \
     -H 'Authorization: Bearer apiKey'
-updating_guide_get_displayed_attributes: |-
+updating_guide_get_displayed_attributes_new: |-
   # whenever you see {index_uid}, replace it with your index's unique id
   curl \
     -X GET 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
     -H 'Authorization: Bearer apiKey'
-updating_guide_reset_displayed_attributes: |-
+updating_guide_get_displayed_attributes_old: |-
+  # whenever you see {index_uid}, replace it with your index's unique id
+  curl \
+    -X GET 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
+    -H 'X-Meili-API-Key: apiKey'    
+updating_guide_reset_displayed_attributes_new: |-
   curl \
     -X DELETE 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
     -H 'Authorization: Bearer apiKey'
+updating_guide_reset_displayed_attributes_old: |-
+  curl \
+    -X DELETE 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
+    -H 'X-Meili-API-Key: apiKey'  
 updating_guide_create_dump: |-
   curl \
     -X POST 'http://127.0.0.1:7700/dumps' \

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -138,8 +138,10 @@ typo_tolerance_guide_3: |-
 typo_tolerance_guide_4: |-
 settings_guide_typo_tolerance_1: |-
 updating_guide_check_version: |-
-updating_guide_get_displayed_attributes: |-
-updating_guide_reset_displayed_attributes: |-
+updating_guide_get_displayed_attributes_new: |-
+updating_guide_get_displayed_attributes_old: |-
+updating_guide_reset_displayed_attributes_old: |-
+updating_guide_reset_displayed_attributes_new: |-
 updating_guide_create_dump: |-
 updating_guide_get_dump_status: |-
 updating_guide_get_settings: |-

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -125,13 +125,13 @@ When creating dumps, Meilisearch calls the same method as the [get documents end
 
 Start by using the [get displayed attributes endpoint](/reference/api/displayed_attributes.md#get-displayed-attributes) to verify that **all attributes are displayed**.
 
-<CodeSamples id="updating_guide_get_displayed_attributes" />
+<CodeSamples id="updating_guide_get_displayed_attributes_new" />
 
 If the response is `{'displayedAttributes': '["*"]'}`, you can move on to the [next step](#step-2-create-the-dump).
 
 If it's something else, then you need to use the [reset displayed attributes endpoint](/reference/api/displayed_attributes.md#reset-displayed-attributes). Before doing this, make sure you save your list of displayed attributes somewhere so you can restore it afterwards.
 
-<CodeSamples id="updating_guide_reset_displayed_attributes" />
+<CodeSamples id="updating_guide_reset_displayed_attributes_new" />
 
 This command returns a `uid`. You can use this to [track the status of the operation](/reference/api/tasks.md#get-task). Once the status is `succeeded`, you're good to go.
 
@@ -281,13 +281,13 @@ To prevent data loss, all fields must be set as [displayed](/learn/configuration
 
 By default, all fields are added to the displayed attributes list. Still, it's a good idea to verify this before proceeding to the next step. You can do so by using the [get displayed attributes endpoint](/reference/api/displayed_attributes.md#get-displayed-attributes):
 
-<CodeSamples id="updating_guide_get_displayed_attributes" />
+<CodeSamples id="updating_guide_get_displayed_attributes_old" />
 
 If the response is `'["*"]'`, you can move on to the [next step](#step-3-save-your-documents).
 
 If it's something else, then you need to use the [reset displayed-attributes endpoint](/reference/api/displayed_attributes.md#reset-displayed-attributes). Before doing this, make sure you save your list of displayed attributes somewhere so you can restore it afterwards.
 
-<CodeSamples id="updating_guide_reset_displayed_attributes" />
+<CodeSamples id="updating_guide_reset_displayed_attributes_old" />
 
 This command should return a [summarized task object](/learn/advanced/asynchronous_operations.md#summarized-task-objects) with `type` as `indexUpdate`.
 


### PR DESCRIPTION
[Step 2](https://docs.meilisearch.com/learn/advanced/updating.html#step-2-set-all-fields-as-displayed-attributes) of `/learn/advanced/updating.md` uses the wrong authorization header, it should be `  -H 'X-Meili-API-Key: apiKey'` instead of `  -H 'Authorization: Bearer apiKey'`  