### PR TITLE
Fix build crash when a case code-sample-id has no associated code-sample

### DIFF
--- a/.vuepress/code-samples/components/codeSamples.vue
+++ b/.vuepress/code-samples/components/codeSamples.vue
@@ -48,7 +48,13 @@ export default {
     },
   },
   created() {
-    this.ignoredTabs = CODE_SAMPLES[this.id].filter(tab => !tab.cacheableTab).map(tab => tab.label)
+    // Add to the ignored list the tabs that cannot be a preferred tab in the local storage
+    if (CODE_SAMPLES[this.id]) {
+      this.ignoredTabs = CODE_SAMPLES[this.id].filter(tab => !tab.cacheableTab).map(tab => tab.label)
+    } else {
+      this.ignoredTabs = []
+    }
+
     this.samples = CODE_SAMPLES[this.id]
   },
   methods: {


### PR DESCRIPTION
When a new code-sample-id is introduced but it has no code-sample associated to it in production the build crashes.

This is caused by a line on the code-sample rendering filters on all code-samples for a given code-sample-id to ensure non catchable tabs are defined. 
```js
this.ignoredTabs = CODE_SAMPLES[this.id].filter(tab => !tab.cacheableTab).map(tab => tab.label)
```
The filtering only works on arrays, but when a code-sample id had no associated code-sample, the filtering on an `undefined` value made the build crash.