### PR TITLE
Replace underscore with hypens in error_code anchor

### DIFF
--- a/.vuepress/enhanceApp.js
+++ b/.vuepress/enhanceApp.js
@@ -1,14 +1,22 @@
-export default ({
-  router,
-}) => {
-  router.addRoutes([
-    {
-      path: '/error/:error',
-      redirect: '/errors/',
-    },
-    {
-      path: '/error/',
-      redirect: '/errors/',
-    },
-  ])
+export default ({ router }) => {
+  // Replaces the underscores (_) in the anchors on error_codes to hypens (-)
+  // example:
+  // before: /reference/errors/error_codes.html#dump_not_found
+  // after: /reference/errors/error_codes.html#dump-not-found
+  router.beforeEach((to, from, next) => {
+    const { fullPath } = to
+
+    // matches error_codes anchors that contains underscore instead of hypens
+    const matches = fullPath.match(/\/reference\/errors\/error_codes\.html#([^-]+)$/)
+    if (matches && matches[1]) {
+      const underscoreAnchor = matches[1]
+      const hypenAnchor = matches[1].replace(/_/g, '-')
+      const newUrl = fullPath.replace(underscoreAnchor, hypenAnchor)
+
+      // redirects to newUrl
+      next({ path: newUrl })
+    } else {
+      next()
+    }
+  })
 }


### PR DESCRIPTION
fixes: https://github.com/meilisearch/meilisearch/issues/3097

This PR ensures fixes the issue where the engine provides links with anchors containing underscores, whereas the doc are expecting hypens. Both type of anchors are now valid.

When an anchor is created for a heading in Vuepress all underscore are transformed to hypens.
For example:

```
# dump_not_found
```

Will have as anchor `#dump-not-found`.

Unfortunately, the meilisearch engine provides the links to the errors with underscores  (e.g. `"link": "https://docs.meilisearch.com/errors#index_not_found"`).

This PR adds a redirect on links to the errors references where an anchors has underscores (_) to the same URL but the underscores are transformed to hypens (-)

Example with the generated doc:
This 
https://deploy-preview-2124--dreamy-wiles-8fd85b.netlify.app/reference/errors/error_codes.html#invalid_api_key_uid
and this 
https://deploy-preview-2124--dreamy-wiles-8fd85b.netlify.app/reference/errors/error_codes.html#invalid-api-key-uid

works