### PR TITLE
merge note and tip for stop words

### DIFF
--- a/reference/api/settings.md
+++ b/reference/api/settings.md
@@ -1096,11 +1096,9 @@ Words added to the `stopWords` list are ignored in future search queries.
 Updating stop words will re-index all documents in the index, which can take some time. We recommend updating your index settings first and then adding documents as this reduces RAM consumption.
 :::
 
-::: note
-Stop words are strongly related to the language used in your dataset. For example, most datasets containing English documents will have countless occurrences of `the` and `of`. Italian datasets, instead, will benefit from ignoring words like `a`, `la`, or `il`.
-:::
-
 ::: tip
+Stop words are strongly related to the language used in your dataset. For example, most datasets containing English documents will have countless occurrences of `the` and `of`. Italian datasets, instead, will benefit from ignoring words like `a`, `la`, or `il`.
+
 [This website maintained by a French developer](https://sites.google.com/site/kevinbouge/stopwords-lists) offers lists of possible stop words in different languages. Note that, depending on your dataset and use case, you will need to tweak these lists for optimal results.
 :::
 


### PR DESCRIPTION
We have a note, tip, and warning at the beginning of the [stop words](https://docs.meilisearch.com/reference/api/settings.html#stop-words) section of the API reference. This PR merges the content of the note and tip to make it less overwhelming.