### PR TITLE
sound less condescending

### DIFF
--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -106,7 +106,7 @@ Now that you know which Meilisearch version your database is compatible with, pr
 
 ## Updating from v0.15.0 or above
 
-Because Meilisearch v0.15.0 and above include the [dumps feature](/learn/advanced/dumps.md), updating is relatively simple.
+Because Meilisearch v0.15.0 and above include the [dumps feature](/learn/advanced/dumps.md), updating is relatively simpler.
 
 In this guide, we will:
 

--- a/learn/configuration/displayed_searchable_attributes.md
+++ b/learn/configuration/displayed_searchable_attributes.md
@@ -36,11 +36,11 @@ There are two possible modes for the `searchableAttributes` list.
 
 This default behavior is indicated by a `searchableAttributes` value of `["*"]`. To verify the current value of your `searchableAttributes` list, use the [get searchable attributes endpoint](/reference/api/searchable_attributes.md#get-searchable-attributes).
 
-If you'd like to restore your searchable attributes list to this default behavior, simply [set `searchableAttributes` to an empty array `[]`](/reference/api/searchable_attributes.md#update-searchable-attributes) or use the [reset searchable attributes endpoint](/reference/api/searchable_attributes.md#reset-searchable-attributes).
+If you'd like to restore your searchable attributes list to this default behavior, [set `searchableAttributes` to an empty array `[]`](/reference/api/searchable_attributes.md#update-searchable-attributes) or use the [reset searchable attributes endpoint](/reference/api/searchable_attributes.md#reset-searchable-attributes).
 
 #### Manual
 
-You may want to make some attributes non-searchable, or change the [attribute ranking order](/learn/core_concepts/relevancy.md#attribute-ranking-order) after documents have been indexed. To do so, simply place the attributes in the desired order and send the updated list using the [update searchable attributes endpoint](/reference/api/searchable_attributes.md#update-searchable-attributes).
+You may want to make some attributes non-searchable, or change the [attribute ranking order](/learn/core_concepts/relevancy.md#attribute-ranking-order) after documents have been indexed. To do so, place the attributes in the desired order and send the updated list using the [update searchable attributes endpoint](/reference/api/searchable_attributes.md#update-searchable-attributes).
 
 After manually updating the `searchableAttributes` list, **subsequent new attributes will no longer be automatically added** unless the settings are [reset](/reference/api/searchable_attributes.md#reset-searchable-attributes).
 

--- a/learn/cookbooks/aws.md
+++ b/learn/cookbooks/aws.md
@@ -47,7 +47,7 @@ Here you can specify [details of your Instance](https://docs.aws.amazon.com/efs/
 
 ![Page titled 'Step 3: Configure Instance Details'. Important: You can launch multiple instances from the same AMI, request Spot instances to take advantage of lower pricing, and assign access management role to the instance.](/aws/04.instance-details.png)
 
-Simply click on **Next: Add Storage** to keep going.
+Click **Next: Add Storage** to keep going.
 
 ### 5. Storage
 


### PR DESCRIPTION
Update docs to sound less condescending. We might need to consider if [Condescending.yml](https://github.com/meilisearch/documentation/pull/1646/files#diff-de6e498212d2c7f02ba048aa9312f113b1f5a6f12244375115db5c685f67c5dc) is a good idea at this point. We use a lot of "easy"s, "simple"s, and "simply"s, and we can't get rid of all of them.

Part of https://github.com/meilisearch/documentation/pull/1646