### PR TITLE
Remove information from "Getting ready for production" guide

### DIFF
--- a/learn/getting_started/getting_ready_for_production.md
+++ b/learn/getting_started/getting_ready_for_production.md
@@ -11,7 +11,6 @@ Meilisearch has configuration options for many critical actions, such as:
 - Changing the database path
 - Starting Meilisearch in a development or production environment
 - Setting a master key to protect API endpoints
-- Disabling telemetry (enabled by default)
 
 You can read about all of them in our [configuration guide](/learn/configuration/instance_options.md).
 


### PR DESCRIPTION
We don't want to encourage people to remove the telemetry. We want the transparency, but not encourage people to remove them when passing in production 😇 