### PR TITLE
New site: Rough home draft

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -3,51 +3,35 @@ title: Meilisearch Documentation
 description: Here you'll find everything you need to learn and create with our lightning fast search engine.
 ---
 
-# Welcome to the Meilisearch documentation
+# Documentation
 
-Here you'll find everything you need to learn and create with our lightning fast search engine.
+Explore our guides and references to learn how to use Meilisearch in your projects.
 
-<Capsule className="my-[72px]">
-  <h3 className="text-3xl">Looking for SDK documentation?</h3>
-  <p>Check out this <ButtonLink href="/docs/learn/what_is_meilisearch/sdks.html" currentColor="true" >list of official Meilisearch</ButtonLink> libraries or use the Integrations dropdown menu at the top of the screen for quick access.</p>
+<Capsule>
+  ## Quick start
+
+  New here? Check out the [Quick start guide](/learn/getting_started/quick_start.mdx) and learn how to launch a basic Meilisearch instance.
 </Capsule>
 
-<h2 className="text-5xl">Meilisearch news</h2>
+<h2 className="text-5xl">Explore The docs</h2>
 
-Announcing Meilisearch Cloud: [register now](https://cloud.meilisearch.com/register) or [log in here](https://cloud.meilisearch.com/login) if you already have an account.
-
-<Divider />
-
-We just raised a 15M Series A! 🥳 Check out the [TechCrunch exclusive](https://docs.meilisearch.com/#:~:text=TechCrunch%20exclusive,opens%20new%20window) or learn more [on our blog](https://blog.meilisearch.com/meilisearch-series-a/).
-
-<Divider />
-
-<h2 className="text-5xl">Explore our documentation</h2>
 <Featured items={[
   {
     icon: 'cube',
-    content: 'Check what we will be working on in the next few weeks!'
+    content: 'Consult the Meilisearch [API reference](/reference/api).'
   },
   {
-    content: 'Check what we will be working on in the next few weeks!',
+    content: 'Looking for SDK documentation? Check out this list of [official Meilisearch libraries](/learn/what_is_meilisearch/sdks.mdx).',
     icon: 'compass'
   },
   {
     content:
-      'Check out this list of official Meilisearch libraries or use the Integrations dropdown menu at the top of the screen for quick access.',
-    icon: 'user'
+      'Announcing [Meilisearch Cloud](https://cloud.meilisearch.com/register): the best way to add Meilisearch to your project',
+    icon: 'cloud'
   },
   {
     content:
-      'Check out this list of official Meilisearch libraries or use the Integrations dropdown menu at the top of the screen for quick access.',
-    icon: 'circle'
-  },
-  {
-    icon: 'globe',
-    content: 'Check what we will be working on in the next few weeks!'
-  },
-  {
-    content: 'Check what we will be working on in the next few weeks!',
-    icon: 'letter'
+      'Read the Meilisearch blog for more tips, tutorials, and information about our company.',
+    icon: 'open-source'
   }
 ]} />

--- a/home.mdx
+++ b/home.mdx
@@ -5,15 +5,15 @@ description: Here you'll find everything you need to learn and create with our l
 
 # Documentation
 
-Explore our guides and references to learn how to use Meilisearch in your projects.
+Learn to use Meilisearch in your projects by exploring our guides and API reference.
 
 <Capsule>
   ## Quick start
 
-  New here? Check out the [Quick start guide](/learn/getting_started/quick_start.mdx) and learn how to launch a basic Meilisearch instance.
+  New here? Check out the [Quick start guide](/learn/getting_started/quick_start.mdx) and learn how to set up Meilisearch, add data, and make your first search.
 </Capsule>
 
-<h2 className="text-5xl">Explore The docs</h2>
+<h2 className="text-5xl">Explore the docs</h2>
 
 <Featured items={[
   {
@@ -31,7 +31,7 @@ Explore our guides and references to learn how to use Meilisearch in your projec
   },
   {
     content:
-      'Read the Meilisearch blog for more tips, tutorials, and information about our company.',
+      'For more tips, tutorials, and information about our company, take a look at the Meilisearch blog.',
     icon: 'open-source'
   }
 ]} />


### PR DESCRIPTION
Trying to sketch what the new home would look like.

- Remove News section
- Remove most text
- Replace SDK reference `Capsule` content with Quick start link
- Replace placeholder `Featured` content with references to API reference, SDK page, Meilisearch Cloud, and blog

![Reference of more or less what I have in mind (ignore the icons)](https://user-images.githubusercontent.com/1923183/228011393-68837da4-7e3e-4a51-ad4f-93f03c3612d0.png)


