### PR TITLE
Put all typos in backticks

### DIFF
--- a/learn/configuration/synonyms.md
+++ b/learn/configuration/synonyms.md
@@ -11,7 +11,7 @@ All synonyms are **lowercased** and **de-unicoded** during the indexing process.
 
 #### Example
 
-Consider a situation where "Résumé" and "CV" are set as synonyms.
+Consider a situation where `Résumé` and `CV` are set as synonyms.
 
 ```json
 {
@@ -24,7 +24,7 @@ Consider a situation where "Résumé" and "CV" are set as synonyms.
 }
 ```
 
-A search for "cv" would return any documents containing "cv" or "CV", in addition to any that contain "Résumé", "resumé", "resume", etc. unaffected by case or accent marks.
+A search for `cv` would return any documents containing `cv` or `CV`, in addition to any that contain `Résumé`, `resumé`, `resume`, etc., unaffected by case or accent marks.
 
 ## One-way association
 
@@ -97,12 +97,12 @@ When a multi-word phrase is considered the synonym of another word or phrase, th
 
 ::: tip
 Multi-word synonyms are limited to a maximum of **three words**.
-For example, although you could make "League of Legends" and "LOL" into synonyms, you could not do the same for "The Lord of the Rings" and "LOTR".
+For example, although you could make `League of Legends` and `LOL` into synonyms, you could not do the same for `The Lord of the Rings` and `LOTR`.
 :::
 
 #### Example
 
