### PR TITLE
No /indexes in swap-indexes endpoint route

### DIFF
--- a/reference/api/indexes.md
+++ b/reference/api/indexes.md
@@ -217,7 +217,7 @@ You can use the response's `taskUid` to [track the status of your request](/refe
 
 ## Swap indexes
 
-<RouteHighlighter method="POST" route="/indexes/swap-indexes"/>
+<RouteHighlighter method="POST" route="/swap-indexes"/>
 
 Swap the documents, settings, and task history of two or more indexes. **You can only swap indexes in pairs.** However, a single request can swap as many index pairs as you wish.
 


### PR DESCRIPTION
Mistake in the `routeHighlighter` element for swap indexes; `/indexes` should not be part of the route.