### PR TITLE
v0.29: Update `invalid_geo_field` error

### DIFF
--- a/reference/api/error_codes.md
+++ b/reference/api/error_codes.md
@@ -111,7 +111,7 @@ The provided ranking rules are invalid. This may be due to syntax errors in your
 
 ### `invalid_geo_field`
 
-The provided `_geo` field of one or more documents is invalid. Read more about `_geo` and how to troubleshoot it in [our dedicated guide](/learn/advanced/geosearch.md).
+The provided `_geo` field of one or more documents is invalid. Meilisearch expects `_geo` to be an object with two fields, `lat` and `lng`, each containing geographic coordinates expressed as a string or number. Read more about `_geo` and how to troubleshoot it in [our dedicated guide](/learn/advanced/geosearch.md).
 
 ### `invalid_api_key`
 


### PR DESCRIPTION
Closes #1851 

This is not strictly necessary as we don't usually go into too much detail in the errors page, nor do we describe variant errors. 

Still, I took the update as an opportunity to add a bit more info to the description in hopes we can save users a click to the dedicated guide.