### PR TITLE
Add CODEOWNERS to .code-samples.meilisearch.yaml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# The integrations-team is responsible for reviewing the code-samples.
+.code-samples.meilisearch.yaml @meilisearch/integration-team


### PR DESCRIPTION
The idea is to use the [Github's CODEOWNERS feature](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) to help us the integrations team, track when the code-samples change.

⚠️ This is not a replacement for the work @maryamsulemani97 graciously does when she creates the issue listing all the changes, this is just a "plus" that will help us automatically review the changes we will implement in the SDKs and also help the docs team to understand if the sample is valid or not.

What happens when a PR with a code-sample change is submitted to the repository? The integration team should be automatically applied as a reviewer.

PS: The whole team should have access to "write" in the repository if you don't feel comfortable opening this permission, we can work differently and just let one of us keep track of it.