### PR TITLE
Replace all Meilisearch Cloud beta typeform links

### DIFF
--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ Looking for SDK documentation? Check out [this list of official Meilisearch libr
 
 ## Meilisearch news
 
-**Announcing Meilisearch Cloud:** Join the closed beta by [filling out this form](https://meilisearch.typeform.com/to/FtnzvZfh), or [log in here](https://cloud.meilisearch.com/login) if you already have an account.
+**Announcing Meilisearch Cloud:** [register now](https://cloud.meilisearch.com/register) or [log in here](https://cloud.meilisearch.com/login) if you already have an account.
 
 **We just raised a 15M Series A! 🥳** Check out the [TechCrunch exclusive](https://techcrunch.com/2022/10/10/meilisearch-lands-15m-investment-to-grow-its-search-as-a-service-business/), or learn more [on our blog](https://blog.meilisearch.com/meilisearch-series-a/).
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.md
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.md
@@ -116,8 +116,8 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 |---|:---:|:----:|:---:|:---:|
 | Self-hosted | ✅  | ❌  | ✅  | ✅ |
 | Official 1-click deploy | ✅ <br> [DigitalOcean](https://marketplace.digitalocean.com/apps/meilisearch) <br> [Platform.sh](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/meilisearch/.platform.template.yaml) | ❌ | 🔶 <br>Only for the cloud-hosted solution | ❌ |
-| Official cloud-hosted solution | [Join the beta](https://meilisearch.typeform.com/to/FtnzvZfh?typeform-source=comparative-table) | ✅ | ✅ | ✅ |
-| High availability | Available with [Meilisearch Cloud](https://meilisearch.typeform.com/to/FtnzvZfh?typeform-source=www.meilisearch.com) | ✅ | ✅ | ✅ |
+| Official cloud-hosted solution | [Meilisearch Cloud](https://cloud.meilisearch.com/register) | ✅ | ✅ | ✅ |
+| High availability | Available with [Meilisearch Cloud](https://cloud.meilisearch.com/register) | ✅ | ✅ | ✅ |
 | Run-time dependencies | None | N/A | None | None |
 | Backward compatibility | ✅ | N/A | ✅ | ✅ |
 | Upgrade path | Documents need to be reindexed | N/A  | Documents need to be reindexed | Documents need to be reindexed |


### PR DESCRIPTION
Replace all Meilisearch Cloud beta typeform links w/ links to the registration page.