### PR TITLE
Update the title `Multi-index search` in the api refs by removing `index`

### DIFF
--- a/reference/api/multi_search.md
+++ b/reference/api/multi_search.md
@@ -1,4 +1,4 @@
-# Multi-index search
+# Multi search
 
 The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-index search is also known as federated search.
 


### PR DESCRIPTION
Using the term `multi-index search` implies that this route is meant to search on multiple indexes only. Which is not the case. This route is meant to perform multiple search on any index, may it be 4 times on the same index.

What do you think?
If you agree, should I update some routes as well?