### PR TITLE
Vale: add list of US vs British spelling+update spelling

### DIFF
--- a/.vale/styles/style_guide/British.yml
+++ b/.vale/styles/style_guide/British.yml
@@ -1,0 +1,23 @@
+---
+# Suggestion: style_guide.British.yml
+# Checks for American  spelling
+#
+extends: substitution
+message: 'Use the American spelling "%s" instead of the British "%s".'
+link: https://about.gitlab.com/handbook/communication/#top-misused-terms
+level: suggestion
+ignorecase: true
+swap:
+  analyse: analyze
+  behaviour: behavior
+  centre: center
+  colour: color
+  dependant: dependent
+  favourite: favorite
+  initialled: initialed
+  initialling: initialing
+  labelling: labeling
+  labelled: labeled
+  programme: program
+  licence: license
+  colour: color

--- a/learn/advanced/filtering_and_faceted_search.md
+++ b/learn/advanced/filtering_and_faceted_search.md
@@ -87,7 +87,7 @@ release_date > 795484800
 ```
 
 ::: warning
-As no specific schema is enforced at indexing, the filtering engine will try to coerce the type of `value`. This can lead to undefined behaviour when big floats are coerced into integers and reciprocally. For this reason, it is best to have homogeneous typing across fields, especially if numbers tend to become large.
+As no specific schema is enforced at indexing, the filtering engine will try to coerce the type of `value`. This can lead to undefined behavior when big floats are coerced into integers and reciprocally. For this reason, it is best to have homogeneous typing across fields, especially if numbers tend to become large.
 :::
 
 ### Filter expressions

--- a/learn/advanced/geosearch.md
+++ b/learn/advanced/geosearch.md
@@ -139,7 +139,7 @@ _geoRadius(lat, lng, distance_in_meters)
 
 ### Examples
 
-`_geoRadius` works like any other filter rule. Using our <a id="downloadRestaurants" href="/restaurants.json" download="restaurants.json">example dataset</a>, we can search for places to eat near the centre of Milan:
+`_geoRadius` works like any other filter rule. Using our <a id="downloadRestaurants" href="/restaurants.json" download="restaurants.json">example dataset</a>, we can search for places to eat near the center of Milan:
 
 <CodeSamples id="geosearch_guide_filter_usage_1" />
 

--- a/learn/advanced/tokenization.md
+++ b/learn/advanced/tokenization.md
@@ -2,7 +2,7 @@
 
 **Tokenization** is the act of taking a sentence or phrase and splitting it into smaller units of language, called tokens. It is the first step of document indexing in the Meilisearch engine, and is a critical factor in the quality of search results.
 
-Breaking sentences into smaller chunks requires understanding where one word ends and another begins, making tokenization a highly complex and language-dependant task. Meilisearch's solution to this problem is a **modular tokenizer** that follows different processes, called **pipelines**, based on the language it detects.
+Breaking sentences into smaller chunks requires understanding where one word ends and another begins, making tokenization a highly complex and language-dependent task. Meilisearch's solution to this problem is a **modular tokenizer** that follows different processes, called **pipelines**, based on the language it detects.
 
 This allows Meilisearch to function in several different languages with zero setup.
 


### PR DESCRIPTION
Adds a file `British.yml` to the style guide. This rule contains a few US vs British spellings. The PR also updates any British spelling