### PR TITLE
v1.0: Remove mentions of `--disable-auto-batching`

### DIFF
--- a/learn/configuration/instance_options.md
+++ b/learn/configuration/instance_options.md
@@ -206,19 +206,6 @@ If no master key is provided in a `development` environment, all routes will be 
 
 [Learn more about Meilisearch's use of security keys.](/learn/security/master_api_keys.md)
 
-### Disable auto-batching
-
-::: warning
-🚩 This option does not take any values. Assigning a value will throw an error. 🚩
-:::
-
-**Environment variable**: `MEILI_DISABLE_AUTO_BATCHING`
-**CLI option**: `--disable-auto-batching`
-
-Deactivates auto-batching when provided.
-
-[Learn more about auto-batching.](/learn/core_concepts/documents.md#auto-batching)
-
 ### Disable analytics
 
 ::: warning

--- a/learn/core_concepts/documents.md
+++ b/learn/core_concepts/documents.md
@@ -139,8 +139,6 @@ Tasks within the same batch share the same values for `startedAt`, `finishedAt`,
 
 If a task fails due to an invalid document, it will be removed from the batch. The rest of the batch will still process normally. If an [`internal`](/reference/errors/overview.md#errors) error occurs, the whole batch will fail and all tasks within it will share the same `error` object.
 
-You can deactivate auto-batching using the `--disable-auto-batching` command-line flag or the `MEILI_DISABLE_AUTO_BATCHING` environment variable. This is useful in cases where you want to avoid any potential bugs in the feature or reduce visibility latency. When auto-batching is disabled, the whole queue takes longer to process, but each individual task will be processed earlier (until a certain number of processed tasks).
-
 #### Auto-batching and task cancelation
 
 If the task you’re canceling is part of a batch, Meilisearch interrupts the whole process, discards all progress, and cancels that task. Then, it automatically creates a new batch without the canceled task and immediately starts processing it.

--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -191,7 +191,7 @@ The previous command added documents from `movies.json` to a new index called `m
 
 Every index must have a [primary key](/learn/core_concepts/primary_key.md#primary-field), an attribute shared across all documents in that index. If you try adding documents to an index and even a single one is missing the primary key, none of the documents will be stored.
 
-By default, Meilisearch combines consecutive document requests into a single batch and processes them together. This process is called [auto-batching](/learn/core_concepts/documents.md#auto-batching), and it significantly speeds up indexing. After adding documents, you should receive a response like this:
+Meilisearch combines consecutive document requests into a single batch and processes them together. This process is called [auto-batching](/learn/core_concepts/documents.md#auto-batching), and it significantly speeds up indexing. After adding documents, you should receive a response like this:
 
 ```json
 {

--- a/learn/getting_started/quick_start.md
+++ b/learn/getting_started/quick_start.md
@@ -203,7 +203,7 @@ Meilisearch combines consecutive document requests into a single batch and proce
 }
 ```
 
-Most database operations in Meilisearch are [asynchronous](/learn/advanced/asynchronous_operations.md). This means that rather than being processed instantly, **API requests are added to a queue and processed one at a time**.
+Most database operations in Meilisearch are [asynchronous](/learn/advanced/asynchronous_operations.md). This means that rather than being processed instantly, **API requests are added to a queue and processed at a later time**.
 
 Use the returned `taskUid` to [check the status](/reference/api/tasks.md) of your documents:
 

--- a/learn/what_is_meilisearch/telemetry.md
+++ b/learn/what_is_meilisearch/telemetry.md
@@ -202,7 +202,6 @@ This list is liable to change with every new version of Meilisearch. It's not be
 | `synonyms.total`                                   | Number of synonyms                                                                          | 3
 | `per_index_uid`                                    | `true` if the `uid` is used to fetch an index stat resource, otherwise `false`              | false
 | `matching_strategy.most_used_strategy`             | Most used word matching strategy                                                            | last
-| `infos.disable_auto_batching`                      | `true` if `--disable-auto-batching`/`MEILI_DISABLE_AUTO_BATCHING` is specified, otherwise `false`     | true
 | `infos.with_configuration_file`                    | `true` if the instance is launched with a configuration file, otherwise `false`             | false
 | `swap_operation_number`                            | Number of swap operations                                                                   | 2
 | `pagination.most_used_navigation`                  | Most used search results navigation                                                         | estimated

--- a/reference/api/documents.md
+++ b/reference/api/documents.md
@@ -8,7 +8,7 @@ The `/documents` route allows you to create, manage, and delete documents.
 
 <RouteHighlighter method="GET" route="/indexes/{index_uid}/documents"/>
 
-Get documents by batch.
+Get a set of documents.
 
 Using the query parameters `offset` and `limit`, you can browse through all your documents.
 


### PR DESCRIPTION
Closes #2085

Additionally, this PR also changes the wording of the `GET` documents endpoint so it doesn't use the word "batch" to keep our terminology consistent.