### PR TITLE
API reference: move task filtering and pagination to async guide

### DIFF
--- a/learn/advanced/asynchronous_operations.md
+++ b/learn/advanced/asynchronous_operations.md
@@ -1,3 +1,8 @@
+---
+
+sidebarDepth: 2
+
+---
 # Asynchronous operations
 
 All index writes are processed **asynchronously**. This means that task requests are not handled as soon as they are received—instead, Meilisearch places these operations in a queue and processes them in the order they were received.
@@ -65,7 +70,7 @@ Task responses always contain a field indicating the request's current `status`.
 - `succeeded`: the task has been successfully processed
 - `failed`: a failure occurred when processing the task. No changes were made to the database
 
-### Examples
+#### Examples
 
 Suppose you add a new document to your instance using the [add documents endpoint](/reference/api/documents.md#add-or-replace-documents) and receive a `taskUid` in response.
 
@@ -145,8 +150,6 @@ For example, the following command would return all `documentAdditionOrUpdate` t
 <CodeSamples id="get_all_tasks_filtering_2" />
 
 At this time, `OR` operations between different filters are not supported. For example, you cannot view only tasks which have a type of `documentAddition` **or** a status of `failed`.
-
-[Read more about the possible values of these fields in our asynchronous operations guide.](/learn/advanced/asynchronous_operations.md)
 
 ### Paginating tasks
 

--- a/learn/advanced/asynchronous_operations.md
+++ b/learn/advanced/asynchronous_operations.md
@@ -132,6 +132,76 @@ Had the task failed, the response would have included an `error` object:
 }
 ```
 
+### Filtering tasks
+
+You can filter tasks based on `status`, `type`, or `indexUid`. For example, the following command returns all tasks belonging to the index `movies`. Note that the `indexUid` is case-sensitive:
+
+<CodeSamples id="get_all_tasks_filtering_1" />
+
+Use the ampersand character `&` to combine filters, equivalent to a logical `AND`. Use the comma character `,` to add multiple filter values for a single field.
+
+For example, the following command would return all `documentAdditionOrUpdate` tasks that either `succeeded` or `failed`:
+
+<CodeSamples id="get_all_tasks_filtering_2" />
+
+At this time, `OR` operations between different filters are not supported. For example, you cannot view only tasks which have a type of `documentAddition` **or** a status of `failed`.
+
+[Read more about the possible values of these fields in our asynchronous operations guide.](/learn/advanced/asynchronous_operations.md)
+
+### Paginating tasks
+
+The task list is paginated, by default returning 20 tasks at a time. You can adjust the number of documents returned using the `limit` parameter, and control where the list begins using the `from` parameter.
+
+For each call to this endpoint, the response will include the `next` field: this value should be passed to `from` to view the next "page" of results. When the value of `next` is `null`, there are no more tasks to view.
+
+This command returns tasks two at a time, starting from task `uid` `10`.
+
+<CodeSamples id="get_all_tasks_paginating_1" />
+
+**Response:**
+
+```json
+{
+  "results": [
+    {
+      "uid": 10,
+      "indexUid": "elements",
+      "status": "succeeded",
+      "type": "indexCreation",
+      "details": {
+        "primaryKey": null
+      },
+      "duration": "PT0.006034S",
+      "enqueuedAt": "2022-06-20T13:41:42.446908Z",
+      "startedAt": "2022-06-20T13:41:42.447477Z",
+      "finishedAt": "2022-06-20T13:41:42.453511Z"
+    },
+    {
+      "uid": 9,
+      "indexUid": "particles",
+      "status": "succeeded",
+      "type": "indexCreation",
+      "details": {
+        "primaryKey": null
+      },
+      "duration": "PT0.007317S",
+      "enqueuedAt": "2022-06-20T13:41:31.841575Z",
+      "startedAt": "2022-06-20T13:41:31.842116Z",
+      "finishedAt": "2022-06-20T13:41:31.849433Z"
+    }
+  ],
+  "limit": 2,
+  "from": 10,
+  "next": 8
+}
+```
+
+To view the next page of results, you would repeat the same query, replacing the value of `from` with the value of `next`:
+
+<CodeSamples id="get_all_tasks_paginating_2" />
+
+When the returned value of `next` is `null`, you have reached the final page of results.
+
 ## Task workflow
 
 1. When you make an [asynchronous request](#which-operations-are-async), Meilisearch puts it in the task queue, sets the task's `status` to `enqueued` and returns a [summarized `task` object](/learn/advanced/asynchronous_operations.md#summarized-task-objects)

--- a/reference/api/tasks.md
+++ b/reference/api/tasks.md
@@ -63,75 +63,7 @@ Task results are [paginated](#paginating-tasks) and can be [filtered](#filtering
 }
 ```
 
