### PR TITLE
Fix homepage links in properties

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -13,19 +13,19 @@ Learn how to use Meilisearch in your projects by exploring our guides and API re
   {
     content:'<h2 style="margin-bottom: -10px">Quick start</h2> New here? Check out our quick start guide to learn how to set up Meilisearch, add data, and make your first search.',
     size: 4,
-    link: '/learn/getting_started/quick_start'
+    link: '/docs/learn/getting_started/quick_start'
   },
   {
     icon: 'cube',
     content:'Consult the Meilisearch API reference.',
     size: 1,
-    link: '/reference/api/overview'
+    link: '/docs/reference/api/overview'
   },
   {
     content: 'Looking for SDK documentation? Check out this list of official Meilisearch libraries.',
     icon: 'compass',
     size: 3,
-    link: '/learn/what_is_meilisearch/sdks'
+    link: '/docs/learn/what_is_meilisearch/sdks'
   },
   {
     content: 'Announcing Meilisearch Cloud: the best way to add Meilisearch to your project',


### PR DESCRIPTION
When we write links in Markdown e.g. [link content](url), they are transformed at build so that /docs is added at the beginning—this gives us the correct site route.

However, when we write links in HTML/JS—like in component properties—they will not be transformed this way. In those cases, we have to remember the `/docs`