### PR TITLE
Update the title Multi-index search in the api refs by removing index (on the new doc)

### DIFF
--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -1,6 +1,6 @@
-# Multi-index search
+# Multi search
 
-The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-index search is also known as federated search.
+The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-search is also known as federated search.
 
 ## POST route
 


### PR DESCRIPTION
Using the term multi-index search implies that this route is meant to search on multiple indexes only. Which is not the case. This route is meant to perform multiple search on any index, may it be 4 times on the same index.

Also, the name of the route is multi-search and the feature is named multi search, it seems more consistent to keep that name.
