### PR TITLE
Fix pipeline count

### DIFF
--- a/learn/what_is_meilisearch/language.md
+++ b/learn/what_is_meilisearch/language.md
@@ -24,7 +24,7 @@ If you'd like to help by developing a tokenizer pipeline yourself: first of all,
 
 ### What do you mean when you say Meilisearch offers _optimized_ support for a language?
 
-Under the hood, Meilisearch relies on tokenizers that identify the most important parts of each document in a given dataset. We currently use four tokenization pipelines:
+Under the hood, Meilisearch relies on tokenizers that identify the most important parts of each document in a given dataset. We currently use five tokenization pipelines:
 
 - A default pipeline designed for languages that separate words with spaces
 - A pipeline specifically tailored for Chinese


### PR DESCRIPTION
It says Meilisearch uses four pipelines but counts five including the default one.

# Pull Request

## Related issue
No issue created.

## What does this PR do?
- Fix wrong information.

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
