### PR TITLE
Use the new latest git tag instead of the stable branch

### DIFF
--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -100,7 +100,7 @@ Choose the release you want to use. You can find the full list [here](https://gi
 In the cloned repository, run the following command to access the most recent version of Meilisearch:
 
 ```bash
-git checkout stable
+git checkout latest
 ```
 
 Finally, update the rust toolchain, compile the project, and execute the binary.


### PR DESCRIPTION
We don't use `stable` git branch anymore, but the `latest` git tag 😇 