### PR TITLE
update `updating.md`

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -920,15 +920,16 @@ updating_guide_get_displayed_attributes_new: |-
   # whenever you see {index_uid}, replace it with your index's unique id
   curl \
     -X GET 'http://localhost:7700/indexes/{index_uid}/settings/displayed-attributes' \
-    -H 'Authorization: Bearer API_KEY'
+    -H 'X-Meili-API-Key: API_KEY'
 updating_guide_reset_displayed_attributes_new: |-
   curl \
     -X DELETE 'http://localhost:7700/indexes/{index_uid}/settings/displayed-attributes' \
-    -H 'Authorization: Bearer API_KEY'
+    -H 'X-Meili-API-Key: API_KEY'
 updating_guide_create_dump: |-
   curl \
     -X POST 'http://localhost:7700/dumps' \
     -H 'Authorization: Bearer API_KEY'
+  # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
 getting_started_typo_tolerance: |-
   curl \
     -X PATCH 'http://localhost:7700/indexes/movies/settings/typo-tolerance' \

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -930,16 +930,6 @@ updating_guide_create_dump: |-
     -X POST 'http://<your-domain-name>/dumps' \
     -H 'Authorization: Bearer API_KEY'
   # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
-updating_guide_get_update_status: |-
-  # replace {updateId} with the updateId returned by the previous request
-  curl \
-    -X GET 'http://<your-domain-name>/indexes/movies/updates/{updateId}'
-    -H 'X-Meili-API-Key: API_KEY'
-updating_guide_get_dump_status: |-
-  curl \
-    -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
-    -H 'Authorization: Bearer API_KEY' 
-  # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below  
 getting_started_typo_tolerance: |-
   curl \
     -X PATCH 'http://localhost:7700/indexes/movies/settings/typo-tolerance' \

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -910,24 +910,24 @@ settings_guide_typo_tolerance_1: |-
     }'
 updating_guide_check_version_new_authorization_header: |-
   curl \
-    -X GET 'http://localhost:7700/version' \
+    -X GET 'http://<your-domain-name>/version' \
     -H 'Authorization: Bearer API_KEY'
 updating_guide_check_version_old_authorization_header: |-
   curl \
-    -X GET 'http://localhost:7700/version' \
+    -X GET 'http://<your-domain-name>/version' \
     -H 'X-Meili-API-Key: API_KEY'  
 updating_guide_get_displayed_attributes_new: |-
   # whenever you see {index_uid}, replace it with your index's unique id
   curl \
-    -X GET 'http://localhost:7700/indexes/{index_uid}/settings/displayed-attributes' \
+    -X GET 'http://<your-domain-name>/indexes/{index_uid}/settings/displayed-attributes' \
     -H 'X-Meili-API-Key: API_KEY'
 updating_guide_reset_displayed_attributes_new: |-
   curl \
-    -X DELETE 'http://localhost:7700/indexes/{index_uid}/settings/displayed-attributes' \
+    -X DELETE 'http://<your-domain-name>/indexes/{index_uid}/settings/displayed-attributes' \
     -H 'X-Meili-API-Key: API_KEY'
 updating_guide_create_dump: |-
   curl \
-    -X POST 'http://localhost:7700/dumps' \
+    -X POST 'http://<your-domain-name>/dumps' \
     -H 'Authorization: Bearer API_KEY'
   # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
 getting_started_typo_tolerance: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -930,6 +930,16 @@ updating_guide_create_dump: |-
     -X POST 'http://<your-domain-name>/dumps' \
     -H 'Authorization: Bearer API_KEY'
   # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
+updating_guide_get_update_status: |-
+  # replace {updateId} with the updateId returned by the previous request
+  curl \
+    -X GET 'http://<your-domain-name>/indexes/movies/updates/{updateId}'
+    -H 'X-Meili-API-Key: API_KEY'
+updating_guide_get_dump_status: |-
+  curl \
+    -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
+    -H 'Authorization: Bearer API_KEY' 
+  # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below  
 getting_started_typo_tolerance: |-
   curl \
     -X PATCH 'http://localhost:7700/indexes/movies/settings/typo-tolerance' \

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -916,12 +916,12 @@ updating_guide_check_version_old_authorization_header: |-
   curl \
     -X GET 'http://<your-domain-name>/version' \
     -H 'X-Meili-API-Key: API_KEY'  
-updating_guide_get_displayed_attributes_new: |-
+updating_guide_get_displayed_attributes_old_authorization_header: |-
   # whenever you see {index_uid}, replace it with your index's unique id
   curl \
     -X GET 'http://<your-domain-name>/indexes/{index_uid}/settings/displayed-attributes' \
     -H 'X-Meili-API-Key: API_KEY'
