### PR TITLE
Add `old` to the code sample name for old header

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -387,8 +387,8 @@ search_parameter_guide_highlight_tag_1: |-
   curl \
     -X POST 'http://localhost:7700/indexes/movies/search' \
     -H 'Content-Type: application/json' \
-    --data-binary '{ 
-      "q": "winter feast", 
+    --data-binary '{
+      "q": "winter feast",
       "attributesToHighlight": ["overview"],
       "highlightPreTag": "<span class=\"highlight\">",
       "highlightPostTag": "</span>"
@@ -816,7 +816,7 @@ typo_tolerance_guide_1: |-
     -H 'Content-Type: application/json' \
     --data-binary '{
       "enabled": false
-    }'    
+    }'
 typo_tolerance_guide_2: |-
   curl \
     -X POST 'http://localhost:7700/indexes/movies/settings/typo-tolerance' \
@@ -870,7 +870,7 @@ updating_guide_get_displayed_attributes_old: |-
   # whenever you see {index_uid}, replace it with your index's unique id
   curl \
     -X GET 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
-    -H 'X-Meili-API-Key: apiKey'    
+    -H 'X-Meili-API-Key: apiKey'
 updating_guide_reset_displayed_attributes_new: |-
   curl \
     -X DELETE 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
@@ -878,7 +878,7 @@ updating_guide_reset_displayed_attributes_new: |-
 updating_guide_reset_displayed_attributes_old: |-
   curl \
     -X DELETE 'http://127.0.0.1:7700/indexes/{index_uid}/settings/displayed-attributes' \
-    -H 'X-Meili-API-Key: apiKey'  
+    -H 'X-Meili-API-Key: apiKey'
 updating_guide_create_dump: |-
   curl \
     -X POST 'http://127.0.0.1:7700/dumps' \
@@ -888,26 +888,25 @@ updating_guide_get_dump_status: |-
   curl \
     -X GET 'http://127.0.0.1:7700/dumps/{dump_uid}/status' \
     -H 'Authorization: Bearer apiKey'
-updating_guide_get_settings: |-
+updating_guide_get_settings_old: |-
   # the -o option saves the output as a local file
   curl \
     -X GET 'http://127.0.0.1:7700/indexes/{index_uid}/settings' -o mysettings.json \
     -H 'X-Meili-API-Key: apiKey'
-updating_guide_retrieve_documents: |-
+updating_guide_retrieve_documents_old: |-
   # the -o option saves the output as a local file
   curl \
-    -X GET 'http://127.0.0.1:7700/indexes/{index_uid}/documents?limit=n' \ -o mydocuments.json \ 
+    -X GET 'http://127.0.0.1:7700/indexes/{index_uid}/documents?limit=n' \ -o mydocuments.json \
     -H 'X-Meili-API-Key: apiKey'
-updating_guide_update_settings: |-
+updating_guide_update_settings_old: |-
   # update your settings
   curl \
     -X POST 'http://127.0.0.1:7700/indexes/{index_uid}/settings' \
     -H 'Content-Type: application/json' -d @mysettings.json \
     -H 'X-Meili-API-Key: apiKey'
-updating_guide_add_documents: |-
+updating_guide_add_documents_old: |-
   # then, add your documents
   curl \
     -X POST 'http://127.0.0.1:7700/indexes/{index_uid}/documents' \
     -H 'Content-Type: application/json' -d @mydocuments.json \
     -H 'X-Meili-API-Key: apiKey'
- 

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -144,7 +144,7 @@ updating_guide_reset_displayed_attributes_old: |-
 updating_guide_reset_displayed_attributes_new: |-
 updating_guide_create_dump: |-
 updating_guide_get_dump_status: |-
-updating_guide_get_settings: |-
-updating_guide_retrieve_documents: |-
-updating_guide_update_settings: |-
-updating_guide_add_documents: |-
+updating_guide_get_settings_old: |-
+updating_guide_retrieve_documents_old: |-
+updating_guide_update_settings_old: |-
+updating_guide_add_documents_old: |-

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -269,7 +269,7 @@ If you don’t need to preserve index settings, skip directly to [step two](#ste
 
 First, use the [get settings endpoint](/reference/api/settings.md#get-settings) to retrieve the [settings](/learn/configuration/settings.md) of any indexes you want to preserve, and save them to a file using the method you prefer.
 
-<CodeSamples id="updating_guide_get_settings" />
+<CodeSamples id="updating_guide_get_settings_old" />
 
 Repeat this process for all indexes you wish to migrate.
 
@@ -297,7 +297,7 @@ Now that all fields are displayed, proceed to the next step.
 
 Use the [get documents endpoint](/reference/api/documents.md#get-documents) to retrieve your documents and save them using the method you prefer. Make sure to set the `limit` on documents returned so that, if you have some number of documents `n`, `limit ≥ n`. Otherwise, you risk data loss.
 
-<CodeSamples id="updating_guide_retrieve_documents" />
+<CodeSamples id="updating_guide_retrieve_documents_old" />
 
 ### Step 4: Delete the database folder
 
@@ -309,9 +309,9 @@ Finally, [install the latest version of Meilisearch](/learn/getting_started/quic
 
 If you chose to save your settings, make sure to follow this order:
 
-<CodeSamples id="updating_guide_update_settings" />
+<CodeSamples id="updating_guide_update_settings_old" />
 
-<CodeSamples id="updating_guide_add_documents" />
+<CodeSamples id="updating_guide_add_documents_old" />
 
 Since updating the settings requires re-indexing all documents, this order saves time and memory.
 


### PR DESCRIPTION
Some code samples use the old `X-Meili-API-Key` header, to avoid confusion between an error and the fact that this header is used voluntarily it would be nice to add the suffix `old` at the end of the sample code name as it is already the case for some.
If you have a better idea I'm interested!
See with @dichotommy