-### Filtering tasks
-
-You can filter the task list by the value of the `status`, `type`, or `indexUid` fields. For example, the following command returns all tasks belonging to the index `movies`. Note that the `indexUid` is case-sensitive:
-
-<CodeSamples id="get_all_tasks_filtering_1" />
-
-Use the ampersand character `&` to combine filters, equivalent to a logical `AND`. Use the comma character `,` to add multiple filter values for a single field.
-
-For example, the following command would return all `documentAdditionOrUpdate` tasks that either `succeeded` or `failed`:
-
-<CodeSamples id="get_all_tasks_filtering_2" />
-
-At this time, `OR` operations between different filters are not supported. For example, you cannot view only tasks which have a type of `documentAddition` **or** a status of `failed`.
-
-[Read more about the possible values of these fields in our asynchronous operations guide.](/learn/advanced/asynchronous_operations.md)
-
-### Paginating tasks
-
-The task list is paginated, by default returning 20 tasks at a time. You can adjust the number of documents returned using the `limit` parameter, and control where the list begins using the `from` parameter.
-
-For each call to this endpoint, the response will include the `next` field: this value should be passed to `from` to view the next "page" of results. When the value of `next` is `null`, there are no more tasks to view.
-
-This command returns tasks two at a time starting from task `uid` `10`.
-
-<CodeSamples id="get_all_tasks_paginating_1" />
-
-**Response:**
-
-```json
-{
-  "results": [
-    {
-      "uid": 10,
-      "indexUid": "elements",
-      "status": "succeeded",
-      "type": "indexCreation",
-      "details": {
-        "primaryKey": null
-      },
-      "duration": "PT0.006034S",
-      "enqueuedAt": "2022-06-20T13:41:42.446908Z",
-      "startedAt": "2022-06-20T13:41:42.447477Z",
-      "finishedAt": "2022-06-20T13:41:42.453511Z"
-    },
-    {
-      "uid": 9,
-      "indexUid": "particles",
-      "status": "succeeded",
-      "type": "indexCreation",
-      "details": {
-        "primaryKey": null
-      },
-      "duration": "PT0.007317S",
-      "enqueuedAt": "2022-06-20T13:41:31.841575Z",
-      "startedAt": "2022-06-20T13:41:31.842116Z",
-      "finishedAt": "2022-06-20T13:41:31.849433Z"
-    }
-  ],
-  "limit": 2,
-  "from": 10,
-  "next": 8
-}
-```
-
-To view the next page of results, you would repeat the same query, replacing the value of `from` with the value of `next`:
-
-<CodeSamples id="get_all_tasks_paginating_2" />
-
-When the returned value of `next` is `null`, you have reached the final page of results.
+You can filter and paginate tasks
 
 ## Get one task
 

--- a/reference/api/tasks.md
+++ b/reference/api/tasks.md
@@ -14,17 +14,17 @@ List all tasks globally, regardless of index. The `task` objects are contained i
 
 Tasks are always returned in descending order of `uid`. This means that by default, **the most recently created `task` objects appear first**.
 
-Task results are [paginated](#paginating-tasks) and can be [filtered](#filtering-tasks).
+Task results are paginated and can be filtered. To learn more, refer to our [asynchronous operations](/learn/advanced/asynchronous_operations.md#filtering-tasks) guide.
 
 #### Query parameters
 
-| Query Parameter | Description                                                          |         Default Value          |
-|-----------------|----------------------------------------------------------------------|:------------------------------:|
-| **limit**       | number of tasks to return                                            |               20               |
-| **from**        | `uid` of the first task returned                                     | `uid` of the last created task |
-| **status**      | [filter tasks](#filtering-tasks) by their `status`                   |          all statuses          |
-| **type**        | [filter tasks](#filtering-tasks) by their `type`                     |           all types            |
-| **indexUid**    | [filter tasks](#filtering-tasks) by their `indexUid`. Case-sensitive |          all indexes           |
+| Query Parameter | Description                                                                                                    |         Default Value          |
+|-----------------|----------------------------------------------------------------------------------------------------------------|:------------------------------:|
+| **limit**       | number of tasks to return                                                                                      |               20               |
+| **from**        | `uid` of the first task returned                                                                               | `uid` of the last created task |
+| **status**      | [filter tasks](/learn/advanced/asynchronous_operations.md#filtering-tasks) by their `status`                   |          all statuses          |
+| **type**        | [filter tasks](/learn/advanced/asynchronous_operations.md#filtering-tasks) by their `type`                     |           all types            |
+| **indexUid**    | [filter tasks](/learn/advanced/asynchronous_operations.md#filtering-tasks) by their `indexUid`. Case-sensitive |          all indexes           |
 
 ### Example
 
@@ -62,8 +62,6 @@ Task results are [paginated](#paginating-tasks) and can be [filtered](#filtering
     ]
 }
 ```
-
-You can filter and paginate tasks
 
 ## Get one task
 


### PR DESCRIPTION
Part of #1351 

- Moved task filtering and pagination to the [async operations guide](https://docs.meilisearch.com/learn/advanced/asynchronous_operations.html)
  - I think compared to the rest of the page, these headings are too technical? But that's something we can fix when we [rewrite the whole page ](https://github.com/meilisearch/documentation/issues/1273)
- Added `sidebarDepth: 2` so all subheadings are visible, especially under `Understanding tasks`
