### PR TITLE
remove useless line from meilisearch 101

### DIFF
--- a/learn/getting_started/customizing_relevancy.md
+++ b/learn/getting_started/customizing_relevancy.md
@@ -8,8 +8,6 @@ To follow along, first click this link to download the file: <a id="downloadMovi
 
 <CodeSamples id="getting_started_add_documents_md" />
 
-If you have already downloaded the dataset and created the `movies` index, you can skip to [the next section](#ranking-rules).
-
 ## Ranking rules
 
 Meilisearch sorts search responses based on an array of rules called `rankingRules`, which is part of the `settings` object.


### PR DESCRIPTION
just what the title says 👍🏻 

using the last sentence in the section solely to link to the next section is not a good look.