### PR TITLE
remove typos

### DIFF
--- a/index.md
+++ b/index.md
@@ -18,7 +18,7 @@ Welcome to the Meilisearch documentation. Here you'll find everything you need t
 
 ## Version compatibility
 
-This documentation only reflects the latest version of Meilisearch. As long as we are pre-`v1.0`, **we do not provide multi-version documentation** and **[databases are not compatible between versions](/learn/advanced/updating.md).**
+This documentation only reflects the latest version of Meilisearch. As long as we are pre-v1.0, **we do not provide multi-version documentation** and **[databases are not compatible between versions](/learn/advanced/updating.md).**
 
 The current version of [Meilisearch](https://github.com/meilisearch/meilisearch) can be found in the top-left of this site.
 

--- a/learn/advanced/known_limitations.md
+++ b/learn/advanced/known_limitations.md
@@ -32,7 +32,7 @@ If your query is `Hello, World`:
 - `World` takes the position `9` of the attribute
 
 ::: note
-`,` takes 8 positions as it is a hard separator. You can read more about word separators in our [article about datatypes](/learn/advanced/datatypes.md#string).
+`,` takes 8 positions as it is a hard separator. You can read more about word separators in our [article about data types](/learn/advanced/datatypes.md#string).
 :::
 
 If your query is `Hello - World`:
@@ -42,7 +42,7 @@ If your query is `Hello - World`:
 - `World` takes the position `2` of the attribute
 
 ::: note
-`-` takes 1 position as it is a soft separator. You can read more about word separators in our [article about datatypes](/learn/advanced/datatypes.md#string).
+`-` takes 1 position as it is a soft separator. You can read more about word separators in our [article about data types](/learn/advanced/datatypes.md#string).
 :::
 
 ## Maximum number of attributes per document
@@ -61,7 +61,7 @@ If your query is `Hello - World`:
 
 **Limitation:** Individual `filterableAttributes` values are limited to 500 bytes.
 
-**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a datatype whose size is limited to approximately 500 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 500 bytes.
+**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to approximately 500 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 500 bytes.
 
 ## Maximum filter depth
 

--- a/learn/advanced/snapshots.md
+++ b/learn/advanced/snapshots.md
@@ -34,7 +34,7 @@ After running the above code, a snapshot is created every hour (3600 seconds).
 
 During snapshot creation, old snapshots are **automatically overwritten**. This means that only the most recent snapshot should be present in the folder at any given time.
 
-[[More about snapshots flags and env variables]](/learn/configuration/instance_options.md#schedule-snapshot-creation)
+[[More about snapshots flags and environment variables]](/learn/configuration/instance_options.md#schedule-snapshot-creation)
 
 ## Starting from a snapshot
 
@@ -62,7 +62,7 @@ If you do not want Meilisearch to throw an error when there is no snapshot at th
 When starting from a snapshot, chances are that you already have an existing database. **For security reasons, a database is never overwritten**. To load a snapshot when an existing database is present, you will have to manually delete the existing database. By default, this is the contents of the `data.ms` folder (unless you [changed the path](/learn/configuration/instance_options.md#database-path)) which is located in the same folder as your Meilisearch binary.
 The simplest way to delete your database is with the terminal command `rm -rf data.ms`, after which you should be able to start Meilisearch with a snapshot.
 
-[[More about snapshots flags and env variables]](/learn/configuration/instance_options.md#schedule-snapshot-creation)
+[[More about snapshots flags and environment variables]](/learn/configuration/instance_options.md#schedule-snapshot-creation)
 
 ## Use cases
 

--- a/learn/advanced/storage.md
+++ b/learn/advanced/storage.md
@@ -26,7 +26,7 @@ For the best performance, it is recommended to provide the same amount of RAM as
 
 ### Understanding LMDB
 
-The choice of LMDB comes with certain pros and cons. In order to understand this choice, its upsides and downsides, we need to have an insight on how LMDB impact size and memory usage. This is well explained in [a blogpost of LMDB](https://web.archive.org/web/20210412154001/https://symas.com/understanding-lmdb-database-file-sizes-and-memory-utilization/) and we are trying to summarize it here.
+The choice of LMDB comes with certain pros and cons. In order to understand this choice, its upsides and downsides, we need to have an insight on how LMDB impact size and memory usage. This is well explained in [a blog post of LMDB](https://web.archive.org/web/20210412154001/https://symas.com/understanding-lmdb-database-file-sizes-and-memory-utilization/) and we are trying to summarize it here.
 
 #### Database size
 

--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -119,7 +119,7 @@ Deactivates Meilisearch's built-in telemetry when provided.
 
 Meilisearch automatically collects data from all instances that do not opt out using this flag. All gathered data is used solely for the purpose of improving Meilisearch, and can be [deleted at any time](/learn/what_is_meilisearch/telemetry.md#how-to-delete-all-collected-data).
 
-[Read more about our policy on data collection](/learn/what_is_meilisearch/telemetry.md), or take a look at [the comprehensive list of all datapoints we collect](/learn/what_is_meilisearch/telemetry.md#exhaustive-list-of-all-collected-data).
+[Read more about our policy on data collection](/learn/what_is_meilisearch/telemetry.md), or take a look at [the comprehensive list of all data points we collect](/learn/what_is_meilisearch/telemetry.md#exhaustive-list-of-all-collected-data).
 
 ### Dumps destination
 

--- a/learn/cookbooks/aws.md
+++ b/learn/cookbooks/aws.md
@@ -21,7 +21,7 @@ In the top-right corner, click on the **Launch instances** button to start the p
 
 ### 2. Select 'Meilisearch' AMI from 'Community AMIs'
 
-You will now select which AMI or system Image to use to run your instance. Type **"meilisearch"** in the searchbar and select the **Community AMIs** tab on the left sidebar.
+You will now select which AMI or system Image to use to run your instance. Type **"meilisearch"** in the search bar and select the **Community AMIs** tab on the left sidebar.
 
 ![Page titled: 'Step 1: Choose an Amazon Machine Image (AMI)'. There is only one AMI available, MeiliSearch-v0.19.0-Debian-10.3](/aws/02.select-ami.png)
 
@@ -77,7 +77,7 @@ For your Meilisearch instance to communicate with the outside world, it is very 
 
 ![Page titled 'Step 6: Configure Security group'. Warning: Rules with sources of 0.0.0.0/0 allow all IP addresses to access your instance. We recommend setting security group rules to allow access from known IP addresses only.](/aws/07.security.png)
 
-By default, opened ports accept inbound traffic from any origin. If you prefer to restrict the IP adresses that are allowed to request your MeiliSearch instance, go to the **Source** column and select the **Custom** option. The **Source** is set to **Anywhere** by default.
+By default, opened ports accept inbound traffic from any origin. If you prefer to restrict the IP addresses that are allowed to request your Meilisearch instance, go to the **Source** column and select the **Custom** option. The **Source** is set to **Anywhere** by default.
 
 You can also **use an existing security group**, if preferred.
 
@@ -101,7 +101,7 @@ Your instance may take a minute or two to get up and running (see the **Instance
 
 ![AWS dashboard showing an active instance](/aws/09.launch.png)
 
-Once the **Instance state** is **Running**, use your web browser to navigate to the **Public IPv4 address** or the **Public IPv4 DNS** displayed in your AWS instances dashboard. You should see the MeiliSearch [search preview](/learn/what_is_meilisearch/search_preview.md).
+Once the **Instance state** is **Running**, use your web browser to navigate to the **Public IPv4 address** or the **Public IPv4 DNS** displayed in your AWS instances dashboard. You should see the Meilisearch [search preview](/learn/what_is_meilisearch/search_preview.md).
 
 ![Meilisearch search preview allowing users to search an example dataset](/aws/10.enjoy.png)
 

--- a/learn/cookbooks/digitalocean_droplet.md
+++ b/learn/cookbooks/digitalocean_droplet.md
@@ -29,7 +29,7 @@ Select your plan. Plans start at $5 (click on "See all plans" for more options).
 
 Select the region where you want to deploy your droplet. Remember, the closer you are to your users or customers, the better will be their search experience with Meilisearch.
 
-![Selecting the London datacenter region](/digitalocean/04.select-region.png)
+![Selecting the London data center region](/digitalocean/04.select-region.png)
 
 ### 5. Add your ssh key
 
@@ -49,7 +49,7 @@ Here you can select the name that will be visible everywhere in your DigitalOcea
 
 Tags are a very good method to know who created resources, and for organizing resources or projects. Tags can contain letters, numbers, colons, dashes, and underscores. Try to always add some tags to make clear what are the server purposes.
 
-![The searchbar, meilisearch, and search-team tags](/digitalocean/06.add-tags.png)
+![The search bar, meilisearch, and search-team tags](/digitalocean/06.add-tags.png)
 
 ### 7. Finally click on 'Create Droplet'
 

--- a/learn/cookbooks/running_production.md
+++ b/learn/cookbooks/running_production.md
@@ -31,7 +31,7 @@ For this tutorial, we will be using a Debian 10 server, running on DigitalOcean.
 ## Prerequisites
 
 + An up-to-date server that runs Debian 10
-+ An ssh keypair to connect to that machine
++ An ssh key pair to connect to that machine
 
 ::: tip
 Learn how to connect via SSH to your [DigitalOcean droplet](https://www.digitalocean.com/docs/droplets/how-to/connect-with-ssh/) or any [Linux or windows server](https://phoenixnap.com/kb/ssh-to-connect-to-remote-server-linux-or-windows)

--- a/learn/cookbooks/search_bar_for_docs.md
+++ b/learn/cookbooks/search_bar_for_docs.md
@@ -2,7 +2,7 @@
 
 You might have noticed the search bar in this documentation.
 
-![MeiliSearch docs search bar updating results for 'faq'](/tuto-searchbar-for-docs/vuepress-searchbar-demo.gif)
+![Meilisearch docs search bar updating results for 'faq'](/tuto-searchbar-for-docs/vuepress-searchbar-demo.gif)
 
 And you are probably wanting the same for your own documentation!
 

--- a/learn/experimental/overview.md
+++ b/learn/experimental/overview.md
@@ -4,7 +4,7 @@
 
 Meilisearch maintains a high standard for new features. The process of adding a new feature to our search engine typically begins with a specification, centers around copious unit testing, and ends with the feature's release, barring some minor iteration in subsequent versions.
 
-This is not necessarily the case for experimental features. **Experimental features are features that may not have been tested to our usual standards, and which may be reworked or removed entirely in future versions.** They come with an increased risk of bugs and unforseen behavior, but some users may find the extra functionality to be worth the risk.
+This is not necessarily the case for experimental features. **Experimental features are features that may not have been tested to our usual standards, and which may be reworked or removed entirely in future versions.** They come with an increased risk of bugs and unforeseen behavior, but some users may find the extra functionality to be worth the risk.
 
 ## Giving feedback
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -39,7 +39,7 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 | SDK      | Meilisearch | Algolia | Typesense | Elasticsearch |
 |---|:---:|:----:|:---:|:---:|
 | REST API | ✅ | ✅ | ✅ | ✅ |
-| [Javascript client](https://github.com/meilisearch/meilisearch-js) |  ✅        |   ✅    |     ✅    |       ✅      |
+| [JavaScript client](https://github.com/meilisearch/meilisearch-js) |  ✅        |   ✅    |     ✅    |       ✅      |
 | [PHP client](https://github.com/meilisearch/meilisearch-php)                  |  ✅         |   ✅     |     ✅      |        ✅       |
 | [Python client](https://github.com/meilisearch/meilisearch-python)              | ✅          | ✅      |        ✅   |       ✅        |
 | [Ruby client](https://github.com/meilisearch/meilisearch-ruby)              | ✅          | ✅      |        ✅   |       ✅        |

--- a/learn/what_is_meilisearch/telemetry.md
+++ b/learn/what_is_meilisearch/telemetry.md
@@ -97,7 +97,7 @@ To do so, send an email to [privacy@meilisearch.com](mailto:privacy@meilisearch.
 Whenever an event is triggered that collects some piece of data, Meilisearch does not send it immediately. Instead, it bundles it with other data in a batch of up to `500kb`. Batches are sent either every hour, or after reaching `500kb`—whichever occurs first. This is done in order to improve performance and reduce network traffic.
 
 ::: tip Be advised!
-This list is liable to change with every new version of Meilisearch. It's not because we're trying to be sneaky! It's because when we add new features we need to collect additional datapoints to see how they perform.
+This list is liable to change with every new version of Meilisearch. It's not because we're trying to be sneaky! It's because when we add new features we need to collect additional data points to see how they perform.
 :::
 
 | Metric name                                        | Description                                                                                 | Example
@@ -132,7 +132,7 @@ This list is liable to change with every new version of Meilisearch. It's not be
 | `system.cores`                                     | Number of cores                                                                             | 24
 | `system.ram_size`                                  | Total RAM capacity. Expressed in `KB`                                                       | 16777216
 | `system.disk_size`                                 | Total capacity of the largest disk. Expressed in `Bytes`                                    | 1048576000
-| `system.server_provider`                           | Users can tell us on which provider Meilisearch is hosted by filling the `MEILI_SERVER_PROVIDER` env var. This is also filled by our cloud deploy scripts, e.g. [GCP cloud-config.yaml](https://github.com/meilisearch/cloud-scripts/blob/56a7c2630c1a508e5ad0c0ba1d8cfeb8d2fa9ae0/scripts/providers/gcp/cloud-config.yaml#L33) | gcp
+| `system.server_provider`                           | Users can tell us on which provider Meilisearch is hosted by filling the `MEILI_SERVER_PROVIDER` environment var. This is also filled by our cloud deploy scripts, e.g. [GCP cloud-config.yaml](https://github.com/meilisearch/cloud-scripts/blob/56a7c2630c1a508e5ad0c0ba1d8cfeb8d2fa9ae0/scripts/providers/gcp/cloud-config.yaml#L33) | gcp
 | `stats.database_size`                              | Database size. Expressed in `Bytes`                                                         | 2621440
 | `stats.indexes_number`                             | Number of indexes                                                                           | 2
 | `start_since_days`                                 | Number of days since instance was launched                                                  | 365


### PR DESCRIPTION
This PR removes any typos from the docs so we don't get a lot of warnings/errors when we merge the [Vale PR](https://github.com/meilisearch/documentation/pull/1646)