### PR TITLE
rename style guide to Meilisearch

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -4,4 +4,4 @@ MinAlertLevel = suggestion
 Vocab = word_list 
 
 [*.md]
-BasedOnStyles = style_guide
+BasedOnStyles = Meilisearch

--- a/.vale/styles/Meilisearch/British.yml
+++ b/.vale/styles/Meilisearch/British.yml
@@ -1,5 +1,5 @@
 ---
-# Suggestion: style_guide.British.yml
+# Suggestion: Meilisearch.British.yml
 # Checks for American  spelling
 #
 extends: substitution

--- a/.vale/styles/Meilisearch/FirstPerson.yml
+++ b/.vale/styles/Meilisearch/FirstPerson.yml
@@ -1,5 +1,5 @@
 ---
-# Suggestion: style_guide.FirstPerson
+# Suggestion: Meilisearch.FirstPerson
 
 # We want to avoid using singular first person pronouns
 extends: existence

--- a/.vale/styles/Meilisearch/Headings.yml
+++ b/.vale/styles/Meilisearch/Headings.yml
@@ -1,5 +1,5 @@
 ---
-# Suggestion: style_guide.Headings.yml
+# Suggestion: Meilisearch.Headings.yml
 
 # Our headings should use sentence-style capitalization. The exceptions include any headings that maybe a list, start with "Step 1: Do this", and the list of words below
 extends: capitalization

--- a/.vale/styles/Meilisearch/Indexing.yml
+++ b/.vale/styles/Meilisearch/Indexing.yml
@@ -1,5 +1,5 @@
 ---
-# Error: style_guide.indexing.yml
+# Error: Meilisearch.indexing.yml
 
 # Most dictionaries still list "indexation" as a term with a very specific meaning in economy so we should use “indexing”
 extends: substitution

--- a/.vale/styles/Meilisearch/LatinTerms.yml
+++ b/.vale/styles/Meilisearch/LatinTerms.yml
@@ -1,5 +1,5 @@
 ---
-# Error: style_guide.LatinTerms.yml
+# Error: Meilisearch.LatinTerms.yml
 
 # Avoid Latin terms like `i.e.` and `e.g.` as everyone does not understand them
 extends: substitution

--- a/.vale/styles/Meilisearch/MergeConflictMarkers.yml
+++ b/.vale/styles/Meilisearch/MergeConflictMarkers.yml
@@ -1,5 +1,5 @@
 ---
-# Error: style_guide.MergeConflictMarkers.yml
+# Error: Meilisearch.MergeConflictMarkers.yml
 
 # Checks for the presence of merge conflict markers.
 extends: existence

--- a/.vale/styles/Meilisearch/OxfordComma.yml
+++ b/.vale/styles/Meilisearch/OxfordComma.yml
@@ -1,5 +1,5 @@
 ---
-# Suggestion: style_guide.OxfordComma.yml
+# Suggestion: Meilisearch.OxfordComma.yml
 
 # Use the Oxford comma, this may not work as intended for complex sentences with many commas
 extends: existence

--- a/.vale/styles/Meilisearch/Periods.yml
+++ b/.vale/styles/Meilisearch/Periods.yml
@@ -1,5 +1,5 @@
 ---
-# Suggestion: style_guide.Period.yml
+# Suggestion: Meilisearch.Period.yml
 
 # Don't use periods with acronyms. "H.T.M.L" is incorrect, HTML isn't
 

--- a/.vale/styles/Meilisearch/Repetition.yml
+++ b/.vale/styles/Meilisearch/Repetition.yml
@@ -1,5 +1,5 @@
 ---
-# Error: style_guide.Repetition.yml
+# Error: Meilisearch.Repetition.yml
 
 # catch any instances of repeated words. E.g., "This is is a sentence"
 extends: repetition

--- a/.vale/styles/Meilisearch/Semicolons.yml
+++ b/.vale/styles/Meilisearch/Semicolons.yml
@@ -1,5 +1,5 @@
 ---
-# Suggestion: style_guide.Semicolons.yml
+# Suggestion: Meilisearch.Semicolons.yml
 
 # If your sentence uses a semicolon, you should break it into two sentences or rewrite it to avoid super long sentences.
 extends: existence

--- a/.vale/styles/Meilisearch/SentenceLength.yml
+++ b/.vale/styles/Meilisearch/SentenceLength.yml
@@ -1,7 +1,7 @@
 ---
-# Warning: style_guide.SentenceLength
+# Warning: Meilisearch.SentenceLength
 
-# Counts words in a sentence and alerts if a sentence exceeds 42 words.
+# Counts words in a sentence and alerts if a sentence exceeds 40 words.
 extends: occurrence
 message: 'Shorter sentences improve readability (max 40 words).'
 scope: sentence

--- a/.vale/styles/Meilisearch/Spacing.yml
+++ b/.vale/styles/Meilisearch/Spacing.yml
@@ -1,5 +1,5 @@
 ---
-# Error: style_guide.Spacing.yml
+# Error: Meilisearch.Spacing.yml
 
 # Use a space between words, sentences, and punctuation marks
 extends: existence

--- a/.vale/styles/Meilisearch/Spelling.yml
+++ b/.vale/styles/Meilisearch/Spelling.yml
@@ -1,5 +1,5 @@
 ---
-# Warning: style_guide.Spelling.yml
+# Warning: Meilisearch.Spelling.yml
 
 # Checks if your words exist in the dictionary. Any exceptions (including Meilisearch) should be defined in `styles/Vocab/word_list/accept.txt`
 extends: spelling

--- a/.vale/styles/Meilisearch/Typos.yml
+++ b/.vale/styles/Meilisearch/Typos.yml
@@ -1,5 +1,5 @@
 ---
-# Error: style_guide.Typos.yml
+# Error: Meilisearch.Typos.yml
 
 # Lists any possible typos and the correct spelling 
 extends: substitution

--- a/.vale/styles/Meilisearch/URLFormat.yml
+++ b/.vale/styles/Meilisearch/URLFormat.yml
@@ -1,5 +1,5 @@
 ---
-# Warning: style_guide.URLFormat.yml
+# Warning: Meilisearch.URLFormat.yml
 
 # Use "a URL"/"an HTML" instead of "an URL"/"a HTML"
 extends: substitution


### PR DESCRIPTION
Our style is currently called `style_guide`. This PR renames it to Meilisearch.

- Updates all rule files to rename the suggestion/warning/error from `style_guide.rule_name.yml` to `Meilisearch.rule_name.yml`
- Updates the style guide name in `vale.ini`
- Fixes typo in SentenceLength.yml