### PR TITLE
Make name of section similar to name of option

### DIFF
--- a/learn/advanced/dumps.md
+++ b/learn/advanced/dumps.md
@@ -50,7 +50,7 @@ This command should return an object with detailed information about the dump op
 
 The dump creation process is an asynchronous task that takes time proportional to the size of your dataset. All indexes of the current instance are exported along with their documents and settings and saved as a single `.dump` file.
 
-After dump creation is finished—when `status` is `succeeded`—the dump file is added to the dump directory. By default, this folder is named `dumps` and can be found in the same directory as your Meilisearch binary. You can customize [this using the `--dumps-dir` configuration option](/learn/configuration/instance_options.md#dumps-destination). **If the dump directory does not already exist when the dump creation process is called, Meilisearch will create it.**
+After dump creation is finished—when `status` is `succeeded`—the dump file is added to the dump directory. By default, this folder is named `dumps` and can be found in the same directory as your Meilisearch binary. You can customize [this using the `--dumps-dir` configuration option](/learn/configuration/instance_options.md#dumps-directory). **If the dump directory does not already exist when the dump creation process is called, Meilisearch will create it.**
 
 If a dump file is visible in the file system, the dump process was successfully completed. **Meilisearch will never create a partial dump file**, even if you interrupt an instance while it is generating a dump.
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -131,7 +131,7 @@ Now that all fields are displayed, proceed to the next step.
 
 ## Step 3: Create the dump
 
-Before creating your dump, make sure that your [dump directory](/learn/configuration/instance_options.md#dumps-destination) is somewhere accessible. By default, dumps are created in a folder called `dumps` at the root of your Meilisearch directory.
+Before creating your dump, make sure that your [dump directory](/learn/configuration/instance_options.md#dumps-directory) is somewhere accessible. By default, dumps are created in a folder called `dumps` at the root of your Meilisearch directory.
 
 ::: note
 If you are running Meilisearch in a service using `systemd`, like AWS or a DO droplet, the dumps folder can be found in the configuration file directory, `cd /var/opt/meilisearch/dumps`.

--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -234,7 +234,7 @@ Meilisearch automatically collects data from all instances that do not opt out u
 
 [Read more about our policy on data collection](/learn/what_is_meilisearch/telemetry.md), or take a look at [the comprehensive list of all data points we collect](/learn/what_is_meilisearch/telemetry.md#exhaustive-list-of-all-collected-data).
 
-### Dumps destination
+### Dumps directory
 
 **Environment variable**: `MEILI_DUMPS_DIR`
 **CLI option**: `--dumps-dir`

--- a/reference/api/dump.md
+++ b/reference/api/dump.md
@@ -8,7 +8,7 @@ The `/dumps` route allows the creation of database dumps. Dumps are `.dump` file
 
 <RouteHighlighter method="POST" route="/dumps"/>
 
-Triggers a dump creation task. Once the process is complete, a dump is created in the [dumps directory](/learn/configuration/instance_options.md#dumps-destination). If the dumps directory does not exist yet, it will be created.
+Triggers a dump creation task. Once the process is complete, a dump is created in the [dumps directory](/learn/configuration/instance_options.md#dumps-directory). If the dumps directory does not exist yet, it will be created.
 
 Dump tasks take priority over all other tasks in the queue. This means that a newly created dump task will be processed as soon as the current task is finished.
 


### PR DESCRIPTION
Small, simple change to bring the `Dumps location` section of the instance options page closer to the name of the actual option (`dumps-dir`).