### PR TITLE
Add Korean to list of supported languages

### DIFF
--- a/learn/what_is_meilisearch/language.md
+++ b/learn/what_is_meilisearch/language.md
@@ -4,8 +4,9 @@ Meilisearch is multilingual, featuring optimized support for:
 
 - Any language that uses whitespace to separate words
 - Chinese
-- Japanese
 - Hebrew
+- Japanese
+- Korean
 - Thai
 
 We aim to provide global language support, and your feedback helps us move closer to that goal. If you notice inconsistencies in your search results or the way your documents are processed, please [open an issue in the Meilisearch repository](https://github.com/meilisearch/meilisearch/issues/new/choose).
@@ -28,8 +29,8 @@ Under the hood, Meilisearch relies on tokenizers that identify the most importan
 
 - A default pipeline designed for languages that separate words with spaces
 - A pipeline specifically tailored for Chinese
-- A pipeline specifically tailored for Japanese
 - A pipeline specifically tailored for Hebrew
+- A pipeline specifically tailored for Japanese
 - A pipeline specifically tailored for Thai
 
 ### My language does not use whitespace to separate words. Can I still use Meilisearch?


### PR DESCRIPTION
Fixes #2172

@ManyTheFish: do I understand correctly that Korean uses the default pipeline for space-separated languages? Or do we use another pipeline?