### PR TITLE
Removed "mandatory" note for optional "q" search parameter

### DIFF
--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -29,7 +29,7 @@ This is the preferred route to perform search when an API key is required, as it
 
 | Query Parameter                                       | Description                                        | Default Value |
 |-------------------------------------------------------|----------------------------------------------------|---------------|
-| **[q](#query-q)**                                     | Query string (mandatory)                           | `""`          |
+| **[q](#query-q)**                                     | Query string                                       | `""`          |
 | **[offset](#offset)**                                 | Number of documents to skip                        | `0`           |
 | **[limit](#limit)**                                   | Maximum number of documents returned               | `20`          |
 | **[filter](#filter)**                                 | Filter queries by an attribute's value             | `null`        |
@@ -120,7 +120,7 @@ This route should only be used when no API key is required. If an API key is req
 
 | Query Parameter                                       | Description                                        | Default Value |
 |-------------------------------------------------------|----------------------------------------------------|---------------|
-| **[q](#query-q)**                                     | Query string (mandatory)                           | `""`          |
+| **[q](#query-q)**                                     | Query string                                       | `""`          |
 | **[offset](#offset)**                                 | Number of documents to skip                        | `0`           |
 | **[limit](#limit)**                                   | Maximum number of documents returned               | `20`          |
 | **[filter](#filter)**                                 | Filter queries by an attribute's value             | `null`        |
@@ -207,7 +207,7 @@ This is not necessary when using the `POST` route or one of our [SDKs](/learn/wh
 
 | Query Parameter                                       | Description                                        | Default Value |
 |-------------------------------------------------------|----------------------------------------------------|---------------|
-| **[q](#query-q)**                                     | Query string (mandatory)                           | `""`          |
+| **[q](#query-q)**                                     | Query string                                       | `""`          |
 | **[offset](#offset)**                                 | Number of documents to skip                        | `0`           |
 | **[limit](#limit)**                                   | Maximum number of documents returned               | `20`          |
 | **[filter](#filter)**                                 | Filter queries by an attribute's value             | `null`        |


### PR DESCRIPTION
This `q` parameter is obviously no longer optional, since the docs state what happens when it's not included:

> #Placeholder search
When q isn't specified, Meilisearch performs a placeholder search. A placeholder search returns all searchable documents in an index, modified by any search parameters used and sorted by that index's custom ranking rules...

# Pull Request

## What does this PR do?
Fixes #<issue_number>
<!-- Please link the issue you're trying to fix with this PR, if none then please create an issue first. -->

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
