### PR TITLE
v0.30: New environment variables

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,9 +52,10 @@ jobs:
   vale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
+          version: 2.21.0
           fail_on_error: true
           debug: true
         env:

--- a/learn/advanced/dumps.md
+++ b/learn/advanced/dumps.md
@@ -52,7 +52,7 @@ If a dump file is visible in the file system, the dump process was successfully 
 
 ## Importing a dump
 
-Dump imports must be performed when launching a Meilisearch instance [using the `--import-dump` configuration option](/learn/configuration/instance_options.md#import-dump).
+Import dumps by launching a Meilisearch instance [with the `--import-dump` configuration option](/learn/configuration/instance_options.md#import-dump).
 
 During a dump import, all indexes contained in the indicated `.dump` file are imported along with their associated documents and settings. Any existing index with the same `uid` as an index in the dump file will be overwritten.
 
@@ -68,7 +68,7 @@ For example, you can import a dump from Meilisearch v0.21 into v0.22 without any
 
 ### Importing a dump for v0.21 or above
 
-Once you have exported a dump you will be able to use the `.dump` file to [launch Meilisearch with the `--import-dump` configuration option](/learn/configuration/instance_options.md#import-dump).
+Once you have exported a dump you can use the resulting `.dump` file to [launch Meilisearch with the `--import-dump` configuration option](/learn/configuration/instance_options.md#import-dump).
 
 As the data contained in the dump needs to be indexed, the process will take some time to complete. Only when the dump has been fully imported will the Meilisearch server start, after which you can begin searching through your data.
 

--- a/learn/advanced/dumps.md
+++ b/learn/advanced/dumps.md
@@ -52,7 +52,7 @@ If a dump file is visible in the file system, the dump process was successfully 
 
 ## Importing a dump
 
-Dump imports must be performed when launching a Meilisearch instance [using the `import-dump` command-line option](/learn/configuration/instance_options.md#import-dump).
+Dump imports must be performed when launching a Meilisearch instance [using the `--import-dump` configuration option](/learn/configuration/instance_options.md#import-dump).
 
 During a dump import, all indexes contained in the indicated `.dump` file are imported along with their associated documents and settings. Any existing index with the same `uid` as an index in the dump file will be overwritten.
 
@@ -68,7 +68,7 @@ For example, you can import a dump from Meilisearch v0.21 into v0.22 without any
 
 ### Importing a dump for v0.21 or above
 
-Once you have exported a dump you will be able to use the `.dump` file to [launch Meilisearch with the `--import-dump` command-line flag](/learn/configuration/instance_options.md#import-dump).
+Once you have exported a dump you will be able to use the `.dump` file to [launch Meilisearch with the `--import-dump` configuration option](/learn/configuration/instance_options.md#import-dump).
 
 As the data contained in the dump needs to be indexed, the process will take some time to complete. Only when the dump has been fully imported will the Meilisearch server start, after which you can begin searching through your data.
 

--- a/learn/advanced/snapshots.md
+++ b/learn/advanced/snapshots.md
@@ -6,7 +6,7 @@ Using this feature, it is possible to schedule snapshot creation at custom inter
 
 ## Creating snapshots
 
-For Meilisearch to create snapshots, the feature must be enabled by adding the following flag:
+To create snapshots, use the [`--schedule-snapshot` configuration option](/learn/configuration/instance_options.md#schedule-snapshot-creation):
 
 ```bash
 meilisearch --schedule-snapshot
@@ -14,7 +14,7 @@ meilisearch --schedule-snapshot
 
 By default, Meilisearch creates snapshots in a directory called `snapshots/` at the root of your Meilisearch.
 
-The destination can be modified with the `--snapshot-dir` flag.
+The destination can be modified with [`--snapshot-dir`](/learn/configuration/instance_options.md#snapshot-destination):
 
 ```bash
 meilisearch --schedule-snapshot --snapshot-dir mySnapShots/
@@ -24,7 +24,7 @@ Now snapshots are created in `mySnapShots/` directory.
 
 The first snapshot is created on launching Meilisearch. After that, snapshots are created routinely on a set interval until you deactivate snapshots by ending the Meilisearch instance. By default, one snapshot is taken every 24 hours.
 
-The amount of time between each new snapshot can be modified with the `--snapshot-interval-sec` flag.
+The amount of time between each new snapshot can be modified with [`--snapshot-interval-sec`](/learn/configuration/instance_options.md#snapshot-interval):
 
 ```bash
 meilisearch --schedule-snapshot --snapshot-interval-sec 3600
@@ -32,7 +32,7 @@ meilisearch --schedule-snapshot --snapshot-interval-sec 3600
 
 After running the above code, a snapshot is created every hour (3600 seconds).
 
-During snapshot creation, old snapshots are **automatically overwritten**. This means that only the most recent snapshot should be present in the folder at any given time.
+During snapshot creation, old snapshots are **automatically overwritten**. This means only the most recent snapshot should be present in the folder at any given time.
 
 [[More about snapshots flags and environment variables]](/learn/configuration/instance_options.md#schedule-snapshot-creation)
 

--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -109,7 +109,7 @@ If no master key is provided in a `development` environment, all routes will be 
 ### Disable auto-batching
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_DISABLE_AUTO_BATCHING`
@@ -122,7 +122,7 @@ Deactivates auto-batching when provided.
 ### Disable analytics
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_NO_ANALYTICS`
@@ -161,7 +161,7 @@ _This option is not available as an environment variable._
 ### Ignore missing dump
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_IGNORE_MISSING_DUMP`
@@ -176,7 +176,7 @@ _This option is not available as an environment variable._
 ### Ignore dump if DB exists
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_IGNORE_DUMP_IF_DB_EXISTS`
@@ -277,7 +277,7 @@ Sets the maximum size of [accepted payloads](/learn/core_concepts/documents.md#d
 ### Schedule snapshot creation
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_SCHEDULE_SNAPSHOT`
@@ -326,7 +326,7 @@ _This option is not available as an environment variable._
 ### Ignore missing snapshot
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_IGNORE_MISSING_SNAPSHOT`
@@ -341,7 +341,7 @@ _This option is not available as an environment variable._
 ### Ignore snapshot if DB exists
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_IGNORE_SNAPSHOT_IF_DB_EXISTS`
@@ -400,7 +400,7 @@ Reads DER-encoded OCSP response from OCSPFILE and staple to certificate.
 #### SSL require auth
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_SSL_REQUIRE_AUTH`
@@ -414,7 +414,7 @@ Sends a fatal alert if the client does not complete client authentication.
 #### SSL resumption
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_SSL_RESUMPTION`
@@ -426,7 +426,7 @@ Activates SSL session resumption.
 #### SSL tickets
 
 ::: warning
-🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
+🚩 This option does not take any values. Assigning a value will throw an error. 🚩
 :::
 
 **Environment variable**: `MEILI_SSL_TICKETS`

--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -147,7 +147,7 @@ Sets the directory where Meilisearch will create dump files.
 
 ### Import dump
 
-**Environment variable**: N/A
+**Environment variable**: `MEILI_IMPORT_DUMP`
 **CLI option**: `--import-dump`
 **Default value**: none
 **Expected value**: a filepath pointing to a `.dump` file
@@ -164,7 +164,7 @@ _This option is not available as an environment variable._
 🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
 :::
 
-**Environment variable**: N/A
+**Environment variable**: `MEILI_IGNORE_MISSING_DUMP`
 **CLI option**: `--ignore-missing-dump`
 
 Prevents Meilisearch from throwing an error when `--import-dump` does not point to a valid dump file. Instead, Meilisearch will start normally without importing any dump.
@@ -179,7 +179,7 @@ _This option is not available as an environment variable._
 🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
 :::
 
-**Environment variable**: N/A
+**Environment variable**: `MEILI_IGNORE_DUMP_IF_DB_EXISTS`
 **CLI option**: `--ignore-dump-if-db-exists`
 
 Prevents a Meilisearch instance with an existing database from throwing an error when using `--import-dump`. Instead, the dump will be ignored and Meilisearch will launch using the existing database.
@@ -307,7 +307,7 @@ Defines the interval between each snapshot. Value must be given in seconds.
 
 ### Import snapshot
 
-**Environment variable**: N/A
+**Environment variable**: `MEILI_IMPORT_SNAPSHOT`
 **CLI option**: `--import-snapshot`
 **Default value**: `None`
 **Expected value**: a filepath pointing to a snapshot file
@@ -329,7 +329,7 @@ _This option is not available as an environment variable._
 🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
 :::
 
-**Environment variable**: N/A
+**Environment variable**: `MEILI_IGNORE_MISSING_SNAPSHOT`
 **CLI option**: `--ignore-missing-snapshot`
 
 Prevents a Meilisearch instance from throwing an error when [`--import-snapshot`](#import-snapshot) does not point to a valid snapshot file.
@@ -344,7 +344,7 @@ _This option is not available as an environment variable._
 🚩 This is a CLI flag and does not take any values. Assigning a value will throw an error. 🚩
 :::
 
-**Environment variable**: N/A
+**Environment variable**: `MEILI_IGNORE_SNAPSHOT_IF_DB_EXISTS`
 **CLI option**: `--ignore-snapshot-if-db-exists`
 
 Prevents a Meilisearch instance with an existing database from throwing an error when using `--import-snapshot`. Instead, the snapshot will be ignored and Meilisearch will launch using the existing database.


### PR DESCRIPTION
Closes #1965

Also updates the CLI flags warning box text since the difference between options available to CLI and env vars no longer exists.