### PR TITLE
Remove disabling security

### DIFF
--- a/learn/security/master_api_keys.md
+++ b/learn/security/master_api_keys.md
@@ -245,46 +245,6 @@ To change the master key, first terminate your Meilisearch instance. Then relaun
 
 **Changing an instance's master key renders all active API keys invalid and generates new values for each one of them.** This is useful if your security is severely compromised and you must reset all API key values at once.
 
-## Disabling security
-
-You can disable instance protection by restarting Meilisearch without providing a master key:
-
-:::: tabs
-::: tab CLI
-
-If your master key was set up using the command-line option, relaunch the instance without the `--master-key` option:
-
-```sh
-./meilisearch
-```
-
-:::
-
-::: tab Environment variable
-
-If your master key was configured with an environment variable, unset `MEILI_MASTER_KEY` and relaunch the instance.
-
-UNIX:
-
-```sh
-export MEILI_MASTER_KEY=
-./meilisearch
-```
-
-Windows:
-
-```sh
-set MEILI_MASTER_KEY=
-./meilisearch
-```
-
-:::
-::::
-
-::: danger
-We strongly advise against deactivating key-based security for any Meilisearch instances used in production or containing sensitive information.
-:::
-
 ## Further security measures
 
 API keys alone might not be enough to handle more complex situations such as multi-tenant indexes. If your application must manage several users and sensitive data, we recommend you [consider using tenant tokens](/learn/security/tenant_tokens.md).

--- a/learn/security/master_api_keys.md
+++ b/learn/security/master_api_keys.md
@@ -247,7 +247,7 @@ To change the master key, first terminate your Meilisearch instance. Then relaun
 
 ## Running an unprotected instance
 
-You can disable instance protection by restarting Meilisearch without providing a master key:
+You can disable instance protection by restarting Meilisearch in `development` environment without providing a master key:
 
 :::: tabs
 ::: tab CLI

--- a/learn/security/master_api_keys.md
+++ b/learn/security/master_api_keys.md
@@ -192,7 +192,7 @@ We can query our instance to confirm which active keys can search our `patient_m
     },
     {
       "name": "Default Admin API Key",
-      "description": "Use it for all other than search operations. Caution! Do not expose it on a public frontend", 
+      "description": "Use it for all other than search operations. Caution! Do not expose it on a public frontend",
       "key": "380689dd379232519a54d15935750cc7625620a2ea2fc06907cb40ba5b421b6f",
       "uid": "20f7e4c4-612c-4dd1-b783-7934cc038213",
       "actions": [
@@ -244,6 +244,44 @@ Once a key is past its `expiresAt` date, using it for API authorization will ret
 To change the master key, first terminate your Meilisearch instance. Then relaunch it, [supplying a new value for the master key](#protecting-a-meilisearch-instance).
 
 **Changing an instance's master key renders all active API keys invalid and generates new values for each one of them.** This is useful if your security is severely compromised and you must reset all API key values at once.
+
+## Running an unprotected instance
+
+You can disable instance protection by restarting Meilisearch without providing a master key:
+
+:::: tabs
+::: tab CLI
+
+If your master key was set up using the command-line option, relaunch the instance without the `--master-key` option:
+
+```sh
+./meilisearch --env development
+```
+
+:::
+
+::: tab Environment variable
+
+If your master key was configured with an environment variable, unset `MEILI_MASTER_KEY` and relaunch the instance.
+
+UNIX:
+
+```sh
+export MEILI_ENV=development
+export MEILI_MASTER_KEY=
+./meilisearch
+```
+
+Windows:
+
+```sh
+set MEILI_ENV=development
+set MEILI_MASTER_KEY=
+./meilisearch
+```
+
+:::
+::::
 
 ## Further security measures
 

--- a/learn/security/master_api_keys.md
+++ b/learn/security/master_api_keys.md
@@ -247,12 +247,10 @@ To change the master key, first terminate your Meilisearch instance. Then relaun
 
 ## Running an unprotected instance
 
-You can disable instance protection by restarting Meilisearch in `development` environment without providing a master key:
+You can run an unprotected Meilisearch instance in the `development` environment without providing a master key:
 
 :::: tabs
 ::: tab CLI
-
-If your master key was set up using the command-line option, relaunch the instance without the `--master-key` option:
 
 ```sh
 ./meilisearch --env development
