### PR TITLE
update quick start to add note on master key

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -494,6 +494,10 @@ Here's how to use the master key you set to [get all keys](/reference/api/keys.m
 
 <CodeSamples id="authorization_header_1" />
 
+::: note
+The master key should only be used for managing your API keys, avoid using it for regular API calls.
+:::
+
 To learn more about key management, refer to our [dedicated guide](/learn/security/master_api_keys.md).
 
 ## What's next?


### PR DESCRIPTION
Adds note to [Securing Meilisearch](https://docs.meilisearch.com/learn/getting_started/quick_start.html#securing-meilisearch) that the master key should only be used for managing API keys