### PR TITLE
update node to ensure compatibility with node 16

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: "yarn"
           cache-dependency-path: yarn.lock
       - run: yarn install
@@ -44,7 +44,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: "yarn"
           cache-dependency-path: yarn.lock
       - run: yarn install

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,5 +1,4 @@
-name: GitHub pages and scraping
-
+name: Deploy documentation
 on:
   push:
     branches:
@@ -8,12 +7,12 @@ on:
 jobs:
   build-deploy:
     runs-on: ubuntu-20.04
-
+    name: build and deploy to Netlify
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           cache: "yarn"
           cache-dependency-path: yarn.lock
       - name: Publish
@@ -27,6 +26,7 @@ jobs:
   scrape-docs:
     needs: build-deploy
     runs-on: ubuntu-20.04
+    name: scrape and push content on Meilisearch instance
     steps:
       - uses: actions/checkout@v3
       - name: Run docs-scraper

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vuex": "^3.6.2"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=12 <=18"
   },
   "resolutions": {
     "vuepress-plugin-check-md/check-md": "https://github.com/bidoubiwa/check-md#add_ignore_pattern"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vuex": "^3.6.2"
   },
   "engines": {
-    "node": ">=12 <=18"
+    "node": ">=14 <=16"
   },
   "resolutions": {
     "vuepress-plugin-check-md/check-md": "https://github.com/bidoubiwa/check-md#add_ignore_pattern"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "vuex": "^3.6.2"
   },
   "engines": {
-    "node": ">=12 <=16"
+    "node": ">=16"
   },
   "resolutions": {
     "vuepress-plugin-check-md/check-md": "https://github.com/bidoubiwa/check-md#add_ignore_pattern"


### PR DESCRIPTION
closes #1657 + removes support for node 12 + renames  `gh-pages-scarping.yml`(not very helpful) to `deploy.yml`