### PR TITLE
Highlight behavior regarding searchableAttributes

### DIFF
--- a/learn/configuration/displayed_searchable_attributes.md
+++ b/learn/configuration/displayed_searchable_attributes.md
@@ -25,8 +25,12 @@ Meilisearch uses an ordered list to determine which attributes are searchable. T
 
 In other words, the `searchableAttributes` list serves two purposes:
 
-1. It designates the fields that are searchable.
-2. It dictates the [attribute ranking order](/learn/core_concepts/relevancy.md#attribute-ranking-order).
+1. It designates the fields that are searchable
+2. It dictates the [attribute ranking order](/learn/core_concepts/relevancy.md#attribute-ranking-order)
+
+::: warning
+Documents with matching query terms will still [highlight](/reference/api/search.md#attributes-to-highlight) and [match](/reference/api/search.md#show-matches-position) attributes even if they are not part of `searchableAttributes`.
+:::
 
 There are two possible modes for the `searchableAttributes` list.
 

--- a/learn/configuration/displayed_searchable_attributes.md
+++ b/learn/configuration/displayed_searchable_attributes.md
@@ -2,8 +2,8 @@
 
 By default, whenever a document is added to Meilisearch, all new attributes found in it are automatically added to two lists:
 
-- [`searchableAttributes`](/learn/configuration/displayed_searchable_attributes.md#the-searchableattributes-list): attributes whose values are searched for matching query words.
-- [`displayedAttributes`](/learn/configuration/displayed_searchable_attributes.md#displayed-fields): attributes whose fields are displayed in documents.
+- [`searchableAttributes`](/learn/configuration/displayed_searchable_attributes.md#the-searchableattributes-list): Attributes whose values are searched for matching query words
+- [`displayedAttributes`](/learn/configuration/displayed_searchable_attributes.md#displayed-fields): Attributes whose fields are displayed in documents
 
 This means that by default, every field in a document is **searchable** and **displayed**. These properties can be modified in the [settings](/reference/api/settings.md).
 
@@ -27,10 +27,6 @@ In other words, the `searchableAttributes` list serves two purposes:
 
 1. It designates the fields that are searchable
 2. It dictates the [attribute ranking order](/learn/core_concepts/relevancy.md#attribute-ranking-order)
-
-::: warning
-Documents with matching query terms will still [highlight](/reference/api/search.md#attributes-to-highlight) and [match](/reference/api/search.md#show-matches-position) attributes even if they are not part of `searchableAttributes`.
-:::
 
 There are two possible modes for the `searchableAttributes` list.
 

--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -565,7 +565,7 @@ By default highlighted elements are enclosed in `<em>` and `</em>` tags. You may
 :::
 
 ::: warning
-`attributesToHighlight` will highlight all attributes added to the `attributesToHighlight` array even if they are not set as `searchableAttributes`.
+`attributesToHighlight` will highlight matches within all attributes added to the `attributesToHighlight` array, even if those attributes are not set as [`searchableAttributes`](/learn/configuration/displayed_searchable_attributes.md#searchable-fields).
 :::
 
 #### Example
@@ -643,7 +643,7 @@ Though it is not necessary to use `highlightPreTag` and `highlightPostTag` in co
 Adds a `_matchesPosition` object to the search response that contains the location of each occurrence of queried terms across all fields. This is useful when you need more control than offered by our [built-in highlighting](#attributes-to-highlight). `showMatchesPosition` only works for strings, numbers, and arrays of strings and numbers.
 
 ::: warning
-`showMatchesPosition` returns match location for all attributes that contain words matching the query terms even if they are not set as `searchableAttributes`.
+`showMatchesPosition` returns the location of matched query terms within all attributes, even attributes that are not set as `searchableAttributes`.
 :::
 
 The beginning of a matching term within a field is indicated by `start`, and its length by `length`.

--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -643,7 +643,7 @@ Though it is not necessary to use `highlightPreTag` and `highlightPostTag` in co
 Adds a `_matchesPosition` object to the search response that contains the location of each occurrence of queried terms across all fields. This is useful when you need more control than offered by our [built-in highlighting](#attributes-to-highlight). `showMatchesPosition` only works for strings, numbers, and arrays of strings and numbers.
 
 ::: warning
-`showMatchesPosition` returns the location of matched query terms within all attributes, even attributes that are not set as `searchableAttributes`.
+`showMatchesPosition` returns the location of matched query terms within all attributes, even attributes that are not set as [`searchableAttributes`](/learn/configuration/displayed_searchable_attributes.md#searchable-fields).
 :::
 
 The beginning of a matching term within a field is indicated by `start`, and its length by `length`.

--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -564,6 +564,10 @@ By default highlighted elements are enclosed in `<em>` and `</em>` tags. You may
 `attributesToHighlight` also highlights terms configured as [synonyms](/reference/api/settings.md#synonyms) and [stop words](/reference/api/settings.md#stop-words).
 :::
 
+::: warning
+`attributesToHighlight` will highlight all attributes added to the `attributesToHighlight` array even if they are not set as `searchableAttributes`.
+:::
+
 #### Example
 
 The following query highlights matches present in the `overview` attribute:
@@ -637,6 +641,10 @@ Though it is not necessary to use `highlightPreTag` and `highlightPostTag` in co
 **Default value**: `false`
 
 Adds a `_matchesPosition` object to the search response that contains the location of each occurrence of queried terms across all fields. This is useful when you need more control than offered by our [built-in highlighting](#attributes-to-highlight). `showMatchesPosition` only works for strings, numbers, and arrays of strings and numbers.
+
+::: warning
+`showMatchesPosition` will consider all attributes that contain words matching the query terms even if they are not set as `searchableAttributes`.
+:::
 
 The beginning of a matching term within a field is indicated by `start`, and its length by `length`.
 

--- a/reference/api/search.md
+++ b/reference/api/search.md
@@ -643,7 +643,7 @@ Though it is not necessary to use `highlightPreTag` and `highlightPostTag` in co
 Adds a `_matchesPosition` object to the search response that contains the location of each occurrence of queried terms across all fields. This is useful when you need more control than offered by our [built-in highlighting](#attributes-to-highlight). `showMatchesPosition` only works for strings, numbers, and arrays of strings and numbers.
 
 ::: warning
-`showMatchesPosition` will consider all attributes that contain words matching the query terms even if they are not set as `searchableAttributes`.
+`showMatchesPosition` returns match location for all attributes that contain words matching the query terms even if they are not set as `searchableAttributes`.
 :::
 
 The beginning of a matching term within a field is indicated by `start`, and its length by `length`.


### PR DESCRIPTION
closes #1256 

- Note vs warning. We agreed to use warnings when "missing the message could lead to really bad consequences". We won't have any bad consequences in this case, but users may not be aware of this so a warning sounds better
- I think a warning/note is enough to explain this behavior. But if we want to add code samples, we could add one to  `learn/configuration/displayed_searchable_attributes.md`. WDYT? 