### PR TITLE
Change SDK page from H3s to H2s

### DIFF
--- a/learn/what_is_meilisearch/sdks.mdx
+++ b/learn/what_is_meilisearch/sdks.mdx
@@ -4,7 +4,7 @@ Our team and community have worked hard to bring Meilisearch to almost all popul
 
 New integrations are constantly in development. If you'd like to contribute, [see below](/learn/what_is_meilisearch/sdks#contributing).
 
-### SDKs
+## SDKs
 
 You can use Meilisearch API wrappers in your favorite language. These libraries support all API routes.
 
@@ -19,13 +19,13 @@ You can use Meilisearch API wrappers in your favorite language. These libraries 
 - [Rust](https://github.com/meilisearch/meilisearch-rust)
 - [Swift](https://github.com/meilisearch/meilisearch-swift)
 
-### Framework integrations
+## Framework integrations
 
 - Laravel: the official [Laravel-Scout](https://github.com/laravel/scout) package supports Meilisearch.
 - [Ruby on Rails](https://github.com/meilisearch/meilisearch-rails)
 - [Symfony](https://github.com/meilisearch/meilisearch-symfony)
 
-### Front-end tools
+## Front-end tools
 
 - [Angular](https://github.com/meilisearch/meilisearch-angular)
 - [React](https://github.com/meilisearch/meilisearch-react)
@@ -33,7 +33,7 @@ You can use Meilisearch API wrappers in your favorite language. These libraries 
 - [Instant Meilisearch](https://github.com/meilisearch/instant-meilisearch): helps you integrate a great search experience with minimum efforts.
 - [docs-searchbar.js](https://github.com/meilisearch/docs-searchbar.js): a search bar integration for all kinds of documentation.
 
-### DevOps tools
+## DevOps tools
 
 - [meilisearch-aws](https://github.com/meilisearch/meilisearch-aws)
   - Guide: [How to deploy a Meilisearch instance on Amazon Web Services](/learn/deployment/aws)
@@ -43,18 +43,18 @@ You can use Meilisearch API wrappers in your favorite language. These libraries 
   - Guide: [How to deploy a Meilisearch instance on Google Cloud Platform](/learn/deployment/gcp)
 - [meilisearch-kubernetes](https://github.com/meilisearch/meilisearch-kubernetes)
 
-### Platform plugins
+## Platform plugins
 
 - [VuePress plugin](https://github.com/meilisearch/vuepress-plugin-meilisearch)
 - [Strapi plugin](https://github.com/meilisearch/strapi-plugin-meilisearch/)
 - [Gatsby plugin](https://github.com/meilisearch/gatsby-plugin-meilisearch/)
 - [Firebase](https://github.com/meilisearch/firestore-meilisearch)
 
-### Other tools
+## Other tools
 
 - [docs-scraper](https://github.com/meilisearch/docs-scraper): a scraper tool to automatically read the content of your documentation and store it into Meilisearch.
 
-### Contributing
+## Contributing
 
 If you want to build a new integration for Meilisearch, you are more than welcome to and we would be happy to help you!
 


### PR DESCRIPTION
This page only had H3s, so nothing was showing up in the sidebar. At first I changed the `sidebarDepth`, but I think it makes more sense to follow best practices and switch to H2s.