### PR TITLE
Clarify update documents with pk

### DIFF
--- a/reference/api/documents.md
+++ b/reference/api/documents.md
@@ -175,7 +175,7 @@ If you send an already existing document (same [document id](/learn/core_concept
 
 To completely overwrite a document, check out the [add or replace documents route](/reference/api/documents.md#add-or-replace-documents).
 
-If you want to set the [**primary key** of your index](/learn/core_concepts/primary_key.md#setting-the-primary-key-on-document-addition) through this route, it only has to be done **the first time you add documents** to the index. After which, the task will result in an error if given.
+If you want to set the [**primary key** of your index](/learn/core_concepts/primary_key.md#setting-the-primary-key-on-document-addition) through this route, you may only do so **the first time you add documents** to the index. If you try to set the primary key after having added documents to the index, the task will return an error.
 
 This endpoint accepts the following content types:
 

--- a/reference/api/documents.md
+++ b/reference/api/documents.md
@@ -175,7 +175,7 @@ If you send an already existing document (same [document id](/learn/core_concept
 
 To completely overwrite a document, check out the [add or replace documents route](/reference/api/documents.md#add-or-replace-documents).
 
-If you want to set the [**primary key** of your index](/learn/core_concepts/primary_key.md#setting-the-primary-key-on-document-addition) through this route, it only has to be done **the first time you add documents** to the index. After which, it will be ignored if given.
+If you want to set the [**primary key** of your index](/learn/core_concepts/primary_key.md#setting-the-primary-key-on-document-addition) through this route, it only has to be done **the first time you add documents** to the index. After which, the task will result in an error if given.
 
 This endpoint accepts the following content types:
 


### PR DESCRIPTION
Hi team, my change is just to illustrate what I propose, but the correct way of explaining is up to you!

Since v1, when a user tries to run a `PUT indexes/my_index/documents` with a primary key, the task will fail and will not be silently ignored like it was in previous versions.

See:

```json
 {
    "uid": 3040,
    "indexUid": "be566493",
    "status": "failed",
    "type": "documentAdditionOrUpdate",
    "canceledBy": null,
    "details": {
        "receivedDocuments": 1,
        "indexedDocuments": 0
    },
    "error": {
        "message": "Index already has a primary key: `unique`.",
        "code": "index_primary_key_already_exists",
        "type": "invalid_request",
        "link": "https://docs.meilisearch.com/errors#index_primary_key_already_exists"
    },
    "duration": "PT0.000590375S",
    "enqueuedAt": "2023-02-06T01:50:52.315238299Z",
    "startedAt": "2023-02-06T01:50:52.317367633Z",
    "finishedAt": "2023-02-06T01:50:52.317958008Z"
},
```
