### PR TITLE
Vale: add sentence length rule

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,5 +6,8 @@ Vocab = word_list
 [*.md]
 BasedOnStyles = style_guide
 
-#style_guide.Headings = NO
-#style_guide.HeadingPunctuation = NO
+style_guide.Headings = NO
+style_guide.HeadingPunctuation = NO
+style_guide.Spelling = NO
+style_guide.Semicolons = NO
+style_guide.FirstPerson = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -5,9 +5,3 @@ Vocab = word_list
 
 [*.md]
 BasedOnStyles = style_guide
-
-style_guide.Headings = NO
-style_guide.HeadingPunctuation = NO
-style_guide.Spelling = NO
-style_guide.Semicolons = NO
-style_guide.FirstPerson = NO

--- a/.vale.ini
+++ b/.vale.ini
@@ -5,3 +5,9 @@ Vocab = word_list
 
 [*.md]
 BasedOnStyles = style_guide
+
+style_guide.Headings = NO
+style_guide.HeadingPunctuation = NO
+style_guide.Spelling = NO
+style_guide.Semicolons = NO
+style_guide.FirstPerson = NO

--- a/.vale/styles/style_guide/SentenceLength.yml
+++ b/.vale/styles/style_guide/SentenceLength.yml
@@ -3,10 +3,10 @@
 
 # Counts words in a sentence and alerts if a sentence exceeds 42 words.
 extends: occurrence
-message: 'Shorter sentences improve readability (max 42 words).'
+message: 'Shorter sentences improve readability (max 40 words).'
 scope: sentence
 link: https://docs.gitlab.com/ee/development/documentation/styleguide/index.html#language
 level: warning
-max: 42
+max: 40
 token: \b(\w+)\b
 

--- a/.vale/styles/style_guide/SentenceLength.yml
+++ b/.vale/styles/style_guide/SentenceLength.yml
@@ -1,0 +1,12 @@
+---
+# Warning: style_guide.SentenceLength
+
+# Counts words in a sentence and alerts if a sentence exceeds 42 words.
+extends: occurrence
+message: 'Shorter sentences improve readability (max 42 words).'
+scope: sentence
+link: https://docs.gitlab.com/ee/development/documentation/styleguide/index.html#language
+level: warning
+max: 42
+token: \b(\w+)\b
+

--- a/learn/advanced/filtering_and_faceted_search.md
+++ b/learn/advanced/filtering_and_faceted_search.md
@@ -244,9 +244,9 @@ When using a dataset of restaurants containing geopositioning data, we can filte
 
 Meilisearch filters can be used to build **faceted search** interfaces. This type of interface allows users to refine search results based on broad categories or **facets**. For example, a clothing webshop can use faceted search to allow users to easily explore items of a certain size or belonging to a specific brand.
 
-Faceted search provides users with a quick way to narrow down search results by selecting categories relevant to what they are looking for. A faceted navigation system is an **intuitive interface to display and navigate through content**. Facets are used in the UI as filters which users can apply to refine the results in real-time.
+Faceted search provides users with a quick way to narrow down search results by selecting categories relevant to what they are looking for. A faceted navigation system is an **intuitive interface to display and navigate through content**. Facets are used in the UI as filters that users can apply to refine the results in real-time.
 
-This is common in ecommerce sites like Amazon: when users perform a search, they are presented not only with a list of results, but also with a list of facets which you can see on the sidebar in the image below:
+This is common in ecommerce sites like Amazon. When users perform a search, they are presented not only with a list of results but also with a list of facets which you can see on the sidebar in the image below:
 
 ![Screenshot of an Amazon product search page displaying faceting UI](/faceted-search/facets-amazon.png)
 

--- a/learn/advanced/geosearch.md
+++ b/learn/advanced/geosearch.md
@@ -121,7 +121,7 @@ Note that Meilisearch will rebuild your index whenever you update `filterableAtt
 
 ### Usage
 
-You first need to ensure your documents contain valid geolocation data and that you have added the `_geo` attribute to the `filterableAttributes` list. Then, you can use the [`filter` search parameter](/reference/api/search.md#filter) along with `_geoRadius`, a special filter rule, to ensure Meilisearch only returns results located within a specific geographic area.
+First, ensure your documents contain valid geolocation data and that you have added the `_geo` attribute to the `filterableAttributes` list. Then, you can use the [`filter` search parameter](/reference/api/search.md#filter) along with `_geoRadius`, a special filter rule, to ensure Meilisearch only returns results located within a specific geographic area.
 
 `_geoRadius` establishes a circular area based on a central point and a radius. Results beyond this area will be excluded from your search. This filter rule requires three parameters: `lat`, `lng` and `distance_in_meters`.
 
@@ -210,7 +210,7 @@ Note that Meilisearch will rebuild your index whenever you update `sortableAttri
 
 ### Usage
 
