### PR TITLE
New site:  Update asset links

### DIFF
--- a/learn/advanced/filtering_and_faceted_search.mdx
+++ b/learn/advanced/filtering_and_faceted_search.mdx
@@ -354,7 +354,7 @@ _geoRadius(lat, lng, distance_in_meters)
 
 `lat` and `lng` must be floating point numbers indicating a geographic position. `distance_in_meters` must be an integer indicating the radius covered by the `_geoRadius` filter.
 
-When using a <a id="downloadRestaurants" href="/restaurants.json" download="restaurants.json"> dataset of restaurants</a> containing geopositioning data, we can filter our search so it only includes places within two kilometers of our location:
+When using a <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/restaurants.json" download="restaurants.json"> dataset of restaurants</a> containing geopositioning data, we can filter our search so it only includes places within two kilometers of our location:
 
 <CodeSamples id="geosearch_guide_filter_usage_1" />
 

--- a/learn/advanced/geosearch.mdx
+++ b/learn/advanced/geosearch.mdx
@@ -143,7 +143,7 @@ _geoRadius(lat, lng, distance_in_meters)
 
 ### Examples
 
-`_geoRadius` works like any other filter rule. Using our <a id="downloadRestaurants" href="/restaurants.json" download="restaurants.json">example dataset</a>, we can search for places to eat near the center of Milan:
+`_geoRadius` works like any other filter rule. Using our <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/restaurants.json" download="restaurants.json">example dataset</a>, we can search for places to eat near the center of Milan:
 
 <CodeSamples id="geosearch_guide_filter_usage_1" />
 
@@ -236,7 +236,7 @@ The `_geoPoint` sorting function can be used like any other sorting rule. We can
 
 <CodeSamples id="geosearch_guide_sort_usage_1" />
 
-With our <a id="downloadRestaurants" href="/restaurants.json" download="restaurants.json">restaurants dataset</a>, the results look like this:
+With our <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/restaurants.json" download="restaurants.json">restaurants dataset</a>, the results look like this:
 
 ```json
 [

--- a/learn/advanced/storage.mdx
+++ b/learn/advanced/storage.mdx
@@ -47,7 +47,7 @@ Meilisearch will always demand a certain amount of space to use as a [memory map
 
 ## Measured disk usage
 
-The following measurements were taken using <a id="downloadMovie" href="/movies.json" download="movies.json">an 8.6 MB JSON dataset containing 19,553 documents</a>.
+The following measurements were taken using <a id="downloadMovie" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/movies.json" download="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/movies.json">an 8.6 MB JSON dataset containing 19,553 documents</a>.
 
 After indexed, the dataset size in LMDB is about 122MB.
 

--- a/learn/advanced/working_with_dates.mdx
+++ b/learn/advanced/working_with_dates.mdx
@@ -59,7 +59,7 @@ game = {
 When preparing your dataset, it can be useful to leave the original date and time fields in your documents intact. In the example above, we keep the `release_date` field because it is more readable than the raw `release_timestamp`.
 </Capsule>
 
-After adding a numeric timestamp to all documents, [index your data](/reference/api/documents.md#add-or-replace-documents) as usual. The example below adds a <a id="downloadVideogames" href="/videogames.json" download="videogames.json">videogame dataset</a> to a `games` index:
+After adding a numeric timestamp to all documents, [index your data](/reference/api/documents.md#add-or-replace-documents) as usual. The example below adds a <a id="downloadVideogames" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/videogames.json" download="videogames.json">videogame dataset</a> to a `games` index:
 
 <CodeSamples id="date_guide_index_1" />
 

--- a/learn/getting_started/customizing_relevancy.mdx
+++ b/learn/getting_started/customizing_relevancy.mdx
@@ -4,7 +4,7 @@ Meilisearch is designed to offer a great search experience out of the box, but s
 
 For this chapter, we will be using a collection of movies as our dataset.
 
-To follow along, first click this link to download the file: <a id="downloadMovie" href="/movies.json" download="movies.json">movies.json</a>. Then, move it into your working directory and run the following command:
+To follow along, first click this link to download the file: <a id="downloadMovie" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/movies.json" download="movies.json">movies.json</a>. Then, move it into your working directory and run the following command:
 
 <CodeSamples id="getting_started_add_documents_md" />
 

--- a/learn/getting_started/filtering_and_sorting.mdx
+++ b/learn/getting_started/filtering_and_sorting.mdx
@@ -2,7 +2,7 @@
 
 Welcome to the Meilisearch 101! This guide aims to introduce you to the main features of Meilisearch as efficiently as possible. It assumes that you have completed the [Quick start](/learn/getting_started/quick_start.md) and already have a running Meilisearch instance.
 
-This chapter uses a dataset of meteorites to demonstrate filtering, sorting, and geosearch. To follow along, first click this link to download the file: <a id="downloadmeteorites" href="/meteorites.json" download="meteorites.json">meteorites.json</a>. Then, move it into your working directory and run the following command:
+This chapter uses a dataset of meteorites to demonstrate filtering, sorting, and geosearch. To follow along, first click this link to download the file: <a id="downloadmeteorites" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/meteorites.json" download="meteorites.json">meteorites.json</a>. Then, move it into your working directory and run the following command:
 
 <CodeSamples id="getting_started_add_meteorites" />
 

--- a/learn/getting_started/quick_start.mdx
+++ b/learn/getting_started/quick_start.mdx
@@ -45,7 +45,7 @@ Congratulations! You're ready to move on to the next step!
 
 ## Add documents
 
-For this quick start, we will be using a collection of movies as our dataset. To follow along, first click this link to download the file: <a id="downloadMovie" href="/movies.json" download="movies.json">movies.json</a>. Then, move the downloaded file into your working directory.
+For this quick start, we will be using a collection of movies as our dataset. To follow along, first click this link to download the file: <a id="downloadMovie" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/movies.json" download="movies.json">movies.json</a>. Then, move the downloaded file into your working directory.
 
 Open a new terminal window and run the following command:
 


### PR DESCRIPTION
Due to the limitations on the new version of the docs website, it will not be able to host images at launch. 

This PR replaces image and dataset URLs to absolute links to the GitHub raw file.

Closes #2270