-Suppose you set "San Francisco" and "SF" as synonyms with a [mutual association](#mutual-association)
+Suppose you set `San Francisco` and `SF` as synonyms with a [mutual association](#mutual-association)
 
 ```json
 {
@@ -115,4 +115,4 @@ Suppose you set "San Francisco" and "SF" as synonyms with a [mutual association]
 }
 ```
 
-If you input "SF" as a search query, then results containing "San Francisco" will also be returned. However, **they will be considered less [relevant](/learn/core_concepts/relevancy.md) than those containing "SF"**. The reverse is also true.
+If you input `SF` as a search query, then results containing `San Francisco` will also be returned. However, **they will be considered less [relevant](/learn/core_concepts/relevancy.md) than those containing `SF`**. The reverse is also true.

--- a/learn/configuration/typo_tolerance.md
+++ b/learn/configuration/typo_tolerance.md
@@ -78,8 +78,8 @@ Meilisearch uses a prefix [Levenshtein algorithm](https://en.wikipedia.org/wiki/
 The [number of typos referenced above](#minwordsizefortypos) is roughly equivalent to Levenshtein distance. The Levenshtein distance between two words _M_ and _P_ can be thought of as "the minimum cost of transforming _M_ into _P_" by performing the following elementary operations on _M_:
 
 - substitution of a character (e.g., **`k`**`itten` → **`s`**`itten`)
-- insertion of a character (e.g., `siting` → `sit**t**ing`)
-- deletion of a character (e.g., `satu**r**day` → `satuday`)
+- insertion of a character (e.g., `siting` → `sit`**`t`**`ing`)
+- deletion of a character (e.g., `satu`**`r`**`day` → `satuday`)
 
 By default, Meilisearch uses the following rules for matching documents. Note that these rules are **by word** and not for the whole query string.
 

--- a/learn/configuration/typo_tolerance.md
+++ b/learn/configuration/typo_tolerance.md
@@ -77,9 +77,9 @@ Meilisearch uses a prefix [Levenshtein algorithm](https://en.wikipedia.org/wiki/
 
 The [number of typos referenced above](#minwordsizefortypos) is roughly equivalent to Levenshtein distance. The Levenshtein distance between two words _M_ and _P_ can be thought of as "the minimum cost of transforming _M_ into _P_" by performing the following elementary operations on _M_:
 
-- substitution of a character (e.g., **`k`**`itten` → **`s`**`itten`)
-- insertion of a character (e.g., `siting` → `sit`**`t`**`ing`)
-- deletion of a character (e.g., `satu`**`r`**`day` → `satuday`)
+- substitution of a character (e.g., `kitten` → `sitten`)
+- insertion of a character (e.g., `siting` → `sitting`)
+- deletion of a character (e.g., `saturday` → `satuday`)
 
 By default, Meilisearch uses the following rules for matching documents. Note that these rules are **by word** and not for the whole query string.
 

--- a/learn/configuration/typo_tolerance.md
+++ b/learn/configuration/typo_tolerance.md
@@ -77,7 +77,7 @@ Meilisearch uses a prefix [Levenshtein algorithm](https://en.wikipedia.org/wiki/
 
 The [number of typos referenced above](#minwordsizefortypos) is roughly equivalent to Levenshtein distance. The Levenshtein distance between two words _M_ and _P_ can be thought of as "the minimum cost of transforming _M_ into _P_" by performing the following elementary operations on _M_:
 
-- substitution of a character (e.g., `**k**itten` → `**s**itten`)
+- substitution of a character (e.g., **`k`**`itten` → **`s`**`itten`)
 - insertion of a character (e.g., `siting` → `sit**t**ing`)
 - deletion of a character (e.g., `satu**r**day` → `satuday`)
 

--- a/learn/configuration/typo_tolerance.md
+++ b/learn/configuration/typo_tolerance.md
@@ -34,7 +34,7 @@ We recommend keeping the value of `oneTypo` between `2` and `8` and the value of
 Meilisearch considers a typo on a query's first character as two typos.
 
 **Concatenation**
-When considering possible candidates for typo tolerance, Meilisearch will concatenate multiple search terms separated by a [space separator](/learn/advanced/datatypes.md#string). This is treated as one typo. For example, a search for "any way" would match documents containing "anyway".
+When considering possible candidates for typo tolerance, Meilisearch will concatenate multiple search terms separated by a [space separator](/learn/advanced/datatypes.md#string). This is treated as one typo. For example, a search for `any way` would match documents containing `anyway`.
 
 For more about typo calculations, [see below](#understanding-typo-calculations).
 :::
@@ -77,9 +77,9 @@ Meilisearch uses a prefix [Levenshtein algorithm](https://en.wikipedia.org/wiki/
 
 The [number of typos referenced above](#minwordsizefortypos) is roughly equivalent to Levenshtein distance. The Levenshtein distance between two words _M_ and _P_ can be thought of as "the minimum cost of transforming _M_ into _P_" by performing the following elementary operations on _M_:
 
-- substitution of a character (e.g., **k**itten → **s**itten)
-- insertion of a character (e.g., siting → sit**t**ing)
-- deletion of a character (e.g., satu**r**day → satuday)
+- substitution of a character (e.g., `**k**itten` → `**s**itten`)
+- insertion of a character (e.g., `siting` → `sit**t**ing`)
+- deletion of a character (e.g., `satu**r**day` → `satuday`)
 
 By default, Meilisearch uses the following rules for matching documents. Note that these rules are **by word** and not for the whole query string.
 
@@ -89,7 +89,7 @@ By default, Meilisearch uses the following rules for matching documents. Note th
 
 This means that "saturday" which is `7` characters long, uses the second rule and matches every document containing **one typo**. For example:
 
-- "saturday" is accepted because it is the same word
-- "satuday" is accepted because it contains **one typo**
-- "sutuday" is not accepted because it contains **two typos**
-- "caturday" is not accepted because it contains **two typos** (as explained [above](#minwordsizefortypos), a typo on the first letter of a word is treated as two typos)
+- `saturday` is accepted because it is the same word
+- `satuday` is accepted because it contains **one typo**
+- `sutuday` is not accepted because it contains **two typos**
+- `caturday` is not accepted because it contains **two typos** (as explained [above](#minwordsizefortypos), a typo on the first letter of a word is treated as two typos)


### PR DESCRIPTION
As part of https://github.com/meilisearch/documentation/pull/1646, we want all words that are meant to be typos in backticks

