### PR TITLE
Homepage remove explore the docs

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -7,8 +7,6 @@ description:  Everything you need to use Meilisearch.
 
 Learn how to use Meilisearch in your projects by exploring our guides and API reference.
 
-## Explore the docs
-
 <Featured items={[
   {
     content: (


### PR DESCRIPTION
Remove "explore the docs" h2 from homepage because the spacing looks strange

<img width="940" alt="Screen Shot 2023-04-06 at 7 12 36 PM" src="https://user-images.githubusercontent.com/68053732/230448974-6998907d-f893-4e24-a937-d2b48f5a5e53.png">
