### PR TITLE
Replace Slack links + mentions w/ discord

### DIFF
--- a/.vuepress/config.js
+++ b/.vuepress/config.js
@@ -72,7 +72,7 @@ module.exports = {
         text: 'More Meilisearch',
         items: [
           { text: 'GitHub', link: 'https://github.com/meilisearch/meilisearch' },
-          { text: 'Slack', link: 'https://slack.meilisearch.com' },
+          { text: 'Discord', link: 'https://discord.gg/meilisearch' },
           { text: 'Blog', link: 'https://blog.meilisearch.com/' },
           { text: 'meilisearch.com', link: 'https://meilisearch.com' },
         ],

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -5,7 +5,7 @@ Currently, Meilisearch databases can only be opened by the Meilisearch version y
 If you already have a Meilisearch database with some data you don’t want to lose, you are in the right place!
 
 ::: danger
-This guide does not work for versions below v0.15. For more information, [contact support](https://slack.meilisearch.com/).
+This guide does not work for versions below v0.15. For more information, [contact support](https://discord.gg/meilisearch).
 :::
 
 ## Step 1: Verify your database version

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -144,7 +144,7 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 |  | Meilisearch | Algolia | Typesense | Elasticsearch |
 |---|:---:|:----:|:---:|:---:|
 | Status page | ✅ | ✅ | ✅ | ✅ |
-| Free support channels | Instant messaging / chatbox (2-3h delay),<br> emails, <br> public Slack community, <br> GitHub issues & discussions,<br> Slack Connect | Instant messaging / chatbox, <br> public community forum |  Instant messaging/chatbox (24h-48h delay),<br> public Slack community, <br> GitHub issues. | Public Slack community, <br> public community forum,<br> GitHub issues |
+| Free support channels | Instant messaging / chatbox (2-3h delay),<br> emails, <br> public Discord community, <br> GitHub issues & discussions | Instant messaging / chatbox, <br> public community forum |  Instant messaging/chatbox (24h-48h delay),<br> public Slack community, <br> GitHub issues. | Public Slack community, <br> public community forum,<br> GitHub issues |
 | Paid support channels | _Support is free!_ | Emails | Emails, <br> phone, <br> private Slack | Web support, <br> emails, <br> phone |
 
 ## Approach comparison


### PR DESCRIPTION
Note that I did not replace the "Public Slack community size" row in the comparison to alternatives. I think we should probably wait til our Discord server fills up a bit then change it to just say "Public community size" and replace the number.