### PR TITLE
add vale rule for latin terms

### DIFF
--- a/.vale/styles/style_guide/LatinTerms.yml
+++ b/.vale/styles/style_guide/LatinTerms.yml
@@ -1,0 +1,17 @@
+---
+# Error: style_guide.LatinTerms.yml
+
+# Avoid Latin terms like `i.e.` and `e.g.` as everyone does not understand them
+extends: substitution
+message: "Use '%s' instead of '%s', but consider rewriting the sentence."
+link: https://developers.google.com/style/abbreviations#dont-use
+level: warning
+nonword: true
+ignorecase: true
+swap:
+  e\.g\.: for example
+  e\. g\.: for example
+  e\.g: for example
+  i\.e\.: that is
+  i\. e\.: that is
+  i\.e: that is


### PR DESCRIPTION
closes #1974 

Adds Vale rule to replace `i.e` and `e.g` with `that is` and `for example`, respectively. 

## For reviewers
`that is` isn't the best replacement for `i.e`, but most style guides use it. I did add `consider rewriting the sentence` to the error message. Should we go with `meaning` instead?  