### PR TITLE
Migration: remove note titles

### DIFF
--- a/learn/update_and_migration/updating.mdx
+++ b/learn/update_and_migration/updating.mdx
@@ -36,7 +36,8 @@ The response should look something like this:
 }
 ```
 
-<Capsule intent="tip" title={<>If you get the <code>missing_authorization_header</code> error, you might be using **v0.24 or below**. For each command, replace the <code>Authorization: Bearer</code> header with the <code>X-Meili-API-Key: API_KEY</code> header:</>}>
+<Capsule intent="tip">
+If you get the `missing_authorization_header` error, you might be using **v0.24 or below**. For each command, replace the `Authorization: Bearer` header with the `X-Meili-API-Key: API_KEY` header:
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 </Capsule>

--- a/learn/update_and_migration/updating.mdx
+++ b/learn/update_and_migration/updating.mdx
@@ -36,7 +36,7 @@ The response should look something like this:
 }
 ```
 
-<Capsule intent="tip" title="If you get the `missing_authorization_header` error, you might be using **v0.24 or below**. For each command, replace the `Authorization: Bearer` header with the `X-Meili-API-Key: API_KEY` header:">
+<Capsule intent="tip" title={<>If you get the <code>missing_authorization_header</code> error, you might be using **v0.24 or below**. For each command, replace the <code>Authorization: Bearer</code> header with the <code>X-Meili-API-Key: API_KEY</code> header:</>}>
 
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 </Capsule>

--- a/reference/api/overview.mdx
+++ b/reference/api/overview.mdx
@@ -27,7 +27,7 @@ By [providing Meilisearch with a master key at launch](/learn/security/master_ap
 
 The [`/keys`](/reference/api/keys) route can only be accessed using the master key. For security reasons, we recommend using regular API keys for all other routes.
 
-<Capsule intent="tip" title={v0.24 and below use the <><code>`X-MEILI-API-KEY: apiKey`</code> authorization header:</>}>
+<Capsule intent="tip" title={<>v0.24 and below use the <code>X-MEILI-API-KEY: apiKey</code> authorization header:</>}>
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 </Capsule>
 

--- a/reference/api/overview.mdx
+++ b/reference/api/overview.mdx
@@ -27,7 +27,7 @@ By [providing Meilisearch with a master key at launch](/learn/security/master_ap
 
 The [`/keys`](/reference/api/keys) route can only be accessed using the master key. For security reasons, we recommend using regular API keys for all other routes.
 
-<Capsule intent="tip" title=" v0.24 and below use the `X-MEILI-API-KEY: apiKey` authorization header:">
+<Capsule intent="tip" title={v0.24 and below use the <><code>`X-MEILI-API-KEY: apiKey`</code> authorization header:</>}>
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 </Capsule>
 

--- a/reference/api/overview.mdx
+++ b/reference/api/overview.mdx
@@ -27,7 +27,9 @@ By [providing Meilisearch with a master key at launch](/learn/security/master_ap
 
 The [`/keys`](/reference/api/keys) route can only be accessed using the master key. For security reasons, we recommend using regular API keys for all other routes.
 
-<Capsule intent="tip" title={<>v0.24 and below use the <code>X-MEILI-API-KEY: apiKey</code> authorization header:</>}>
+<Capsule intent="tip">
+v0.24 and below use the `X-MEILI-API-KEY: apiKey` authorization header:
+
 <CodeSamples id="updating_guide_check_version_old_authorization_header" />
 </Capsule>
 


### PR DESCRIPTION
This PR removes container titles and adds them to the container body for:
- `reference/api/overview.mdx`
- `learn/update_and_migration/updating.mdx`