### PR TITLE
Update instance_options.md

### DIFF
--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -197,7 +197,7 @@ _This option is not available as an environment variable._
 
 Defines how much detail should be present in Meilisearch's logs.
 
-Meilisearch currently supports four log levels, listed in order of increasing verbosity:
+Meilisearch currently supports five log levels, listed in order of increasing verbosity:
 
 - `'ERROR'`: only log unexpected events indicating Meilisearch is not functioning as expected
 - `'WARN:'` log all unexpected events, regardless of their severity


### PR DESCRIPTION
Meilisearch supports five log levels, not four.