-You first need to ensure your documents contain valid geolocation data and that you have added the `_geo` attribute to the `sortableAttributes` list. Then, you can use the [`sort` search parameter](/reference/api/search.md#sort) along with `_geoPoint`, a special sorting function, to order results based on their distance from a geographic location.
+First, ensure your documents contain valid geolocation data and that you have added the `_geo` attribute to the `sortableAttributes` list. Then, you can use the [`sort` search parameter](/reference/api/search.md#sort) along with `_geoPoint`, a special sorting function, to order results based on their distance from a geographic location.
 
 ```
 _geoPoint(0.0, 0.0):asc

--- a/learn/advanced/geosearch.md
+++ b/learn/advanced/geosearch.md
@@ -121,7 +121,7 @@ Note that Meilisearch will rebuild your index whenever you update `filterableAtt
 
 ### Usage
 
-Once you are sure that all your documents contain valid geolocation data and that you have added the `_geo` attribute to the `filterableAttributes` list, you can use the [`filter` search parameter](/reference/api/search.md#filter) along with `_geoRadius`, a special filter rule, to ensure Meilisearch only returns results located within a specific geographic area.
+You first need to ensure your documents contain valid geolocation data and that you have added the `_geo` attribute to the `filterableAttributes` list. Then, you can use the [`filter` search parameter](/reference/api/search.md#filter) along with `_geoRadius`, a special filter rule, to ensure Meilisearch only returns results located within a specific geographic area.
 
 `_geoRadius` establishes a circular area based on a central point and a radius. Results beyond this area will be excluded from your search. This filter rule requires three parameters: `lat`, `lng` and `distance_in_meters`.
 
@@ -210,7 +210,7 @@ Note that Meilisearch will rebuild your index whenever you update `sortableAttri
 
 ### Usage
 
-Once you are sure that all your documents contain valid geolocation data and that you have added the `_geo` attribute to the `sortableAttributes` list, you can use the [`sort` search parameter](/reference/api/search.md#sort) along with `_geoPoint`, a special sorting function, to order results based on their distance from a geographic location.
+You first need to ensure your documents contain valid geolocation data and that you have added the `_geo` attribute to the `sortableAttributes` list. Then, you can use the [`sort` search parameter](/reference/api/search.md#sort) along with `_geoPoint`, a special sorting function, to order results based on their distance from a geographic location.
 
 ```
 _geoPoint(0.0, 0.0):asc

--- a/learn/core_concepts/primary_key.md
+++ b/learn/core_concepts/primary_key.md
@@ -160,7 +160,7 @@ The code below updates the primary key to `title`:
 
 ### Meilisearch guesses your primary key
 
-If you attempt to add documents to an index without previously setting its primary key, Meilisearch will automatically look for an attribute that contains the string `id` in a case-insensitive manner (e.g., `uid`, `BookId`, `ID`, `123id123`) in your first document and set it as that index's primary key.
+Suppose you add documents to an index without previously setting its primary key. In this case, Meilisearch will automatically look for an attribute containing the string `id` in a case-insensitive manner (e.g., `uid`, `BookId`, `ID`, `123id123`) in your first document and set it as the index's primary key.
 
 If Meilisearch cannot find a suitable attribute, the document addition process will be interrupted and no documents will be added to your index.
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -157,7 +157,7 @@ Elasticsearch can handle search through massive amounts of data and perform text
 Meilisearch is intended to deliver performant instant search experiences aimed at end-users. However, processing complex queries or analyzing very large datasets is not possible.
 
 Elasticsearch can sometimes be too slow if you want to provide a full instant search experience. Most of the time, it is significantly slower in returning search results compared to Meilisearch.
-Meilisearch is a perfect choice if you need a simple and easy tool to deploy a typo-tolerant search bar that provides a prefix searching capability, makes search intuitive for users, and returns them their results instantly with near-perfect relevance.
+Meilisearch is a perfect choice if you need a simple and easy tool to deploy a typo-tolerant search bar that provides prefix searching capability, makes search intuitive for users, and returns results instantly with near-perfect relevance.
 
 ### Meilisearch vs Algolia
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -208,7 +208,8 @@ Since Lucene is the technology behind many open source or closed source search e
 
 #### Sonic
 
-Sonic is a lightweight and schema-less search index server written in Rust. Sonic cannot be considered as an out-of-the-box solution and, compared to Meilisearch, it does not ensure relevancy ranking. Indeed, it does not store any documents but is comprised of an inverted index with a Levenshtein automaton, which means any application querying Sonic has to retrieve the search results from an external database using the IDs that are returned and then apply some relevancy ranking.
+Sonic is a lightweight and schema-less search index server written in Rust. Sonic cannot be considered as an out-of-the-box solution, and compared to Meilisearch, it does not ensure relevancy ranking. Instead of storing documents, it comprises an inverted index with a Levenshtein automaton. This means any application querying Sonic has to retrieve the search results from an external database using the returned IDs and then apply some relevancy ranking.
+
 Its ability to run on a few MBs of RAM makes it a minimalist and resource-efficient alternative to database tools that can be too heavyweight to scale.
 
 #### Typesense


### PR DESCRIPTION
- Adds `SentenceLength.yml` to the style guide. This rule shows a warning if a sentence exceeds 40 words
- Updates any existing sentences with >40 words 

Most rules use a max of 25-30 words. Most of our “longer” (more than 25 words) sentences are between 27-30 words. The longest are ~42. We can start with 40 and bring it down


part of #1711 