### PR TITLE
[FIX]: homepage JSX syntax

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -11,7 +11,11 @@ Learn how to use Meilisearch in your projects by exploring our guides and API re
 
 <Featured items={[
   {
-    content:{<h2 style="margin-bottom: -10px">Quick start</h2> New here? Check out our quick start guide to learn how to set up Meilisearch, add data, and make your first search.},
+    content: (
+        <>
+          <h2 style="margin-bottom: -10px">Quick start</h2> New here? Check out our quick start guide to learn how to set up Meilisearch, add data, and make your first search.
+        </>
+      ),
     size: 4,
     link: '/docs/learn/getting_started/quick_start'
   },


### PR DESCRIPTION
# Pull Request

## What does this PR do?
Fixes homepage JSX syntax on `Featured` component.

_JSX should be always wrapped in only one tag (it can be an empty tag called "fragment"). We can use `()` for grouping it, `{}` means is a JS object so it won't work_
