### PR TITLE
v1.0: remove stable v1 mentions

### DIFF
--- a/resources/faq.md
+++ b/resources/faq.md
@@ -82,7 +82,7 @@ Meilisearch major versions introduce breaking changes and are not compatible wit
 
 ## What are the recommended requirements for hosting a Meilisearch instance?
 
-Indexing documents is a highly complex process, making it difficult to accurately estimate the size and memory use of a Meilisearch database. There are a few aspects to keep in mind when optimizing your instance.
+Indexing documents is a complex process, making it difficult to accurately estimate the size and memory use of a Meilisearch database. There are a few aspects to keep in mind when optimizing your instance.
 
 ### Memory usage
 

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -78,15 +78,11 @@ For more accurate features and issues, everything is detailed in the issues of a
 
 ## I have just updated Meilisearch, and I am getting an error: "Cannot open database, expected Meilisearch engine version..."
 
-Until our first stable release (v1.0), Meilisearch minor versions are not compatible with each other. This means **every new version is considered breaking** with the small exception of bug-fixing patches. To fix this error, simply delete your database folder (`data.ms` by default) and re-index your documents with the current-version engine. See [updating Meilisearch](/learn/advanced/updating.md) for more information.
+Meilisearch major versions introduce breaking changes and are not compatible with each other. Meilisearch version 0 releases, such as v0.30 or v0.24, are also not compatible with each other. Consult the [updating guide](/learn/advanced/updating.md) for more information on how to safely migrate your data between Meilisearch releases.
 
 ## What are the recommended requirements for hosting a Meilisearch instance?
 
-**The short answer: we don't know yet!**
-
-Indexing documents is a highly complex process, making it difficult to accurately estimate the size and memory use of a Meilisearch database. At this stage, our engine is changing constantly, which means benchmarks are constantly out of date.
-
-Once our engine is completely stable (v1), we will provide detailed benchmarks with different datasets. Until then, read on to learn how to optimize your Meilisearch instance.
+Indexing documents is a highly complex process, making it difficult to accurately estimate the size and memory use of a Meilisearch database. There are a few aspects to keep in mind when optimizing your instance.
 
 ### Memory usage
 
@@ -123,13 +119,9 @@ Meilisearch also uses disk space as [virtual memory](/learn/advanced/storage.md#
 
 At this time, the number of CPU cores has no direct impact on index or search speed. However, **the more cores you provide to the engine, the more search queries it will be able to process at the same time**.
 
-::: tip
-Our new engine (currently in development) **will support multi-core indexing at launch**.
-:::
-
 #### Speeding up Meilisearch
 
-Meilisearch is designed to be fast (≤50ms response time), so speeding it up is rarely necessary. However, if you find that your Meilisearch instance is querying slowly, there are two primary methods to speed it up:
+Meilisearch is designed to be fast (≤50ms response time), so speeding it up is rarely necessary. However, if you find that your Meilisearch instance is querying slowly, there are two primary methods to improve search performance:
 
 1. Increase the amount of RAM (or virtual memory)
 2. Reduce the size of the database

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -76,10 +76,6 @@ Yes, as Meilisearch and its integration tools are open source, we maintain a [pu
 
 For more accurate features and issues, everything is detailed in the issues of all our [GitHub repositories](https://github.com/meilisearch/meilisearch/issues).
 
-## I have just updated Meilisearch, and I am getting an error: "Cannot open database, expected Meilisearch engine version..."
-
-Meilisearch major versions introduce breaking changes and are not compatible with each other. Meilisearch version 0 releases, such as v0.30 or v0.24, are also not compatible with each other. Consult the [updating guide](/learn/advanced/updating.md) for more information on how to safely migrate your data between Meilisearch releases.
-
 ## What are the recommended requirements for hosting a Meilisearch instance?
 
 **The short answer:**

--- a/resources/faq.md
+++ b/resources/faq.md
@@ -82,6 +82,12 @@ Meilisearch major versions introduce breaking changes and are not compatible wit
 
 ## What are the recommended requirements for hosting a Meilisearch instance?
 
+**The short answer:**
+
+The recommended requirements for hosting a Meilisearch instance will depend on many factors, such as the number of documents, the size of those documents, the number of filters/sorts you will need, and more. For a quick estimate to start with, try to use a machine that has at least ten times the disk space of your dataset.
+
+**The long answer:**
+
 Indexing documents is a complex process, making it difficult to accurately estimate the size and memory use of a Meilisearch database. There are a few aspects to keep in mind when optimizing your instance.
 
 ### Memory usage


### PR DESCRIPTION
We found four old mentions reflecting our hopes and wishes for v1 around the documentation. Search was conducted using a grep-like tool with the following terms:

- `v1`
- `stable`
- `unstable`
- `in development`
- `major`
- `alpha`
- `beta`

Two mentions on the updating guide will be fixed by #2102.

This PR removes the remaining two mentions on the FAQ.