@@ -262,13 +260,10 @@ If your master key was set up using the command-line option, relaunch the instan
 
 ::: tab Environment variable
 
-If your master key was configured with an environment variable, unset `MEILI_MASTER_KEY` and relaunch the instance.
-
 UNIX:
 
 ```sh
 export MEILI_ENV=development
-export MEILI_MASTER_KEY=
 ./meilisearch
 ```
 
@@ -276,7 +271,6 @@ Windows:
 
 ```sh
 set MEILI_ENV=development
-set MEILI_MASTER_KEY=
 ./meilisearch
 ```
 


### PR DESCRIPTION
# Pull Request

## Related issue
N/A

## What does this PR do?

The 'disabling security' section is no longer accurate in v1.0.0, following:
> As a security measure, Meilisearch will now reject master keys that are less than 16 bytes in [production environment](https://docs.meilisearch.com/learn/configuration/instance_options.html#environment) (https://github.com/meilisearch/meilisearch/pull/3274 and https://github.com/meilisearch/meilisearch/pull/3295)

```bash
$ docker run -it --rm -p 7700:7700 -e MEILI_ENV='production' -e MEILI_MASTER_KEY= -v $(pwd)/meili_data:/meili_data getmeili/meilisearch:v1.0
Error: The master key must be at least 16 bytes in a production environment. The provided key is only 0 bytes.

We generated a new secure master key for you (you can safely use this token):

>> --master-key JCXXid9dc52xJlGdzdw_krLhJ-uK6-ms9j5gDJoxAds <<

```

```bash
$ docker run -it --rm -p 7700:7700 -e MEILI_ENV='development' -e MEILI_MASTER_KEY= -v $(pwd)/meili_data:/meili_data getmeili/meilisearch:v1.0

888b     d888          d8b 888 d8b                                            888
8888b   d8888          Y8P 888 Y8P                                            888
88888b.d88888              888                                                888
888Y88888P888  .d88b.  888 888 888 .d8888b   .d88b.   8888b.  888d888 .d8888b 88888b.
888 Y888P 888 d8P  Y8b 888 888 888 88K      d8P  Y8b     "88b 888P"  d88P"    888 "88b
888  Y8P  888 88888888 888 888 888 "Y8888b. 88888888 .d888888 888    888      888  888
888   "   888 Y8b.     888 888 888      X88 Y8b.     888  888 888    Y88b.    888  888
888       888  "Y8888  888 888 888  88888P'  "Y8888  "Y888888 888     "Y8888P 888  888

Config file path:       "none"
Database path:          "./data.ms"
Server listening on:    "http://0.0.0.0:7700"
Environment:            "development"
Commit SHA:             "5e12af88e2575a42f53bb3907aea42d7cd4b8b20"
Commit date:            "2023-02-01T11:07:46+00:00"
Package version:        "1.0.0"

Thank you for using Meilisearch!


We collect anonymized analytics to improve our product and your experience. To learn more, including how to turn off analytics, visit our dedicated documentation page: https://docs.meilisearch.com/learn/what_is_meilisearch/telemetry.html

Anonymous telemetry:    "Enabled"
Instance UID:           "9e51c045-3ca6-491a-ad5d-a3d9ba534ef7"

A master key has been set. Requests to Meilisearch won't be authorized unless you provide an authentication key.


 Meilisearch started with a master key considered unsafe for use in a production environment.

 A master key of at least 16 bytes will be required when switching to a production environment.


We generated a new secure master key for you (you can safely use this token):

>> --master-key aHrA_lWHfipjRGGAzhp2qTAU6BSpo2T2lrMNFzi2rsk <<

Restart Meilisearch with the argument above to use this new and secure master key.

Documentation:          https://docs.meilisearch.com
Source code:            https://github.com/meilisearch/meilisearch
Contact:                https://docs.meilisearch.com/resources/contact.html

[2023-02-10T18:25:22Z INFO  actix_server::builder] Starting 4 workers
[2023-02-10T18:25:22Z INFO  actix_server::server] Actix runtime found; starting in Actix runtime

```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
