### PR TITLE
add `od`as typo+rename file

### DIFF
--- a/.vale/styles/style_guide/Typos.yml
+++ b/.vale/styles/style_guide/Typos.yml
@@ -1,7 +1,7 @@
 ---
-# Error: style_guide.Meilisearch.yml
+# Error: style_guide.Typos.yml
 
-# Lists any possible typos for Meilisearch
+# Lists any possible typos and the correct spelling 
 extends: substitution
 message: "Use '%s' instead of '%s'."
 level: error
@@ -9,3 +9,4 @@ swap:
   MeiliSearch: Meilisearch
   MieliSearch: Meilisearch
   meiliSearch: Meilisearch
+  od: of


### PR DESCRIPTION
- We have mistyped `of` as `od` multiple times, and Vale didn't throw any error as it is an actual word. This PR updates the Typos rule to add `od` to our list of typos
- I have renamed the file `Meilisearch.yml` to `Typos.yml` as we now have words other than Meilisearch in the file