-updating_guide_reset_displayed_attributes_new: |-
+updating_guide_reset_displayed_attributes_old_authorization_header: |-
   curl \
     -X DELETE 'http://<your-domain-name>/indexes/{index_uid}/settings/displayed-attributes' \
     -H 'X-Meili-API-Key: API_KEY'

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -139,6 +139,8 @@ updating_guide_check_version_old_authorization_header: |-
 updating_guide_get_displayed_attributes_old_authorization_header: |-
 updating_guide_reset_displayed_attributes_old_authorization_header: |-
 updating_guide_create_dump: |-
+updating_guide_get_update_status: |-
+updating_guide_get_dump_status: |-
 getting_started_typo_tolerance: |-
 settings_guide_pagination_1: |-
 get_pagination_settings_1: |-

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -136,8 +136,8 @@ typo_tolerance_guide_4: |-
 settings_guide_typo_tolerance_1: |-
 updating_guide_check_version_new_authorization_header: |-
 updating_guide_check_version_old_authorization_header: |-
-updating_guide_get_displayed_attributes_new: |-
-updating_guide_reset_displayed_attributes_new: |-
+updating_guide_get_displayed_attributes_old_authorization_header: |-
+updating_guide_reset_displayed_attributes_old_authorization_header: |-
 updating_guide_create_dump: |-
 getting_started_typo_tolerance: |-
 settings_guide_pagination_1: |-

--- a/.vuepress/public/sample-template.yaml
+++ b/.vuepress/public/sample-template.yaml
@@ -139,8 +139,6 @@ updating_guide_check_version_old_authorization_header: |-
 updating_guide_get_displayed_attributes_old_authorization_header: |-
 updating_guide_reset_displayed_attributes_old_authorization_header: |-
 updating_guide_create_dump: |-
-updating_guide_get_update_status: |-
-updating_guide_get_dump_status: |-
 getting_started_typo_tolerance: |-
 settings_guide_pagination_1: |-
 get_pagination_settings_1: |-

--- a/learn/advanced/geosearch.md
+++ b/learn/advanced/geosearch.md
@@ -2,6 +2,10 @@
 
 Meilisearch allows you to filter and sort results based on their geographic location. This can be useful when you only want results within a specific area or when sorting results based on their distance from a specific location.
 
+::: danger `_geo` field in v0.27, v0.28, and v0.29
+Due to Meilisearch allowing malformed `_geo` fields in the above-mentioned versions, please ensure the `_geo` field follows the correct format.
+:::
+
 ## Preparing documents for location-based search
 
 In order to start filtering and sorting documents based on their geographic location, you must make sure they contain a valid `_geo` field.

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -314,7 +314,7 @@ If something went wrong, you can always roll back to the previous version and tr
 
 ### Delete backup files or rollback (_optional_)
 
