### PR TITLE
Update vuepress-plugin-meilisearch to version v0.13.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "vuepress-plugin-code-copy": "^1.0.6",
     "vuepress-plugin-container": "^2.1.5",
     "vuepress-plugin-img-lazy": "^1.0.4",
-    "vuepress-plugin-meilisearch": "^0.12.4",
+    "vuepress-plugin-meilisearch": "^0.13.0",
     "vuepress-plugin-seo": "^0.1.4",
     "vuepress-plugin-sitemap": "^2.3.1",
     "vuepress-plugin-zooming": "^1.1.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8909,10 +8909,10 @@ vuepress-plugin-img-lazy@^1.0.4:
     markdown-it-img-lazy "^1.0.2"
     markdown-it-imsize "^2.0.1"
 
-vuepress-plugin-meilisearch@^0.12.4:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/vuepress-plugin-meilisearch/-/vuepress-plugin-meilisearch-0.12.4.tgz#35012abfa637c0182032d329d7abb6eaa4d49212"
-  integrity sha512-plD+xCmjF5I5BChHLTeLu2cCzu1fusrW9Ubak8Iyt0wTThV4l8eKeaxSnt0JEFhTv5cF1nosPtuubczeSJjjaA==
+vuepress-plugin-meilisearch@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/vuepress-plugin-meilisearch/-/vuepress-plugin-meilisearch-0.13.0.tgz#1a5bf413486ec2a03cf2167883507b73826564f5"
+  integrity sha512-qNDjY6rqDwP52v06zO+U+6CdTiMvJBb64Puq+pe0kROUrmuBwxLZ7g3ssYRMe3vil6EhLYnamRmVb/gJ88I/RQ==
   dependencies:
     docs-searchbar.js "^2.4.0"
 


### PR DESCRIPTION
Upgrade version of vuepress-plugin-meilisearch that introduces the fix to the bad aligned logo on the right bottom corner of the popup.

before
<img width="501" alt="Screenshot 2022-10-31 at 11 07 51" src="https://user-images.githubusercontent.com/33010418/198983793-22109503-658a-4b8c-81a6-78c98f4f432d.png">

after
<img width="499" alt="Screenshot 2022-10-31 at 11 07 43" src="https://user-images.githubusercontent.com/33010418/198983801-f6edb1fe-175b-4535-a962-67331681a405.png">
