### PR TITLE
Fix the Docker guide link in the Quick Start documentation

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -62,7 +62,7 @@ docker run -it --rm \
     meilisearch --env="development"
 ```
 
-You can learn more about [using Meilisearch with Docker in our dedicated guide](https://docs.docker.com/get-docker/).
+You can learn more about [using Meilisearch with Docker in our dedicated guide](/learn/cookbooks/docker.md).
 :::
 
 ::: tab APT


### PR DESCRIPTION
# Pull Request

The Quick Start page link to the wrong Docker Guide.

## What does this PR do?

- Fix the link to use the existing guide

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
