### PR TITLE
Add backslash to Docker command in quick_start.

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -58,7 +58,7 @@ docker run -it --rm \
     -p 7700:7700 \
     -e MEILI_MASTER_KEY='MASTER_KEY'\
     -v $(pwd)/meili_data:/meili_data \
-    getmeili/meilisearch:v0.27.1
+    getmeili/meilisearch:v0.27.1 \
     meilisearch --env="development"
 ```
 


### PR DESCRIPTION
# Pull Request

## What does this PR do?
In the command to start Meilisearch with Docker a backslash is missing in line 5.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
