### PR TITLE
Add direct download option to quick start installation section

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -52,9 +52,10 @@ jobs:
   vale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
+          version: 2.21.0
           fail_on_error: true
           debug: true
         env:

--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -122,12 +122,22 @@ cargo build --release
 
 To install Meilisearch on Windows, you can:
 
-- use Docker (see "Docker" tab above)
-- [download the latest binary](https://github.com/meilisearch/Meilisearch/releases)
-- use the installation script (see "cURL" tab above) if you have installed [Cygwin](https://www.cygwin.com/), [WSL](https://learn.microsoft.com/en-us/windows/wsl/), or equivalent
-- compile from source (see "Source" tab above)
+- Use Docker (see "Docker" tab above)
+- Download the latest binary (see "Direct download" tab above)
+- Use the installation script (see "cURL" tab above) if you have installed [Cygwin](https://www.cygwin.com/), [WSL](https://learn.microsoft.com/en-us/windows/wsl/), or equivalent
+- Compile from source (see "Source" tab above)
 
 To learn more about the Windows command prompt, follow this [introductory guide](https://www.makeuseof.com/tag/a-beginners-guide-to-the-windows-command-line/).
+
+:::
+
+::: tab Direct download
+
+If none of the other installation options work for you, you can always download the Meilisearch binary directly on GitHub.
+
+Go to the [latest Meilisearch release](https://github.com/meilisearch/meilisearch/releases/latest), scroll down to "Assets", and select the binary corresponding to your operating system.
+
+:::
 
 ::::
 


### PR DESCRIPTION
We received [feedback](https://meilisearch.slack.com/archives/C010VV3SHQF/p1668426724232999) (private link) from a user whose network security blocked all download requests except in-browser ones. This user couldn't figure out how to download Meilisearch based on the quick start docs.

This change should help users in similar situations.