### PR TITLE
vale: update firstperson.yml

### DIFF
--- a/.vale/styles/style_guide/FirstPerson.yml
+++ b/.vale/styles/style_guide/FirstPerson.yml
@@ -3,7 +3,7 @@
 
 # We want to avoid using singular first person pronouns
 extends: existence
-message: "Avoid first-person pronouns such as '%s'."
+message: "Avoid first-person pronouns such as '%s' unless writing FAQs"
 link: 'https://developers.google.com/style/pronouns#personal-pronouns'
 ignorecase: true
 level: suggestion


### PR DESCRIPTION
Updates the `FirstPerson.yml` message to: "Avoid first-person pronouns such as '%s' unless writing FAQs"

Unfortunately, we can't ignore this rule on some files like the FAQs, `learn/what_is_meilisearch/language.md`, etc., so we'll go with this for now. 


Part of https://github.com/meilisearch/documentation/issues/1711