### PR TITLE
Add version of meilisearch-js in algolia migration guide

### DIFF
--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -24,6 +24,7 @@ This guide was tested with the following package versions:
 
 `Node`: `16.14`
 `algoliasearch`: `4.13`
+`meilisearch-js`: `0.25.1`
 `meilisearch`: `0.27`
 
 :::

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -22,10 +22,10 @@ Before continuing, make sure you have both Meilisearch and Node.js installed and
 
 This guide was tested with the following package versions:
 
-`Node`: `16.14`
-`algoliasearch`: `4.13`
-`meilisearch-js`: `0.25.1`
-`meilisearch`: `0.27`
+[`node.js`](https://nodejs.org/en/): `16.14`
+[`algoliasearch`](https://www.npmjs.com/package/algoliasearch): `4.13`
+[`meilisearch-js`](https://www.npmjs.com/package/meilisearch): `0.25.1`
+[`meilisearch`](https://github.com/meilisearch/meilisearch): `0.27`
 
 :::
 

--- a/learn/getting_started/algolia_migration.md
+++ b/learn/getting_started/algolia_migration.md
@@ -56,7 +56,7 @@ This file will contain our migration script.
 To get started, you'll need two different packages. The first is `algoliasearch`, the JavaScript client for the Algolia API, and the second is `meilisearch`, the JavaScript client for the Meilisearch API.
 
 ```bash
-npm install -s algoliasearch meilisearch
+npm install -s algoliasearch@4.13 meilisearch@0.25.1
 ```
 
 ### Create Algolia client
@@ -67,6 +67,7 @@ Paste the below code in `script.js`:
 
 ```js
 const algoliaSearch = require("algoliasearch");
+
 const algoliaClient = algoliaSearch(
   "APPLICATION_ID",
   "ADMIN_API_KEY"
@@ -101,6 +102,7 @@ Create a Meilisearch client by passing the host URL and API key of your Meilisea
 
 ```js
 const { MeiliSearch } = require("meilisearch");
+
 const meiliClient = new MeiliSearch({
   host: "MEILI_HOST",
   apiKey: "MEILI_API_KEY",
@@ -130,6 +132,7 @@ node script.js
 ```js
 const algoliaSearch = require("algoliasearch");
 const { MeiliSearch } = require("meilisearch");
+
 const BATCH_SIZE = 1000;
 
 (async () => {


### PR DESCRIPTION
The version of `meilisearch-js` is missing and impacts the code present in the guide a lot. 

To ensure the user install the correct version of the script I have added that specific version to the npm install command.

I also added some new lines where required (sorry for the out of subject action)