### PR TITLE
Migration: remove open-api-readme.mdx

### DIFF
--- a/resources/open-api-readme.mdx
+++ b/resources/open-api-readme.mdx
@@ -1,9 +1,0 @@
----
-permalink: /open-api-readme.html
----
-
-# OpenAPI
-
-Every one of Meilisearch's [API endpoints](/reference/api/overview) is also documented with [OpenAPI v3.1.0](http://spec.openapis.org/oas/v3.1.0).
-
-The raw YAML file is available [here](https://bump.sh/doc/meilisearch.yaml) and a browser interface [here](https://bump.sh/doc/meilisearch).


### PR DESCRIPTION
This file contains links to the OpenAPI specifications. We have this links on the `/reference/overview` page