-Move the files back to their previous location using:
+Delete the Meilisearch binary and `data.ms` folder created in the previous step. Next, move the old files back to their previous location using:
 
 :::: tabs
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -6,7 +6,7 @@ This guide does not work for versions below v0.15. For more information, [contac
 
 Currently, Meilisearch databases can only be opened by the Meilisearch version you used to create them. The following guide will walk you through all the steps to migrate an existing database from an older version of Meilisearch to the most recent one.
 
-If you're updating your Meilisearch instance on cloud platforms like DigitalOcean, AWS, or GCP, ensure that you are able to your cloud instance connect via SSH. Depending on the user you are connecting with (root, admin, etc.), you may need to prefix some commands with `sudo`.
+If you're updating your Meilisearch instance on cloud platforms like DigitalOcean, AWS, or GCP, ensure that you can connect to your cloud instance via SSH. Depending on the user you are connecting with (root, admin, etc.), you may need to prefix some commands with `sudo`.
 
 ::: tip
 If you are using v0.22 or above, use our [migration script](https://github.com/meilisearch/meilisearch-migration) to update to a newer Meilisearch version without losing data or settings.
@@ -14,14 +14,14 @@ If you are using v0.22 or above, use our [migration script](https://github.com/m
 
 ## Step 1: Verify your database version
 
-Before we begin, you need to verify the version of Meilisearch that's compatible with your database, in other words, the version that indexed the data. You can do so by launching a Meilisearch instance:
+Before we begin, you need to verify the version of Meilisearch that's compatible with your database, in other words, the version that indexed the data.
 
-If Meilisearch launches successfully, use the get version endpoint and note your `pkgVersion`:
+Use the get version endpoint to check your Meilisearch version and note your `pkgVersion`:
 
 <CodeSamples id="updating_guide_check_version_new_authorization_header" />
 
 ::: warning
-If Meilisearch returns a [`missing_authorization_header`](/reference/errors/error_codes.md#missing-authorization-header) error code, you might be using v0.24 or below. Change the authorization header to `X-MEILI-API-KEY: apiKey`:
+If Meilisearch returns a [`missing_authorization_header`](/reference/errors/error_codes.md#missing-authorization-header) error code, you might be using v0.24 or below. Change the authorization header to `X-MEILI-API-KEY: API_KEY`:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 :::
@@ -42,70 +42,7 @@ If you get the error `Cannot open database, expected Meilisearch engine version:
 
 In this case, you need to download the compatible version now (`0.X.X` in the above error message) to access and export your database.
 
-:::: tabs
-
-::: tab cURL
-If you downloaded Meilisearch using `curl`, find and download the compatible version [here](https://github.com/meilisearch/meilisearch/releases) before continuing.
-:::
-
-::: tab Homebrew
-
-Replace `0.X.X` with the version you would like to install.
-
-```bash
-brew install meilisearch@0.X.X
-```
-
-:::
-
-::: tab Source
-
-Replace `0.X.X` with the version you would like to install.
-
-```bash
-# clone Meilisearch and checkout the branch of the expected version
-git clone https://github.com/meilisearch/meilisearch
-cd MeiliSearch
-git checkout v0.X.X
-
-# update the rust toolchain to the latest version
-rustup update
-
-# compile the project
-cargo build --release
-
-# execute the server binary
-./target/release/meilisearch
-```
-
-:::
-
-::: tab APT
-
-Replace `0.X.X` with the version you would like to install.
-
-```bash
-apt-get install meilisearch-http=0.X.X
-```
-
-:::
-
-::: tab Docker
-
-Replace `0.X.X` with the version you would like to install.
-
-```bash
-docker run -it --rm \
-    -p 7700:7700 \
-    -v $(pwd)/meili_data:/meili_data \
-    getmeili/meilisearch:v0.X.X
-```
-
-:::
-
-::::
-
-:::note
+::: note
 If you are updating to v0.28, keys imported from the old version will have their `key` and `uid` fields regenerated.
 :::
 
@@ -123,11 +60,11 @@ Start by verifying that all attributes are included in the displayed attributes 
 
 If the response is `{'displayedAttributes': '["*"]'}`, you can move on to the [next step](#step-3-create-the-dump).
 
-If it's something else, save the current list of displayed attributes to restore it after the migration is complete. Next, reset the list of displayed attributes to its default value (["*"]) using:
+If it's something else, save the current list of displayed attributes to restore it after the migration is complete. Next, reset the list of displayed attributes to its default value `(["*"])` using:
 
 <CodeSamples id="updating_guide_reset_displayed_attributes_new" />
 
-This command returns a `updateId`. You can use this to [track the status of the operation](/reference/api/tasks.md#get-one-task). Once the status is `processed`, you're good to go.
+This command returns an `updateId`. You can use this to [track the status of the operation](/reference/api/tasks.md#get-one-task). Once the status is `processed`, you're good to go.
 
 Now that all fields are displayed, proceed to the next step.
 
@@ -136,7 +73,7 @@ Now that all fields are displayed, proceed to the next step.
 Before creating your dump, make sure that your [dump directory](/learn/configuration/instance_options.md#dumps-directory) is somewhere accessible. By default, dumps are created in a folder called `dumps` at the root of your Meilisearch directory.
 
 ::: note
-If you are running Meilisearch in a service using `systemd`, like AWS or a DO droplet, the dumps folder can be found in the configuration file directory, `cd /var/opt/meilisearch/dumps`.
+By default, cloud platforms are configured to store dumps in the `/var/opt/meilisearch/dumps` directory.
 :::
 
 If you're unsure where your Meilisearch directory is located, try this:
@@ -208,7 +145,7 @@ The response will vary slightly depending on your version. For v0.27 and below, 
 
 ```sh
 curl \
-  -X GET /dumps/:dump_uid/status
+  -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
   -H 'Authorization: Bearer API_KEY' 
 # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
 ```
@@ -259,10 +196,11 @@ Move the binary of the current Meilisearch version and the database to the `tmp/
 
 :::: tabs
 
-::: tab Meilisearch instance
+::: tab Local installation
 
 ```
-
+mv /path/to/your/meilisearch/directory/meilisearch /tmp
+mv /path/to/your/meilisearch/directory/meilisearch/data.ms /tmp/
 ```
 
 :::
@@ -284,9 +222,9 @@ Install the latest version of Meilisearch using:
 
 :::: tabs
 
-::: tab Meilisearch instance
+::: tab Local installation
 
-```
+```bash
 # Install Meilisearch
 curl -L https://install.meilisearch.com | sh
 
@@ -325,10 +263,10 @@ Execute the command below to import the dump at launch:
 
 :::: tabs
 
-::: tab Meilisearch instance
+::: tab Local installation
 
 ```bash
-# launch the latest version of Meilisearch with the master key and import the specified dump file
+# replace {dump_uid.dump} with the name of your dump file
 ./meilisearch --import-dump /dumps/{your_dump_file.dump} --master-key="MASTER_KEY"
 ```
 
@@ -378,16 +316,49 @@ rm -r /tmp/data.ms
 
 You can also delete the dump file using:
 
+:::: tabs
+
+::: tab Local installation
+
+```
+rm /path/to/your/meilisearch/directory/meilisearch/dumps/{dump_uid.dump}
+```
+
+:::
+
+::: tab Cloud platforms
+
 ```
 rm /var/opt/meilisearch/dumps/{dump_uid.dump}
 ```
 
+:::
+
+::::
+
 If for some reason, something went wrong, you can always roll back to the previous version. Move the files back to their previous location using:
+
+:::: tabs
+
+::: tab Local installation
+
+```
+mv /tmp/meilisearch /path/to/your/meilisearch/directory/meilisearch
+mv /tmp/data.ms /path/to/your/meilisearch/directory/meilisearch/data.ms
+```
+
+:::
+
+::: tab Cloud platforms
 
 ```
 mv /tmp/meilisearch /usr/bin/meilisearch
 mv /tmp/data.ms /var/lib/meilisearch/data.ms
 ```
+
+:::
+
+::::
 
 And run the configuration script:
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -14,7 +14,7 @@ If you are using v0.22 or above, use our [migration script](https://github.com/m
 
 ## Step 1: Verify your database version
 
-Before we begin, you need to verify the version of Meilisearch that's compatible with your database. Use the get version endpoint and note your `pkgVersion`:
+First, verify the version of Meilisearch that's compatible with your database using the get version endpoint:
 
 <CodeSamples id="updating_guide_check_version_new_authorization_header" />
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -4,7 +4,7 @@
 This guide does not work for versions below v0.15. For more information, [contact support](https://discord.gg/meilisearch).
 :::
 
-Currently, Meilisearch databases can only be safely opened by the Meilisearch version you used to create them. The following guide will walk you through all the steps to migrate an existing database from an older version of Meilisearch to the most recent one.
+Currently, Meilisearch databases are only compatible with the version of Meilisearch used to create them. The following guide will walk you through using a [dump](/learn/advanced/dumps.md) to migrate an existing database from an older version of Meilisearch to the most recent one.
 
 If you're updating your Meilisearch instance on cloud platforms like DigitalOcean, AWS, or GCP, ensure that you can connect to your cloud instance via SSH. Depending on the user you are connecting with (root, admin, etc.), you may need to prefix some commands with `sudo`.
 
@@ -54,7 +54,7 @@ Start by verifying that all attributes are included in the displayed attributes 
 
 If the response is `{'displayedAttributes': '["*"]'}`, you can move on to the [next step](#step-3-create-the-dump).
 
-If it's something else, save the current list of displayed attributes to restore it after the migration is complete. Next, reset the list of displayed attributes to its default value `(["*"])` using:
+If the response is anything else, save the current list of displayed attributes in a text file and then reset the displayed attributes list to its default value `(["*"])`:
 
 <CodeSamples id="updating_guide_reset_displayed_attributes_old_authorization_header" />
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -72,7 +72,7 @@ This command returns an `updateId`. Use the get update endpoint to track the sta
  # replace {indexUid} with the uid of your index and {updateId} with the updateId returned by the previous request
   curl \
     -X GET 'http://<your-domain-name>/indexes/{indexUid}/updates/{updateId}'
-    -H 'X-MEILI-API-Key: API_KEY'
+    -H 'X-Meili-API-Key: API_KEY'
 ```
 
 Once the status is `processed`, you're good to go. Repeat this process for all indexes, then move on to creating your dump.
@@ -156,7 +156,7 @@ The response will vary slightly depending on your version. For v0.27 and below, 
   curl \
     -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
     -H 'Authorization: Bearer API_KEY' 
-  # -H 'X-MEILI-API-Key: API_KEY' for v0.24 or below
+  # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
 ```
 
 :::
@@ -204,8 +204,8 @@ Move the binary of the current Meilisearch installation and database to the `/tm
 ::: tab Local installation
 
 ```
-mv /path/to/your/meilisearch/directory/meilisearch /tmp
-mv /path/to/your/meilisearch/directory/data.ms /tmp/
+mv /path/to/your/meilisearch/directory/meilisearch/data.ms /tmp/
+mv /path/to/your/meilisearch/directory/meilisearch /tmp/
 ```
 
 :::
@@ -213,7 +213,7 @@ mv /path/to/your/meilisearch/directory/data.ms /tmp/
 ::: tab Cloud platforms
 
 ```
-mv /usr/bin/meilisearch /tmp
+mv /usr/bin/meilisearch /tmp/
 mv /var/lib/meilisearch/data.ms /tmp/
 ```
 
@@ -314,7 +314,7 @@ If something went wrong, you can always roll back to the previous version and tr
 
 ### Delete backup files or rollback (_optional_)
 
-Delete the Meilisearch binary and `data.ms` folder created in the previous step. Next, move the old files back to their previous location using:
+Delete the Meilisearch binary and `data.ms` folder created by the previous steps. Next, move the backup files back to their previous location using:
 
 :::: tabs
 
@@ -322,7 +322,7 @@ Delete the Meilisearch binary and `data.ms` folder created in the previous step.
 
 ```
 mv /tmp/meilisearch /path/to/your/meilisearch/directory/meilisearch
-mv /tmp/data.ms /path/to/your/meilisearch/directory/data.ms
+mv /tmp/data.ms /path/to/your/meilisearch/directory/meilisearch/data.ms
 ```
 
 :::

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -16,11 +16,11 @@ Before we begin, you need to verify the version of Meilisearch that's compatible
 ./meilisearch --master-key="MASTER_KEY"
 ```
 
-If Meilisearch launches successfully, use the get version endpoint, note your `pkgVersion`, and [proceed to the next step](#step-2-set-all-fields-as-displayed-attributes).
+If Meilisearch launches successfully, use the get version endpoint and note your `pkgVersion`:
 
 <CodeSamples id="updating_guide_check_version_new_authorization_header" />
 
-::: note
+::: warning
 If Meilisearch returns a [`missing_authorization_header`](/reference/errors/error_codes.md#missing-authorization-header) error code, you might be using v0.24 or below. Change the authorization header to `X-MEILI-API-KEY: apiKey`:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
@@ -35,6 +35,8 @@ The response should look something like this:
   "pkgVersion": "x.y.z"
 }
 ```
+
+If your `pkgVersion` is 0.21 or above, you can jump to [step 3](#step-3-create-the-dump). If not, proceed to the next step.
 
 If you get the error `Cannot open database, expected Meilisearch engine version: 0.X.X, current engine version 0.Y.Y`, your database is not compatible with the currently installed Meilisearch version.
 
@@ -125,7 +127,7 @@ If it's something else, then you need to reset the list of displayed attributes.
 
 <CodeSamples id="updating_guide_reset_displayed_attributes_new" />
 
-This command returns a `taskUid`. You can use this to [track the status of the operation](/reference/api/tasks.md#get-one-task). Once the status is `succeeded`, you're good to go.
+This command returns a `updateId`. You can use this to [track the status of the operation](/reference/api/tasks.md#get-one-task). Once the status is `processed`, you're good to go.
 
 Now that all fields are displayed, proceed to the next step.
 
@@ -245,11 +247,13 @@ Now that you’ve got your dump, install the [latest version of Meilisearch](/le
 
 ```bash
 # launch the latest version of Meilisearch with the master key and import the specified dump file
-./meilisearch --import-dump /dumps/your_dump_file.dump --master-key="MASTER_KEY"
+./meilisearch --import-dump /dumps/{your_dump_file.dump} --master-key="MASTER_KEY"
 ```
 
 ::: warning
 If you are using Meilisearch v0.20 or below, migration should be done in two steps. First, import your dump into an instance running any version of Meilisearch from v0.21 to v0.24, inclusive. Second, export another dump from this instance and import it to a final instance running your targeted version.
+
+This two-step process won't be necessary with v1.
 :::
 
 Importing a dump requires indexing all the documents it contains. Depending on the size of your dataset, this process can take a long time and cause a spike in memory usage.

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -60,12 +60,7 @@ If it's something else, save the current list of displayed attributes to restore
 
 This command returns an `updateId`. Use the get update endpoint to track the status of the operation:
 
-```sh
-# replace {updateId} with the updateId returned by the previous request
-curl \
-    -X GET 'http://localhost:7700/indexes/movies/updates/{updateId}'
-    -H 'X-Meili-API-Key: API_KEY'
-```
+<CodeSamples id="updating_guide_get_update_status" />
 
 Once the status is `processed`, you're good to go.
 
@@ -146,12 +141,7 @@ Use the `taskUid` to [track the status](/reference/api/tasks.md#get-one-task) of
 ::: note
 The response will vary slightly depending on your version. For v0.27 and below, the response returns a dump `uid`. You can track the status of the dump using the get dumps status endpoint:
 
-```sh
-curl \
-  -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
-  -H 'Authorization: Bearer API_KEY' 
-# -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
-```
+<CodeSamples id="updating_guide_get_dump_status" />
 
 :::
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -20,7 +20,7 @@ This guide only works for versions v0.15 and above. If you are using an older ve
 
 This section contains instructions for upgrading from specific versions. Most versions don't require version-specific steps and you should be able to upgrade directly. If the version you are upgrading from isn't listed here, no additional steps are required.
 
-- If you are using **v0.24 or below**, use the `X-MEILI-API-Key: API_KEY` authorization header:
+- If you are using **v0.24 or below**, use the `X-Meili-API-Key: API_KEY` authorization header:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -20,7 +20,7 @@ This guide only works for versions v0.15 and above. If you are using an older ve
 
 This section contains instructions for upgrading from specific versions. Most versions don't require version-specific steps and you should be able to upgrade directly. If the version you are upgrading from isn't listed here, no additional steps are required.
 
-- If you are using **v0.24 or below**, use the `X-MEILI-API-KEY: API_KEY` authorization header:
+- If you are using **v0.24 or below**, use the `X-MEILI-API-Key: API_KEY` authorization header:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 
@@ -72,7 +72,7 @@ This command returns an `updateId`. Use the get update endpoint to track the sta
  # replace {indexUid} with the uid of your index and {updateId} with the updateId returned by the previous request
   curl \
     -X GET 'http://<your-domain-name>/indexes/{indexUid}/updates/{updateId}'
-    -H 'X-Meili-API-Key: API_KEY'
+    -H 'X-MEILI-API-Key: API_KEY'
 ```
 
 Once the status is `processed`, you're good to go. Repeat this process for all indexes, then move on to creating your dump.
@@ -156,7 +156,7 @@ The response will vary slightly depending on your version. For v0.27 and below, 
   curl \
     -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
     -H 'Authorization: Bearer API_KEY' 
-  # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
+  # -H 'X-MEILI-API-Key: API_KEY' for v0.24 or below
 ```
 
 :::
@@ -205,7 +205,7 @@ Move the binary of the current Meilisearch installation and database to the `/tm
 
 ```
 mv /path/to/your/meilisearch/directory/meilisearch /tmp
-mv /path/to/your/meilisearch/directory/meilisearch/data.ms /tmp/
+mv /path/to/your/meilisearch/directory/data.ms /tmp/
 ```
 
 :::
@@ -220,8 +220,6 @@ mv /var/lib/meilisearch/data.ms /tmp/
 :::
 
 ::::
-
-## Step 3: Import data
 
 ### Install the desired version of Meilisearch
 
@@ -266,6 +264,8 @@ If you are using Meilisearch v0.20 or below, migration should be done in two ste
 Once Meilisearch v1 is released, this two-step process won't be necessary as v1 will be compatible with dumps from all previous versions.
 :::
 
+## Step 3: Import data
+
 ### Launch Meilisearch and import the dump
 
 Execute the command below to import the dump at launch:
@@ -308,12 +308,11 @@ If required, set `displayedAttributes` back to its previous value using the [upd
 
 Now that your updated Meilisearch instance is up and running, verify that the dump import was successful and no data was lost.
 
-If everything looks good, then congratulations! You successfully migrated your database to the latest version of Meilisearch. Be sure to check out the [changelogs]().
+If everything looks good, then congratulations! You successfully migrated your database to the latest version of Meilisearch. Be sure to check out the [changelogs](https://github.com/meilisearch/MeiliSearch/releases).
 
 If something went wrong, you can always roll back to the previous version and try again. Be sure to check out the [version-specific update instructions](#version-specific-update-instructions), and feel free to [reach out for help](https://discord.gg/meilisearch) if the problem continues.
 
 ### Delete backup files or rollback (_optional_)
-
 
 Move the files back to their previous location using:
 
@@ -323,7 +322,7 @@ Move the files back to their previous location using:
 
 ```
 mv /tmp/meilisearch /path/to/your/meilisearch/directory/meilisearch
-mv /tmp/data.ms /path/to/your/meilisearch/directory/meilisearch/data.ms
+mv /tmp/data.ms /path/to/your/meilisearch/directory/data.ms
 ```
 
 :::

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -64,6 +64,7 @@ This command returns an `updateId`. Use the get update endpoint to track the sta
 # replace {updateId} with the updateId returned by the previous request
 curl \
     -X GET 'http://localhost:7700/indexes/movies/updates/{updateId}'
+    -H 'X-Meili-API-Key: API_KEY'
 ```
 
 Once the status is `processed`, you're good to go.
@@ -160,6 +161,16 @@ Once the `dumpCreation` task shows `"status": "succeeded"`, you're ready to move
 
 Stop your Meilisearch instance.
 
+:::: tabs
+
+::: tab Local installation
+
+If you're running Meilisearch locally, you can stop the program with `Ctrl + c`.
+
+:::
+
+::: tab Cloud platforms
+
 If you're running Meilisearch as a `systemctl` service, connect via SSH to your cloud instance and execute the following command to stop Meilisearch:
 
 ```bash
@@ -168,7 +179,9 @@ systemctl stop meilisearch
 
 You may need to prefix the above command with `sudo` if you are not connected as root.
 
-If you're running Meilisearch locally, you can stop the program with `Ctrl + c`.
+:::
+
+::::
 
 ## Step 5: Create a backup
 
@@ -211,11 +224,7 @@ Install the latest version of Meilisearch using:
 ::: tab Local installation
 
 ```bash
-# Install Meilisearch
 curl -L https://install.meilisearch.com | sh
-
-# Launch Meilisearch
-./meilisearch
 ```
 
 :::
@@ -259,7 +268,7 @@ Execute the command below to import the dump at launch:
 
 ```bash
 # replace {dump_uid.dump} with the name of your dump file
-./meilisearch --import-dump /dumps/{dump_uid.dump} --master-key="MASTER_KEY"
+./meilisearch --import-dump dumps/{dump_uid.dump} --master-key="MASTER_KEY"
 ```
 
 :::
@@ -283,7 +292,7 @@ You might not be able to import your dump due to Meilisearch due to an error aff
 
 ## Step 8: Restart Meilisearch as a service
 
-Once your dump has been correctly imported, press `Ctrl`+`C`  to stop Meilisearch. Next, execute the following command to run the script to configure Meilisearch and restart it as a service:
+If you're running a cloud instance, press `Ctrl`+`C`  to stop Meilisearch once your dump has been correctly imported. Next, execute the following command to run the script to configure Meilisearch and restart it as a service:
 
 ```
 meilisearch-setup
@@ -319,7 +328,7 @@ mv /tmp/data.ms /var/lib/meilisearch/data.ms
 
 ::::
 
-And run the configuration script:
+And run the configuration script at the root of your Meilisearch directory:
 
 ```
 meilisearch-setup

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -26,7 +26,7 @@ This section contains instructions for upgrading from specific versions. Most ve
 
 - You might not be able to import your dump due to Meilisearch due to an error affecting `_geo` fields in **v0.27, v0.28, and v0.29**. Please ensure the `_geo` field follows the [correct format](/learn/advanced/geosearch.md#preparing-documents-for-location-based-search).
 
-- If you are **updating to v0.28 or above**, keys imported from the old version will have their `key` and `uid` fields regenerated
+- If you are **updating to v0.28 or above**, existing keys will have their `key` and `uid` fields regenerated
 
 ## Step 1: Export data
 
@@ -76,7 +76,7 @@ Once the status is `processed`, you're good to go.
 
 Before creating your dump, make sure that your [dump directory](/learn/configuration/instance_options.md#dumps-directory) is somewhere accessible. By default, dumps are created in a folder called `dumps` at the root of your Meilisearch directory.
 
-**Cloud platforms** like  DigitalOcean, AWS, and GCP are configured to store dumps in the `/var/opt/meilisearch/dumps` directory.
+**Cloud platforms** like DigitalOcean, AWS, and GCP are configured to store dumps in the `/var/opt/meilisearch/dumps` directory.
 
 If you're unsure where your Meilisearch directory is located, try this:
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -9,7 +9,7 @@ Currently, Meilisearch databases are only compatible with the version of Meilise
 If you're updating your Meilisearch instance on cloud platforms like DigitalOcean, AWS, or GCP, ensure that you can connect to your cloud instance via SSH. Depending on the user you are connecting with (root, admin, etc.), you may need to prefix some commands with `sudo`.
 
 ::: tip
-If you are using v0.22 or above, use our [migration script](https://github.com/meilisearch/meilisearch-migration).
+If you are running Meilisearch as a `systemctl` service using v0.22 or above, try our [migration script](https://github.com/meilisearch/meilisearch-migration).
 :::
 
 ::: danger
@@ -24,9 +24,9 @@ This section contains instructions for upgrading from specific versions. Most ve
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 
-- You might not be able to import your dump due to Meilisearch due to an error affecting `_geo` fields in **v0.27, v0.28, and v0.29**. Please ensure the `_geo` field follows the [correct format](/learn/advanced/geosearch.md#preparing-documents-for-location-based-search).
+- Due to an error affecting `_geo` fields in Meilisearch **v0.27, v0.28, and v0.29**, you might not be able to import your dump. Please ensure the `_geo` field follows the [correct format](/learn/advanced/geosearch.md#preparing-documents-for-location-based-search) before creating your dump.
 
-- If you are **updating to v0.28 or above**, existing keys will have their `key` and `uid` fields regenerated
+- If you are **updating to v0.28 or above**, existing keys will have their `key` and `uid` fields regenerated.
 
 ## Step 1: Export data
 
@@ -51,7 +51,7 @@ If your [`pkgVersion`](/reference/api/version.md#version-object) is 0.21 or abov
 ### Set all fields as displayed attributes
 
 ::: note
-If your dump was created in Meilisearch v0.21 or above, continue to the [next step](#create-the-dump).
+If your dump was created in Meilisearch v0.21 or above, [skip this step](#create-the-dump).
 :::
 
 When creating dumps using Meilisearch versions below v0.21, all fields must be [displayed](/learn/configuration/displayed_searchable_attributes.md#displayed-fields) in order to be saved in the dump.
@@ -60,7 +60,7 @@ Start by verifying that all attributes are included in the displayed attributes 
 
 <CodeSamples id="updating_guide_get_displayed_attributes_old_authorization_header" />
 
-If the response is `{'displayedAttributes': '["*"]'}`, you can move on to the [next step](#create-the-dump).
+If the response for all indexes is `{'displayedAttributes': '["*"]'}`, you can move on to the [next step](#create-the-dump).
 
 If the response is anything else, save the current list of displayed attributes in a text file and then reset the displayed attributes list to its default value `(["*"])`:
 
@@ -69,13 +69,13 @@ If the response is anything else, save the current list of displayed attributes 
 This command returns an `updateId`. Use the get update endpoint to track the status of the operation:
 
 ```sh
- # replace {updateId} with the updateId returned by the previous request
+ # replace {indexUid} with the uid of your index and {updateId} with the updateId returned by the previous request
   curl \
-    -X GET 'http://<your-domain-name>/indexes/movies/updates/{updateId}'
+    -X GET 'http://<your-domain-name>/indexes/{indexUid}/updates/{updateId}'
     -H 'X-Meili-API-Key: API_KEY'
 ```
 
-Once the status is `processed`, you're good to go.
+Once the status is `processed`, you're good to go. Repeat this process for all indexes, then move on to creating your dump.
 
 ### Create the dump
 
@@ -193,7 +193,7 @@ You may need to prefix the above command with `sudo` if you are not connected as
 
 ### Create a backup
 
-Instead of deleting `data.ms`, we suggest creating a backup in case something goes wrong. `data.ms` should be at the root of the Meilisearch binary, unless you chose [another location](/learn/configuration/instance_options.md#database-path).
+Instead of deleting `data.ms`, we suggest creating a backup in case something goes wrong. `data.ms` should be at the root of the Meilisearch binary unless you chose [another location](/learn/configuration/instance_options.md#database-path).
 
 On **cloud platforms**, you will find the `data.ms` folder at `/var/lib/meilisearch/data.ms`.
 
@@ -254,7 +254,7 @@ Give execute permission to the Meilisearch binary:
 chmod +x meilisearch
 ```
 
-For **cloud platforms**, move the new Meilisearch binary to the `/usr/bin` directory containing the executable files:
+For **cloud platforms**, move the new Meilisearch binary to the `/usr/bin` directory:
 
 ```
 mv meilisearch /usr/bin/meilisearch
@@ -304,11 +304,18 @@ meilisearch-setup
 
 If required, set `displayedAttributes` back to its previous value using the [update displayed attributes endpoint](/reference/api/settings.md#update-displayed-attributes).
 
-### Delete backup files or rollback (_optional_)
+## Conclusion
 
 Now that your updated Meilisearch instance is up and running, verify that the dump import was successful and no data was lost.
 
-If for some reason, something went wrong, you can always roll back to the previous version. Move the files back to their previous location using:
+If everything looks good, then congratulations! You successfully migrated your database to the latest version of Meilisearch. Be sure to check out the [changelogs]().
+
+If something went wrong, you can always roll back to the previous version and try again. Be sure to check out the [version-specific update instructions](#version-specific-update-instructions), and feel free to [reach out for help](https://discord.gg/meilisearch) if the problem continues.
+
+### Delete backup files or rollback (_optional_)
+
+
+Move the files back to their previous location using:
 
 :::: tabs
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -68,7 +68,12 @@ If the response is anything else, save the current list of displayed attributes 
 
 This command returns an `updateId`. Use the get update endpoint to track the status of the operation:
 
-<CodeSamples id="updating_guide_get_update_status" />
+```sh
+ # replace {updateId} with the updateId returned by the previous request
+  curl \
+    -X GET 'http://<your-domain-name>/indexes/movies/updates/{updateId}'
+    -H 'X-Meili-API-Key: API_KEY'
+```
 
 Once the status is `processed`, you're good to go.
 
@@ -147,7 +152,12 @@ Use the `taskUid` to [track the status](/reference/api/tasks.md#get-one-task) of
 ::: note
 The response will vary slightly depending on your version. For v0.27 and below, the response returns a dump `uid`. You can track the status of the dump using the get dumps status endpoint:
 
-<CodeSamples id="updating_guide_get_dump_status" />
+```sh
+  curl \
+    -X GET 'http://<your-domain-name>/dumps/:dump_uid/status'
+    -H 'Authorization: Bearer API_KEY' 
+  # -H 'X-Meili-API-Key: API_KEY' for v0.24 or below
+```
 
 :::
 


### PR DESCRIPTION
closes https://github.com/meilisearch/documentation/issues/1849 and https://github.com/meilisearch/documentation/issues/1583

- This is a three-step guide with sub-headings for the other steps
- Added a heading on "version-specific instructions" at the beginning of the guide
- Used bold for cloud platforms to help it stand out
- For this version of the guide, old versions will only have curl code samples
<hr>

- Update code samples to use `X-Meili-API-Key: API_KEY` for v0.24 and below
- Update the "Set all fields as displayed attributes" step to 
   - use `updateId` instead of `taskUid`
   - use `processed` instead of `succeeded`
- Use {} for dumpfile in the "create dump" step
- Update note to mention v1 
- add content for updating Meilisearch on cloud platforms
  - add tabs for local installation and cloud platforms for code samples
  - update code samples to use `<your-domain-name>` instead of `local host` 