### PR TITLE
Update vale action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,6 +55,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
+          version: 2.21.1
           fail_on_error: true
           debug: true
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
-          version: 2.21.0
           fail_on_error: true
           debug: true
         env:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -55,7 +55,6 @@ jobs:
       - uses: actions/checkout@v3
       - uses: errata-ai/vale-action@reviewdog
         with:
-          version: 2.21.1
           fail_on_error: true
           debug: true
         env:

--- a/reference/api/documents.md
+++ b/reference/api/documents.md
@@ -1,6 +1,6 @@
 # Documents
 
-The `/documents` route allows you to create, manage, and delete documents.
+The `/documents` route allows you to create, manage and delete documents.
 
 [Learn more about documents.](/learn/core_concepts/documents.md)
 

--- a/reference/api/documents.md
+++ b/reference/api/documents.md
@@ -1,6 +1,6 @@
 # Documents
 
-The `/documents` route allows you to create, manage and delete documents.
+The `/documents` route allows you to create, manage, and delete documents.
 
 [Learn more about documents.](/learn/core_concepts/documents.md)
 


### PR DESCRIPTION
closing #2014 

We updated the Vale action to use Vale 2.21.0 as the tests failed for Vale 2.21.1 (the latest version at the time of v0.30). It works with the latest version (2.21.3) now, so I'm removing that line