### PR TITLE
Sync versions with docker pull and docker run commands to v0.29

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -58,7 +58,7 @@ docker run -it --rm \
     -p 7700:7700 \
     -e MEILI_MASTER_KEY='MASTER_KEY'\
     -v $(pwd)/meili_data:/meili_data \
-    getmeili/meilisearch:v0.28 \
+    getmeili/meilisearch:v0.29 \
     meilisearch --env="development"
 ```
 


### PR DESCRIPTION
## What does this PR do?
Syncs the versions with the docker pull and docker run commands to v0.29 in the quickstart guide. Otherwise, an error will be occur.
