### PR TITLE
v1.0: `too_many_open_files` error

### DIFF
--- a/learn/advanced/known_limitations.md
+++ b/learn/advanced/known_limitations.md
@@ -106,9 +106,3 @@ user = 1 OR user = 2 […] OR user = 1500 OR user = 1501 […] OR user = 2000 OR
 **Limitation:** By default, Meilisearch returns up to 1000 documents per search.
 
 **Explanation:** Meilisearch limits the maximum amount of returned search results to protect your database from malicious scraping. You may change this by using the `maxTotalHits` property of the [pagination index settings](/reference/api/settings.md#pagination-object). `maxTotalHits` only applies to the [search route](/reference/api/search.md) and has no effect on the [get documents endpoint](/reference/api/documents.md#get-documents).
-
-## Large datasets and internal errors
-
-**Limitation:** Meilisearch might throw an internal error when indexing large batches of documents.
-
-**Explanation:** Indexing a large batch of documents, such as a JSON file over 3.5GB in size, can result in Meilisearch opening too many file descriptors. Depending on your machine, this might reach your system's default resource usage limits and trigger an internal error. Use [`ulimit`](https://www.ibm.com/docs/en/aix/7.1?topic=u-ulimit-command) or a similar tool to increase resource consumption limits before running Meilisearch. For example, call `ulimit -Sn 3000` in a UNIX environment to raise the number of allowed open file descriptors to 3000.

--- a/reference/errors/error_codes.md
+++ b/reference/errors/error_codes.md
@@ -207,6 +207,10 @@ The payload sent to the server was too large. Check out this [guide](/learn/conf
 
 The requested task does not exist. Please ensure that you are using the correct `uid`.
 
+## `too_many_open_files`
+
+Indexing a large batch of documents, such as a JSON file over 3.5GB in size, can result in Meilisearch opening too many file descriptors. Depending on your machine, this might reach your system's default resource usage limits and trigger the `too_many_open_files` error. Use [`ulimit`](https://www.ibm.com/docs/en/aix/7.1?topic=u-ulimit-command) or a similar tool to increase resource consumption limits before running Meilisearch. For example, call `ulimit -Sn 3000` in a UNIX environment to raise the number of allowed open file descriptors to 3000.
+
 ## `unretrievable_document`
 
 The document exists in store, but there was an error retrieving it. This probably comes from an inconsistent state in the database.


### PR DESCRIPTION
closes #2068 

Since users no longer get an `internal` error, I removed the "Large datasets and internal errors" limitation