### PR TITLE
Migration: remove `sidebarDepth:  2`

### DIFF
--- a/learn/advanced/asynchronous_operations.mdx
+++ b/learn/advanced/asynchronous_operations.mdx
@@ -1,8 +1,3 @@
----
-
-sidebarDepth: 2
-
----
 # Tasks and asynchronous operations
 
 Many operations in Meilisearch are processed **asynchronously**. These API requests are not handled immediately—instead, Meilisearch places them in a queue and processes them in the order they were received.

--- a/learn/advanced/faceted_search.mdx
+++ b/learn/advanced/faceted_search.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Faceted search
 
 You can use Meilisearch filters to build faceted search interfaces. This type of interface allows users to refine search results based on broad categories or facets. Faceted search provides users with a quick way to narrow down search results by selecting categories relevant to what they are looking for. A faceted navigation system is an **intuitive interface to display and navigate through content**.

--- a/learn/advanced/filtering.mdx
+++ b/learn/advanced/filtering.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Filtering
 
 Filters have several use-cases, such as refining search results and creating faceted search interfaces. Faceted search interfaces are particularly efficient in helping users navigate a great number of results across many broad categories.

--- a/learn/configuration/instance_options.mdx
+++ b/learn/configuration/instance_options.mdx
@@ -1,7 +1,3 @@
----
-sidebarDepth: 2
----
-
 # Configure Meilisearch at launch
 
 You can configure Meilisearch at launch with **command-line options**, **environment variables**, or a **configuration file**.

--- a/learn/deployment/aws.mdx
+++ b/learn/deployment/aws.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Deploy a Meilisearch instance on Amazon Web Services (AWS)
 
 Using our **Meilisearch [AMI](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html)**, Meilisearch can be deployed on AWS in just a few minutes.

--- a/learn/deployment/digitalocean.mdx
+++ b/learn/deployment/digitalocean.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Deploy a Meilisearch instance on DigitalOcean
 
 ## Part 1: Deploy Meilisearch on a Droplet

--- a/learn/deployment/gcp.mdx
+++ b/learn/deployment/gcp.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Deploy a Meilisearch instance on Google Cloud Platform (GCP) Compute Engine
 
 Using our GCP custom image, Meilisearch can be deployed on GCP in just a few minutes.

--- a/learn/update_and_migration/updating.mdx
+++ b/learn/update_and_migration/updating.mdx
@@ -1,7 +1,3 @@
----
-sidebarDepth: 2
----
-
 # Update to the latest Meilisearch version
 
 Currently, Meilisearch databases are only compatible with the version of Meilisearch used to create them. The following guide will walk you through using a [dump](/learn/advanced/dumps) to migrate an existing database from an older version of Meilisearch to the most recent one.

--- a/learn/what_is_meilisearch/comparison_to_alternatives.mdx
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Comparison to alternatives
 
 There are many search engines on the web, both open-source and otherwise. Deciding which search solution is the best fit for your project is very important, but also difficult. In this article, we'll go over the differences between Meilisearch and other search engines:

--- a/learn/what_is_meilisearch/features.mdx
+++ b/learn/what_is_meilisearch/features.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Features
 
 Meilisearch is a flexible and powerful user-focused search engine. Here are some of its major features.

--- a/learn/what_is_meilisearch/telemetry.mdx
+++ b/learn/what_is_meilisearch/telemetry.mdx
@@ -1,7 +1,3 @@
----
-sidebarDepth: 2
----
-
 # Telemetry
 
 Meilisearch collects anonymized data from users in order to improve our product. This can be [deactivated at any time](#how-to-disable-data-collection), and any data that has already been collected can be [deleted on request](#how-to-delete-all-collected-data).

--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -1,9 +1,3 @@
----
-
-sidebarDepth: 2
-
----
-
 # Search
 
 Meilisearch exposes 2 routes to perform searches:

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -1,7 +1,3 @@
----
-sidebarDepth:  2
----
-
 # Settings
 
 The `/settings` route allows you to customize search settings for the given index. You can either modify all of an index's settings at once using the [update settings endpoint](#update-settings), or modify each one individually using the child routes.


### PR DESCRIPTION
closes #2311 

Removes `sidebarDepth:  2` so users can see all headings in the "On this page" sidebar