### PR TITLE
add MD026

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,7 +1,7 @@
 {
   "MD013": false, // line-length Line length [Expected: 80; Actual: 119]
   "MD001": false, // heading-increment/header-increment Heading levels should only increment by one level at a time
-  "MD026": {"punctuation": ".,;:。，；"}, // no-trailing-punctuation Trailing punctuation in heading 
+  "MD026": {"punctuation": ".,;:。，；"}, // no-trailing-punctuation Trailing punctuation in headings except ? and ! 
   "MD014": false, // commands-show-output Dollar signs used before commands without showing output
   "MD024": false, // no-duplicate-heading/no-duplicate-header
   "MD040": false, // fenced-code-language Fenced code blocks should have a language specified

--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,7 +1,7 @@
 {
   "MD013": false, // line-length Line length [Expected: 80; Actual: 119]
   "MD001": false, // heading-increment/header-increment Heading levels should only increment by one level at a time
-  "MD026": false, // no-trailing-punctuation Trailing punctuation in heading 
+  "MD026": {"punctuation": ".,;:。，；"}, // no-trailing-punctuation Trailing punctuation in heading 
   "MD014": false, // commands-show-output Dollar signs used before commands without showing output
   "MD024": false, // no-duplicate-heading/no-duplicate-header
   "MD040": false, // fenced-code-language Fenced code blocks should have a language specified

--- a/learn/cookbooks/digitalocean_droplet.md
+++ b/learn/cookbooks/digitalocean_droplet.md
@@ -65,7 +65,7 @@ Instance creation in progress...
 
 ![meilisearch-droplet-name instance created successfully](/digitalocean/08.created-ip.png)
 
-### 9. Test Meilisearch.
+### 9. Test Meilisearch
 
 Copy the public IP address:
 

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -65,7 +65,7 @@ All asynchronous operations return a [summarized version of the `task` object](/
 
 This response indicates that the operation has been taken into account and will be processed once it reaches the front of the queue. You can use this `taskUid` to get more details on [the status of the task](/reference/api/tasks.md#get-one-task).
 
-## I am trying to add my documents but I keep receiving a `400 - Bad Request` response.
+## I am trying to add my documents but I keep receiving a `400 - Bad Request` response
 
 Meilisearch API accepts JSON, CSV, and NDJSON formats.
 In case of a [document addition](/reference/api/documents.md#add-or-replace-documents), only an array of objects is expected.
@@ -116,7 +116,7 @@ Meilisearch has the following types of errors:
 | internal        | This is due to machine or configuration constraints. The most common cause is reaching or exceeding hard limits, such as the size of the disk, the size limit of an index, etc. It is accompanied by the HTTP code `5xx`.  |
 | auth            | This type of error is related to authentication and authorization. It is accompanied by the HTTP code `4xx`. |
 
-## My document upload failed with the `document id is missing` error.
+## My document upload failed with the `document id is missing` error
 
 ::: note TLDR;
 Most common reasons:
@@ -149,7 +149,7 @@ Good:
 
 See more [information about the primary key](/learn/core_concepts/primary_key.md#primary-key-2).
 
-## I have uploaded my documents, but I get no result when I search in my index.
+## I have uploaded my documents, but I get no result when I search in my index
 
 Your document upload probably failed. To understand why, please check the status of the document addition task using the returned `taskUid`. If the task failed, the response should contain an `error` object.
 
@@ -195,7 +195,7 @@ Since the production environment requires an API key for searching, the search p
 
 Here is more information about [Meilisearch's search preview](/learn/what_is_meilisearch/search_preview.md).
 
-## I do not understand the relevancy of my search results.
+## I do not understand the relevancy of my search results
 
 The search responses are sorted according to a set of consecutive rules called ranking rules.
 Here is more information about the [relevancy of Meilisearch](/learn/core_concepts/relevancy.md).


### PR DESCRIPTION
This PR:
- adds markdownlint's [MD0026](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md026---trailing-punctuation-in-heading) for trailing punctuation in headings. For now, we will only allow `?` and `!`
- removes any trailing punctuation that isn't a `?` or `!` 

Part of #1711 
