### PR TITLE
Fix duplicate scrapping of some nested pages

### DIFF
--- a/.vuepress/config-path-checker/README.md
+++ b/.vuepress/config-path-checker/README.md
@@ -1,0 +1,26 @@
+# Config path checker
+
+This local plugin checks inside the routing of `config.js` every chosen predicate.
+
+These are the current predicates:
+
+### Parent's paths must contains a trailing html extension
+
+This predicate only applies to elements that do have childs.
+
+For example:
+
+```js
+  {
+    title: 'Settings',
+    path: '/reference/api/settings.html', // Must contain an html extension
+    collapsable: false,
+    children: [
+      {
+        title: 'All Settings',
+        path: '/reference/api/settings', // Should not contain an html extension
+      },
+      '/reference/api/displayed_attributes',
+    ],
+  }
+```

--- a/.vuepress/config-path-checker/find-and-check.js
+++ b/.vuepress/config-path-checker/find-and-check.js
@@ -5,7 +5,7 @@ const path = require('path')
 // Check if the path validates the predicates
 function checkPathValidity(parentPath, elem) {
   // Check for a trailing html extension
-  if (parentPath.slice(-1) !== '.html') {
+  if (parentPath.slice(-5) !== '.html') {
     const origin = (elem && elem.title) ? `section ${elem.title}` : 'config.json'
     addError.call(this, {
       type: 'error',

--- a/.vuepress/config-path-checker/find-and-check.js
+++ b/.vuepress/config-path-checker/find-and-check.js
@@ -2,40 +2,45 @@ const { isObject } = require('./utils')
 const { addError } = require('./result-report')
 const path = require('path')
 
-function checkPath(givenPath, elem) {
-  if (givenPath.slice(-1) !== '/') {
+// Check if the path validates the predicates
+function checkPathValidity(parentPath, elem) {
+  // Check for a trailing html extension
+  if (parentPath.slice(-1) !== '.html') {
     const origin = (elem && elem.title) ? `section ${elem.title}` : 'config.json'
     addError.call(this, {
       type: 'error',
-      errMsg: `In ${origin} the path is missing a trailing slash`,
+      errMsg: `In ${origin} the path is missing the trailing html extension`,
       fileUrl: path.join(process.cwd(), '/.vuepress/config.js'),
-      fullText: `path: '${givenPath}'`,
-      path: givenPath,
+      fullText: `path: '${parentPath}'`,
+      path: parentPath,
     })
   }
 }
 
-function searchForPath(element) {
+function findParentPath(element) {
+  // If the element is not an object it cannot contain a `path` key
   if (isObject(element)) {
+    // Will only check the path of the current element if it has childs.
     if (element.path && element.children) {
-      checkPath.call(this, element.path, element)
+      checkPathValidity.call(this, element.path, element)
     }
     if (element.children) {
-      SearchForChilds.call(this, element.children)
+      findChilds.call(this, element.children)
     }
   }
 }
 
-function SearchForChilds(element) {
+// Crawl inside elements to find childs
+function findChilds(element) {
   if (Array.isArray(element)) {
-    element.map((child) => searchForPath.call(this, child))
+    element.map((child) => findParentPath.call(this, child))
   } else if (isObject(element)) {
-    searchForPath.call(this, element)
+    findParentPath.call(this, element)
   }
 }
 
 module.exports = {
-  checkPath,
-  searchForPath,
-  SearchForChilds,
+  checkPathValidity,
+  findParentPath,
+  findChilds,
 }

--- a/.vuepress/config-path-checker/index.js
+++ b/.vuepress/config-path-checker/index.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const path = require('path')
 const { displayReport, createReportResult } = require('./result-report')
 const { isObject } = require('./utils')
-const { checkPath, SearchForChilds } = require('./find-and-check')
+const { checkPathValidity, findChilds } = require('./find-and-check')
 
 const defaultOptions = {
   exitLevel: 'warn',
@@ -24,7 +24,7 @@ module.exports = (opt = {}) => {
     }),
     error: createReportResult({
       msgFn(r) {
-        return `${r.list.length} missing trailing slash`
+        return `${r.list.length} missing trailing html extension`
       },
       type: 'error',
     }),
@@ -36,16 +36,16 @@ module.exports = (opt = {}) => {
       cli
         .command(
           'check-config-paths',
-          'Checks for trailing slash in vuepress paths'
+          'Checks for trailing html extension in vuepress paths with childs'
         )
         .action(() => {
           const sidebar = config.themeConfig.sidebar
           // Output information to distinguish with check-md
-          log('Checking for missing trailing slashes...')
+          log('Checking for missing trailing html extensions in parent\'s path...')
           if (isObject(sidebar)) {
             Object.keys(sidebar).map((key) => {
-              checkPath.call(result, key)
-              SearchForChilds.call(result, sidebar[key])
+              checkPathValidity.call(result, key)
+              findChilds.call(result, sidebar[key])
             })
           }
           displayReport(result, options)

--- a/.vuepress/config-path-checker/index.js
+++ b/.vuepress/config-path-checker/index.js
@@ -2,7 +2,7 @@ const chalk = require('chalk')
 const path = require('path')
 const { displayReport, createReportResult } = require('./result-report')
 const { isObject } = require('./utils')
-const { checkPathValidity, findChilds } = require('./find-and-check')
+const { findChilds } = require('./find-and-check')
 
 const defaultOptions = {
   exitLevel: 'warn',
@@ -44,7 +44,6 @@ module.exports = (opt = {}) => {
           log('Checking for missing trailing html extensions in parent\'s path...')
           if (isObject(sidebar)) {
             Object.keys(sidebar).map((key) => {
-              checkPathValidity.call(result, key)
               findChilds.call(result, sidebar[key])
             })
           }

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -360,6 +360,7 @@ module.exports = {
     // Change are done in .vuepress/styles/palette.styl
     'vuepress-plugin-element-tabs',
     ['vuepress-plugin-container', { type: 'note' }],
+    [require('./config-path-checker')],
     [require('./custom-markdown-rules')],
     [require('./code-samples')],
     [

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -143,7 +143,7 @@ module.exports = {
             {
               title: 'Index settings',
               collapsable: false,
-              path: '/learn/configuration/settings/',
+              path: '/learn/configuration/settings',
               children: [
                 {
                   title: 'Overview',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -80,7 +80,7 @@ module.exports = {
       '/learn/': [
         {
           title: '🔎 What is Meilisearch?',
-          path: '/learn/what_is_meilisearch/overview/',
+          path: '/learn/what_is_meilisearch/overview.html',
           collapsable: false,
           sidebarDepth: 0,
           children: [
@@ -100,13 +100,13 @@ module.exports = {
         },
         {
           title: '🚀 Getting started',
-          path: '/learn/getting_started/quick_start/',
+          path: '/learn/getting_started/quick_start.html',
           collapsable: false,
           children: [
             '/learn/getting_started/quick_start',
             {
               title: 'Meilisearch 101',
-              path: '/learn/getting_started/filtering_and_sorting/',
+              path: '/learn/getting_started/filtering_and_sorting.html',
               collapsable: false,
               children: [
                 '/learn/getting_started/filtering_and_sorting',
@@ -122,7 +122,7 @@ module.exports = {
         },
         {
           title: '💡 Core concepts',
-          path: '/learn/core_concepts/documents/',
+          path: '/learn/core_concepts/documents.html',
           collapsable: false,
           children: [
             '/learn/core_concepts/documents',
@@ -134,7 +134,7 @@ module.exports = {
         {
           title: '⚙️ Configuration',
           collapsable: false,
-          path: '/learn/configuration/instance_options/',
+          path: '/learn/configuration/instance_options.html',
           children: [
             {
               title: 'Configure Meilisearch at launch',
@@ -160,7 +160,7 @@ module.exports = {
         {
           title: '🔐 Security and permissions',
           collapsable: false,
-          path: '/learn/security/master_api_keys/',
+          path: '/learn/security/master_api_keys.html',
           children: [
             '/learn/security/master_api_keys',
             '/learn/security/tenant_tokens',
@@ -168,7 +168,7 @@ module.exports = {
         },
         {
           title: '📚 Advanced topics',
-          path: '/learn/advanced/asynchronous_operations/',
+          path: '/learn/advanced/asynchronous_operations.html',
           collapsable: false,
           children: [
             '/learn/advanced/asynchronous_operations',
@@ -177,7 +177,7 @@ module.exports = {
             '/learn/advanced/sorting',
             {
               title: 'Updating Meilisearch',
-              path: '/learn/advanced/updating.md',
+              path: '/learn/advanced/updating',
             },
             {
               title: 'Data backup',
@@ -214,7 +214,7 @@ module.exports = {
         },
         {
           title: '📕 Cookbooks',
-          path: '/learn/cookbooks/running_production/',
+          path: '/learn/cookbooks/running_production.html',
           collapsable: false,
           children: [
             {
@@ -269,7 +269,7 @@ module.exports = {
         {
           title: '🧪 Experimental',
           collapsable: false,
-          path: '/learn/experimental/overview/',
+          path: '/learn/experimental/overview.html',
           children: [
             {
               title: 'Overview',
@@ -283,7 +283,7 @@ module.exports = {
         },
         {
           title: '👐 Contributing',
-          path: '/learn/contributing/overview/',
+          path: '/learn/contributing/overview.html',
           collapsable: false,
           children: [
             {
@@ -300,7 +300,7 @@ module.exports = {
       '/reference/': [
         {
           title: '📒 API reference',
-          path: '/reference/api/overview/',
+          path: '/reference/api/overview.html',
           collapsable: false,
           children: [
             {
@@ -314,7 +314,7 @@ module.exports = {
             '/reference/api/keys',
             {
               title: 'Settings',
-              path: '/reference/api/settings/',
+              path: '/reference/api/settings.html',
               collapsable: false,
               children: [
                 {
@@ -360,7 +360,6 @@ module.exports = {
     // Change are done in .vuepress/styles/palette.styl
     'vuepress-plugin-element-tabs',
     ['vuepress-plugin-container', { type: 'note' }],
-    [require('./config-path-checker')],
     [require('./custom-markdown-rules')],
     [require('./code-samples')],
     [

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -143,7 +143,6 @@ module.exports = {
             {
               title: 'Index settings',
               collapsable: false,
-              path: '/learn/configuration/settings',
               children: [
                 {
                   title: 'Overview',

--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -143,6 +143,7 @@ module.exports = {
             {
               title: 'Index settings',
               collapsable: false,
+              path: '/learn/configuration/settings.html',
               children: [
                 {
                   title: 'Overview',

--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -111,7 +111,7 @@
 /create/how_to/aws.html                             /learn/cookbooks/aws.html
 /create/how_to/gcp.html                             /learn/cookbooks/gcp.html
 /create/how_to/qovery.html                          /learn/cookbooks/qovery.html
-/create/how_to/digitalocean_droplet.html            /learn/cookbooks/digitalocean_droplet.html
+/create/how_to/digitalocean_droplet.html            /learn/cookbooks/digitalocean_droplet.html      
 /create/how_to/http2_ssl.html                       /learn/cookbooks/http2_ssl.html
 /create/how_to/running_production.html              /learn/cookbooks/running_production.html
 /create/how_to/search_bar_for_docs.html             /learn/cookbooks/search_bar_for_docs.html
@@ -180,6 +180,3 @@
 
 # remove typo tolerance
 /learn/advanced/typotolerance.html                  /learn/configuration/typo_tolerance.html
-
-
-/reference/api/settings                             /reference/api/settings.html

--- a/.vuepress/public/_redirects
+++ b/.vuepress/public/_redirects
@@ -111,7 +111,7 @@
 /create/how_to/aws.html                             /learn/cookbooks/aws.html
 /create/how_to/gcp.html                             /learn/cookbooks/gcp.html
 /create/how_to/qovery.html                          /learn/cookbooks/qovery.html
-/create/how_to/digitalocean_droplet.html            /learn/cookbooks/digitalocean_droplet.html      
+/create/how_to/digitalocean_droplet.html            /learn/cookbooks/digitalocean_droplet.html
 /create/how_to/http2_ssl.html                       /learn/cookbooks/http2_ssl.html
 /create/how_to/running_production.html              /learn/cookbooks/running_production.html
 /create/how_to/search_bar_for_docs.html             /learn/cookbooks/search_bar_for_docs.html
@@ -180,3 +180,6 @@
 
 # remove typo tolerance
 /learn/advanced/typotolerance.html                  /learn/configuration/typo_tolerance.html
+
+
+/reference/api/settings                             /reference/api/settings.html


### PR DESCRIPTION
## Issue

For some reason, since, we think, the introduction of this [PR](https://github.com/meilisearch/documentation/commit/09dedf36f14a4a019bacfce3029b577f4c637526) some pages were scraped two times by docs-scraper.

These pages have a pattern, these are always the parent of a sub menu with some child's on which it points: 

Example: 
https://github.com/meilisearch/documentation/blob/6687a450c5c3c46cf357bbf502854cd8c329423f/.vuepress/config.js#L143-L157

In these case, `/learn/configuration/settings.html` and `/learn/configuration/settings/` were considered as two different url's by the scraper and thus scraped two times (but not on every run..).

Resulting in situation like this one: 
<img width="543" alt="Screenshot 2022-05-25 at 18 07 07" src="https://user-images.githubusercontent.com/33010418/170320459-6703b180-0e2b-4037-8c12-afea4532a1a5.png">

## Problem solving

**docs-scraper**
Because this behaviour is **flaky** we thought we might find a solution inside [docs-scraper](https://github.com/meilisearch/docs-scraper/) which is the tool used to scrap the documentation.
Unfortunately, this is harder than expected as we are not able to reproduce the problem locally and when trying remote it is flaky so we need to wait a long time for every test.

**Updating the routing**

The working solution is to add the `html` extension to the path of a child:

Example: 
```js
              title: 'Index settings',
              collapsable: false,
              path: '/learn/configuration/settings.html', // Added the extension
              children: [
                {
                  title: 'Overview',
                  path: '/learn/configuration/settings',
                },
            //....
```

By updating the parent path to the exact link (with HTML extension) to its child, we avoid using a link like this one: `/learn/configuration/settings/` that is considered different than the one with the extension by the scrapper.
This may not be the best solution but it is one. 

In the past I created a plugin called `config-path-checker` that checked for trailing slashes in parents paths. 
This checker has been updated to check for trailing `html` extension in parents paths. 
