### PR TITLE
v1.0: remove two-step dump import process

### DIFF
--- a/learn/advanced/dumps.md
+++ b/learn/advanced/dumps.md
@@ -8,7 +8,7 @@ Creating a dump is also referred to as exporting it, whereas launching Meilisear
 
 ## Creating a dump
 
-To create a dump of your dataset, to use the [create a dump endpoint](/reference/api/dump.md#create-a-dump):
+To create a dump of your dataset, use the [create a dump endpoint](/reference/api/dump.md#create-a-dump):
 
 <CodeSamples id="post_dump_1" />
 
@@ -79,10 +79,6 @@ As the data contained in the dump needs to be indexed, the process will take som
 ```bash
 ./meilisearch --import-dump /dumps/20200813-042312213.dump
 ```
-
-### Importing a dump for v0.20 or below
-
-If you are using Meilisearch v0.20 or below, migration should be done in two steps. First, import your v0.20 dump into an instance running any version of Meilisearch between v0.21 and v0.25. Second, export another dump from this instance and import it to a final instance running your targeted version.
 
 ## Use cases
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -22,6 +22,8 @@ This section contains instructions for upgrading from specific versions. Most ve
 
 - If you are updating **from v0.19 or below**, please ensure all updates finish processing before creating the dump. `enqueued` updates will not be exported and may result in data loss.
 
+- If you are updating from **v0.20 or below**, the database creation date will not be imported to the new version.
+
 - If you are using **v0.24 or below**, use the `X-Meili-API-Key: API_KEY` authorization header:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -20,6 +20,8 @@ This guide only works for versions v0.15 and above. If you are using an older ve
 
 This section contains instructions for upgrading from specific versions. Most versions don't require version-specific steps and you should be able to upgrade directly. If the version you are upgrading from isn't listed here, no additional steps are required.
 
+- If you are updating **from v0.19 or below**, please ensure all updates finish processing before creating the dump. `enqueued` updates will not be exported and may result in data loss.
+
 - If you are using **v0.24 or below**, use the `X-Meili-API-Key: API_KEY` authorization header:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
@@ -257,12 +259,6 @@ For **cloud platforms**, move the new Meilisearch binary to the `/usr/bin` direc
 ```
 mv meilisearch /usr/bin/meilisearch
 ```
-
-::: warning
-If you are using Meilisearch v0.20 or below, migration should be done in two steps. First, import your dump into an instance running any version of Meilisearch from v0.21 to v0.24, inclusive. Second, export another dump from this instance and import it to a final instance running your targeted version.
-
-Once Meilisearch v1 is released, this two-step process won't be necessary as v1 will be compatible with dumps from all previous versions.
-:::
 
 ## Step 3: Import data
 

--- a/learn/advanced/updating.md
+++ b/learn/advanced/updating.md
@@ -20,9 +20,7 @@ This guide only works for versions v0.15 and above. If you are using an older ve
 
 This section contains instructions for upgrading from specific versions. Most versions don't require version-specific steps and you should be able to upgrade directly. If the version you are upgrading from isn't listed here, no additional steps are required.
 
-- If you are updating **from v0.19 or below**, please ensure all updates finish processing before creating the dump. `enqueued` updates will not be exported and may result in data loss.
-
-- If you are updating from **v0.20 or below**, the database creation date will not be imported to the new version.
+- If you are updating **from v0.20 or below**, please ensure all updates finish processing before creating the dump. `enqueued` updates will not be exported and may result in data loss.
 
 - If you are using **v0.24 or below**, use the `X-Meili-API-Key: API_KEY` authorization header:
 


### PR DESCRIPTION
closes #2067

## Docs team review

[This comment](https://github.com/meilisearch/meilisearch/issues/2985#issuecomment-1333840498) mentions some version-specific update FYIs that we can document. I added the first (`enqueued` updates are not exported) and last (DB creation date isn't exported) points. The other two seem too dump version specific. Please let me know if I should add them as well.