### PR TITLE
Update the docker tag according to changes in v0.28.0

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -51,7 +51,7 @@ These commands launch the **latest stable release** of Meilisearch.
 
 ```bash
 # Fetch the latest version of Meilisearch image from DockerHub
-docker pull getmeili/meilisearch:v0.27.2
+docker pull getmeili/meilisearch:v0.28
 
 # Launch Meilisearch in development mode with a master key
 docker run -it --rm \
@@ -433,7 +433,7 @@ The following code sample uses [React](https://reactjs.org/), a JavaScript libra
         hit: props.hit
       })
     );
-    
+
     const domContainer = document.querySelector('#app');
     ReactDOM.render(React.createElement(App), domContainer);
   </script>


### PR DESCRIPTION
Since https://github.com/meilisearch/meilisearch/issues/2497 has been implemented by a contributor, when releasing v0.28.0, 3 docker tags will be pushed: `latest`, `v0.28.0` and `v0.28` that are exactly the same version of Meilisearch.

If, for any reason, we release a patch version of v0.28 (so `v0.28.1`), the following scenario will happen
- the docker tag `v0.28.1` is created
- the docker tag `v0.28` is updated to correspond to this new version
- the docker tag `latest` is updated to correspond to this new version

It means you can change the docker command in your guide as I did in the PR.
Why?
- this is the same for the users, I mean using the latest stable version
- they don't use the `latest` tag, but it's still a good practice. Only bugs are fixed between `v0.28.0` and `v0.28.1` which does not impact the users without noticing it.
- you, the docs team, have less maintenance. You only need to change the version in this guide for each new minor (i.e. big release)