### PR TITLE
sorting accented characters

### DIFF
--- a/learn/advanced/sorting.md
+++ b/learn/advanced/sorting.md
@@ -16,6 +16,10 @@ To allow your users to sort results at search time you must:
 2. Add those attributes to the `sortableAttributes` index setting
 3. Update Meilisearch's [ranking rules](/learn/core_concepts/relevancy.md) (optional)
 
+::: note
+Meilisearch sorts strings in lexicographic order based on their byte values. This means, `á` which has a value of 225, will be sorted after `z`, which has a value of 122.  
+:::
+
 ### Select attributes for sorting
 
 Meilisearch allows you to sort results based on document fields. Only fields containing numbers, strings, arrays of numeric values, and arrays of string values can be used for sorting.

--- a/learn/advanced/sorting.md
+++ b/learn/advanced/sorting.md
@@ -17,7 +17,7 @@ To allow your users to sort results at search time you must:
 3. Update Meilisearch's [ranking rules](/learn/core_concepts/relevancy.md) (optional)
 
 ::: note
-Documents used for sort are converted to lowercase and then sorted in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
+Meilisearch converts documents to lowercase for sorting, they remain unchanged in the results. They are then sorted in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
 :::
 
 ### Select attributes for sorting

--- a/learn/advanced/sorting.md
+++ b/learn/advanced/sorting.md
@@ -17,7 +17,7 @@ To allow your users to sort results at search time you must:
 3. Update Meilisearch's [ranking rules](/learn/core_concepts/relevancy.md) (optional)
 
 ::: note
-Meilisearch sorts strings in lexicographic order based on their byte values. This means, `á` which has a value of 225, will be sorted after `z`, which has a value of 122.  
+Meilisearch sorts strings in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
 :::
 
 ### Select attributes for sorting

--- a/learn/advanced/sorting.md
+++ b/learn/advanced/sorting.md
@@ -17,7 +17,7 @@ To allow your users to sort results at search time you must:
 3. Update Meilisearch's [ranking rules](/learn/core_concepts/relevancy.md) (optional)
 
 ::: note
-Meilisearch sorts strings in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
+Documents used for sort are converted to lowercase and then sorted in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
 :::
 
 ### Select attributes for sorting

--- a/learn/advanced/sorting.md
+++ b/learn/advanced/sorting.md
@@ -17,7 +17,9 @@ To allow your users to sort results at search time you must:
 3. Update Meilisearch's [ranking rules](/learn/core_concepts/relevancy.md) (optional)
 
 ::: note
-Meilisearch converts documents to lowercase for sorting, they remain unchanged in the results. They are then sorted in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
+Meilisearch sorts strings in lexicographic order based on their byte values. For example, `á`, which has a value of 225, will be sorted after `z`, which has a value of 122.
+
+Uppercase letters are sorted as if they were lowercase. They will still appear uppercase in search results.
 :::
 
 ### Select attributes for sorting


### PR DESCRIPTION
Mention that strings are sorted lexicographically based on their byte value