### PR TITLE
Migration: update slugs in `config/sidebar-learn.json`

### DIFF
--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -63,7 +63,7 @@
 	},
 	{
 			"title": "Meilisearch 101",
-			"slug": "getting_started",
+			"slug": "meilisearch_101",
 			"routes": [
 					{
 							"source": "learn/meilisearch_101/filtering_and_sorting.mdx",
@@ -121,7 +121,7 @@
   },
 	{
 			"title": "Index settings",
-			"slug": "configuration",
+			"slug": "index_settings",
 			"routes": [
 					{
 							"source": "learn/index_settings/overview.mdx",
@@ -235,7 +235,7 @@
 	},
 	{
 			"title": "Data backup",
-			"slug": "advanced",
+			"slug": "data_backup",
 			"routes": [
 					{
 							"source": "learn/data_backup/snapshots_vs_dumps.mdx",
@@ -256,7 +256,7 @@
 	},
 	{
 			"title": "Inner workings",
-			"slug": "advanced",
+			"slug": "inner_workings",
 			"routes": [
 					{
 							"source": "learn/inner_workings/concat.mdx",
@@ -328,7 +328,7 @@
 	},
 	{
 			"title": "Deployment",
-			"slug": "cookbooks",
+			"slug": "deployment",
 			"routes": [
 					{
 							"source": "learn/deployment/aws.mdx",


### PR DESCRIPTION
Some sections were using the same slugs, so the "Previous" and "Next" page links were incorrect. This PR assigns unique slugs to each section