### PR TITLE
Add vue3 code-sample

### DIFF
--- a/.vuepress/code-samples/sdks.json
+++ b/.vuepress/code-samples/sdks.json
@@ -87,6 +87,7 @@
   {
     "language": "javascript",
     "cacheableTab": false,
+    "ignoreInSamplesReport": true,
     "label": "Vue3.js",
     "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-vue/main/.code-samples-vue-3.meilisearch.yaml"
   }

--- a/.vuepress/code-samples/sdks.json
+++ b/.vuepress/code-samples/sdks.json
@@ -83,5 +83,11 @@
     "cacheableTab": false,
     "label": "Vue.js",
     "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-vue/main/.code-samples.meilisearch.yaml"
+  },
+  {
+    "language": "javascript",
+    "cacheableTab": false,
+    "label": "Vue3.js",
+    "url": "https://raw.githubusercontent.com/meilisearch/meilisearch-vue/main/.code-samples-vue-3.meilisearch.yaml"
   }
 ]


### PR DESCRIPTION
Vue3 code-sample was asked for and missing in the front-end integration samples. This PR add its.

⚠️ DO NOT MERGE before this PR is merged: https://github.com/meilisearch/meilisearch-vue/pull/121