### PR TITLE
Migration: update `docker` to `Docker` in the learn sidebar

### DIFF
--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -316,7 +316,7 @@
 					},
 					{
 							"source": "learn/cookbooks/docker.mdx",
-							"label": "Use with docker",
+							"label": "Use with Docker",
 							"slug": "docker"
 					},
 					{


### PR DESCRIPTION
update `docker` to `Docker` in the learn sidebar