### PR TITLE
Fix cURL code-sample where POST method was in lowercase

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -932,7 +932,7 @@ search_parameter_guide_matching_strategy_2: |
     }'    
 date_guide_index_1: |
   curl \
-    -x post 'http://localhost:7700/indexes/games/documents' \
+    -x POST 'http://localhost:7700/indexes/games/documents' \
     -h 'content-type: application/json' \
     --data-binary @games.json
 date_guide_filterable_attributes_1: |


### PR DESCRIPTION
The `date_guide_index_1` code sample method flag is set as `post`, but it should be uppercased `POST`. 



https://github.com/meilisearch/documentation/blob/fc03ae707cb7890a0ce11be15165205234e26cee/.code-samples.meilisearch.yaml#L933-L937