### PR TITLE
Migration: Update asset links

### DIFF
--- a/learn/advanced/faceted_search.mdx
+++ b/learn/advanced/faceted_search.mdx
@@ -8,7 +8,7 @@ You can use Meilisearch filters to build faceted search interfaces. This type of
 
 Facets are common in ecommerce sites like Amazon. When users search for products, they are presented with a list of results and a list of facets which you can see on the sidebar in the image below:
 
-![Meilisearch demo for an ecommerce website displaying faceting UI](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/faceted-search/facets-ecommerce.png)
+![Meilisearch demo for an ecommerce website displaying faceting UI](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/faceted-search/facets-ecommerce.png)
 
 Faceted search interfaces often have a count of how many results belong to each facet. This gives users a visual clue of the range of results available for each facet.
 
@@ -24,7 +24,7 @@ Like any other filter, you must add any attributes you want to use as facets to 
 Synonyms don't apply to facets. If you have `SF` and `San Francisco` set as synonyms, faceting by `SF` and `San Francisco` will show you different results.
 </Capsule>
 
-Suppose you have a <a id="downloadBooks" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/books.json" download="books.json">books dataset</a> containing the following fields:
+Suppose you have a <a id="downloadBooks" href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/datasets/books.json" download="books.json">books dataset</a> containing the following fields:
 
 ```json
 {
@@ -163,7 +163,7 @@ With conjunctive facets, when a user selects `English` from the `language` facet
 
 The GIF below shows how the facet count for `genres` updates to only include books that meet **all three conditions**.
 
-![Selecting English books with 'Fiction' and 'Literature' as 'genres' for the books dataset](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/faceted-search/conjunctive-factes.gif)
+![Selecting English books with 'Fiction' and 'Literature' as 'genres' for the books dataset](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/faceted-search/conjunctive-factes.gif)
 
 ### Disjunctive facets
 
@@ -177,7 +177,7 @@ With disjunctive facets, when a user selects `Fiction`, and `Literature`, Meilis
 
 The GIF below shows the `books` dataset with disjunctive facets. Notice how the facet count for `genres` updates based on the selection.
 
-![Selecting 'Fiction' and 'Literature' as 'genres' for the books dataset](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/faceted-search/disjunctive_facets.gif)
+![Selecting 'Fiction' and 'Literature' as 'genres' for the books dataset](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/faceted-search/disjunctive_facets.gif)
 
 ### Combining conjunctive and disjunctive facets
 
@@ -203,4 +203,4 @@ The user can combine these two filter expressions in one by wrapping them in par
 
 The GIF below shows the `books` dataset with conjunctive and disjunctive facets. Notice how the facet count for each facet updates based on the selection.
 
-![Selecting 'Fiction' and 'Literature' as 'genres' for English books](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/faceted-search/conjunctive-and-disjunctive-facets.gif)
+![Selecting 'Fiction' and 'Literature' as 'genres' for English books](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/faceted-search/conjunctive-and-disjunctive-facets.gif)

--- a/learn/advanced/geosearch.mdx
+++ b/learn/advanced/geosearch.mdx
@@ -153,7 +153,7 @@ _geoBoundingBox([{lat}, {lng}], [{lat}, {lng}])
 
 ### Examples
 
-Using our <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/restaurants.json" download="restaurants.json">example dataset</a>, we can search for places to eat near the center of Milan with `_geoRadius`:
+Using our <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/datasets/restaurants.json" download="restaurants.json">example dataset</a>, we can search for places to eat near the center of Milan with `_geoRadius`:
 
 <CodeSamples id="geosearch_guide_filter_usage_1" />
 
@@ -256,7 +256,7 @@ The `_geoPoint` sorting function can be used like any other sorting rule. We can
 
 <CodeSamples id="geosearch_guide_sort_usage_1" />
 
-With our <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/restaurants.json" download="restaurants.json">restaurants dataset</a>, the results look like this:
+With our <a id="downloadRestaurants" href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/datasets/restaurants.json" download="restaurants.json">restaurants dataset</a>, the results look like this:
 
 ```json
 [

--- a/learn/advanced/working_with_dates.mdx
+++ b/learn/advanced/working_with_dates.mdx
@@ -59,7 +59,7 @@ game = {
 When preparing your dataset, it can be useful to leave the original date and time fields in your documents intact. In the example above, we keep the `release_date` field because it is more readable than the raw `release_timestamp`.
 </Capsule>
 
-After adding a numeric timestamp to all documents, [index your data](/reference/api/documents#add-or-replace-documents) as usual. The example below adds a <a id="downloadVideogames" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/videogames.json" download="videogames.json">videogame dataset</a> to a `games` index:
+After adding a numeric timestamp to all documents, [index your data](/reference/api/documents#add-or-replace-documents) as usual. The example below adds a <a id="downloadVideogames" href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/datasets/videogames.json" download="videogames.json">videogame dataset</a> to a `games` index:
 
 <CodeSamples id="date_guide_index_1" />
 

--- a/learn/cookbooks/postman_collection.mdx
+++ b/learn/cookbooks/postman_collection.mdx
@@ -2,7 +2,7 @@
 
 Are you tired of using the `curl` command in your terminal to test Meilisearch? It can be tedious to re-write every route when wanting to try out an API.
 
-Postman is a platform that lets you create HTTP requests you can easily reuse and share with everyone. We provide a <a href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/misc/postman/meilisearch-collection.json" download="meilisearch-collection-postman.json">Postman collection</a> containing all the routes of the Meilisearch API! 🚀
+Postman is a platform that lets you create HTTP requests you can easily reuse and share with everyone. We provide a <a href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/misc/postman/meilisearch-collection.json" download="meilisearch-collection-postman.json">Postman collection</a> containing all the routes of the Meilisearch API! 🚀
 
 <Capsule intent="tip">
 If you don't have Postman already, you can [download it here](https://www.postman.com/downloads/). It's free and available on many OS distributions.
@@ -10,28 +10,28 @@ If you don't have Postman already, you can [download it here](https://www.postma
 
 ## Import the collection
 
-Once you have downloaded the [Postman collection](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/misc/meilisearch-collection-postman.json), you need to import it into Postman.
+Once you have downloaded the [Postman collection](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/misc/meilisearch-collection-postman.json), you need to import it into Postman.
 
-![The "Import" button](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/postman/import.png)
+![The "Import" button](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/postman/import.png)
 
 ## Edit the configuration
 
-![Selecting "Edit" from the overflow menu](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/postman/edit.png)
+![Selecting "Edit" from the overflow menu](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/postman/edit.png)
 
 Set the "Token" if needed (set to `masterKey` by default):
 
-![The "Token" field set to masterKey and "Type" to Bearer Token in the "Authorization" tab.](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/postman/set_token.png)
+![The "Token" field set to masterKey and "Type" to Bearer Token in the "Authorization" tab.](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/postman/set_token.png)
 
 Set `url` (set to Meilisearch's local port by default) and `indexUID` (set to `indexUID` by default):
 
-![Setting the "url" to http://localhost:7700/ and "indexUID" to indexUId in the Variables tab.](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/postman/set_variables.png)
+![Setting the "url" to http://localhost:7700/ and "indexUID" to indexUId in the Variables tab.](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/postman/set_variables.png)
 
 The `url` and `indexUID` variables are used in all the collection routes, like in this one:
 
-![Highlighting {{url}} and {{indexUID}}](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/postman/url.png)
+![Highlighting {{url}} and {{indexUID}}](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/postman/url.png)
 
 ## Start to use it!
 
 You can now [run your Meilisearch instance](/learn/getting_started/quick_start#setup-and-installation) and create your first index:
 
-![The "Send" button](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/postman/create_index.png)
+![The "Send" button](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/postman/create_index.png)

--- a/learn/cookbooks/search_bar_for_docs.mdx
+++ b/learn/cookbooks/search_bar_for_docs.mdx
@@ -173,7 +173,7 @@ Read more about [Meilisearch security](/learn/security/master_api_keys).
 
 If you don't use VuePress for your documentation, we provide a [front-end SDK](https://github.com/meilisearch/docs-searchbar.js) to integrate a powerful and relevant search bar to any documentation website.
 
-![Docxtemplater search bar updating results for 'html'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/tuto-searchbar-for-docs/docxtemplater-searchbar-demo.gif)
+![Docxtemplater search bar updating results for 'html'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/tuto-searchbar-for-docs/docxtemplater-searchbar-demo.gif)
 _[Docxtemplater](https://docxtemplater.com/) search bar demo_
 
 ```html

--- a/learn/core_concepts/documents.mdx
+++ b/learn/core_concepts/documents.mdx
@@ -8,7 +8,7 @@ A document is an object composed of one or more fields. Each field consists of a
 
 ## Structure
 
-![Diagram illustration Meilisearch's document structure](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/document_structure.svg)
+![Diagram illustration Meilisearch's document structure](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/document_structure.svg)
 
 ### Important terms
 

--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -81,7 +81,7 @@ Results are sorted by **the similarity of the matched words with the query words
 
 <Tabs.Content label="Typo">
 
-![Demonstrating the typo ranking rule by searching for 'vogli'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/ranking-rules/vogli3.png)
+![Demonstrating the typo ranking rule by searching for 'vogli'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/vogli3.png)
 
 ### Typo
 
@@ -93,7 +93,7 @@ The `typo` rule sorts the results by increasing number of typos on matched query
 </Tabs.Content>
 
 <Tabs.Content label="Proximity">
-![Demonstrating the proximity ranking rule by searching for 'new road'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/ranking-rules/new_road.png)
+![Demonstrating the proximity ranking rule by searching for 'new road'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/new_road.png)
 
 ### Proximity
 
@@ -103,7 +103,7 @@ The `proximity` rule sorts the results by increasing distance between matched qu
 </Tabs.Content>
 
 <Tabs.Content label="Attribute">
-![Demonstrating the attribute ranking rule by searching for 'belgium'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/ranking-rules/belgium.png)
+![Demonstrating the attribute ranking rule by searching for 'belgium'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/belgium.png)
 
 ### Attribute
 
@@ -114,7 +114,7 @@ The `attribute` rule sorts the results by [attribute importance](/learn/core_con
 </Tabs.Content>
 
 <Tabs.Content label="Exactness">
-![Demonstrating the exactness ranking rule by searching for 'Knight'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/ranking-rules/knight.png?raw=true)
+![Demonstrating the exactness ranking rule by searching for 'Knight'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/knight.png?raw=true)
 
 ### Exactness
 

--- a/learn/deployment/aws.mdx
+++ b/learn/deployment/aws.mdx
@@ -14,7 +14,7 @@ The following guide will walk you through every step to deploy Meilisearch in an
 
 After logging into your [AWS Console](https://aws.amazon.com/console), navigate to the "Compute" service. Then go to "EC2", and finally open your "Instances" console.
 
-![Page titled 'Instances'. Text in center of screen: You do not have any instances in this region](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/01.launch-instances.png)
+![Page titled 'Instances'. Text in center of screen: You do not have any instances in this region](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/01.launch-instances.png)
 
 In the top-right corner, click on the "Launch instances" button to start the process of configuring your Meilisearch instance.
 
@@ -22,7 +22,7 @@ In the top-right corner, click on the "Launch instances" button to start the pro
 
 You will now select which AMI or system Image to use to run your instance. Type `meilisearch` in the search bar and select the "Community AMIs" tab on the left sidebar.
 
-![Page titled: 'Step 1: Choose an Amazon Machine Image (AMI)'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/02.select-ami.png)
+![Page titled: 'Step 1: Choose an Amazon Machine Image (AMI)'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/02.select-ami.png)
 
 Click on "Select" (right side of the screen) to confirm your choice.
 
@@ -30,7 +30,7 @@ Click on "Select" (right side of the screen) to confirm your choice.
 
 Select the specifications of the server you want Meilisearch to run on.
 
-![Page titled: 'Step 2: Choose an Instance Type'. Selecting the free tier eligible instance type](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/03.size-and-specs.png)
+![Page titled: 'Step 2: Choose an Instance Type'. Selecting the free tier eligible instance type](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/03.size-and-specs.png)
 
 We recommend prioritizing memory allocation for better Meilisearch performance.
 
@@ -44,7 +44,7 @@ Once you've made your choice, click on "Next: Configure instance details" to con
 
 Here you can specify [details of your Instance](https://docs.aws.amazon.com/efs/latest/ug/gs-step-one-create-ec2-resources.html). Since **this section is not required to run Meilisearch**, we won't cover it in this guide.
 
-![Page titled 'Step 3: Configure Instance Details'. Important: You can launch multiple instances from the same AMI, request Spot instances to take advantage of lower pricing, and assign access management role to the instance.](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/04.instance-details.png)
+![Page titled 'Step 3: Configure Instance Details'. Important: You can launch multiple instances from the same AMI, request Spot instances to take advantage of lower pricing, and assign access management role to the instance.](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/04.instance-details.png)
 
 Click "Next: Add Storage" to keep going.
 
@@ -52,7 +52,7 @@ Click "Next: Add Storage" to keep going.
 
 Choose the storage **device** and **size** for your Meilisearch instance.
 
-![Page titled 'Step 4: Add Storage'. Text at bottom of screen: Free tier eligible users can get up to 30GB of EBS General Purpose (SSD) or Magnetic storage.](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/05.storage.png)
+![Page titled 'Step 4: Add Storage'. Text at bottom of screen: Free tier eligible users can get up to 30GB of EBS General Purpose (SSD) or Magnetic storage.](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/05.storage.png)
 
 The amount of storage space required can [vary drastically](/learn/advanced/storage#measured-disk-usage) depending on the data you plan to index. In this example, we will use 25 GiB, which is more than enough for most small datasets (< 1 million documents). We have the "Volume Type" set to "General Purpose SSD (gp2)".
 
@@ -62,7 +62,7 @@ When you're ready, click on "Next: Add Tags" to continue.
 
 Tags are used to identify your resources in AWS. **They are not required by Meilisearch**.
 
-![Page titled 'Step 5: Add Tags'. Text in center of screen: Make sure your IAM policy includes permissions to create tags. ](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/06.tags.png)
+![Page titled 'Step 5: Add Tags'. Text in center of screen: Make sure your IAM policy includes permissions to create tags. ](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/06.tags.png)
 
 Click on "Next: Configure Security Groups".
 
@@ -74,7 +74,7 @@ For your Meilisearch instance to communicate with the outside world, it is very 
 - Click on "Add rule" and select "HTTP" from the drop-down menu. This will open the HTTP port (80)
 - Click on "Add rule" and select "HTTPS" from the drop-down menu. This will open the HTTPS port (443)
 
-![Page titled 'Step 6: Configure Security group'. Warning: Rules with sources of 0.0.0.0/0 allow all IP addresses to access your instance. We recommend setting security group rules to allow access from known IP addresses only.](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/07.security.png)
+![Page titled 'Step 6: Configure Security group'. Warning: Rules with sources of 0.0.0.0/0 allow all IP addresses to access your instance. We recommend setting security group rules to allow access from known IP addresses only.](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/07.security.png)
 
 By default, opened ports accept inbound traffic from any origin. If you prefer to restrict the IP addresses that are allowed to request your Meilisearch instance, go to the "Source" column and select the "Custom" option. The "Source" is set to "Anywhere" by default.
 
@@ -88,7 +88,7 @@ Once you have reviewed your instance configuration, there is one last step befor
 
 Click on "Launch" and a pop-up window will ask you to select a **key pair**. This key pair is very important as it will be your private key to access the instance via SSH, which is required to [configure your Meilisearch instance in a production environment](#part-2-configure-production-settings).
 
-![A popup titled: "Select an existing key pair or create a new key pair". Inside the popup, there is a form that allows you to configure key pairs. It also contains a warning: "Download and store your private key file in a secure accessible location. You cannot download it again once it has been created"](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/08.key-pair.png)
+![A popup titled: "Select an existing key pair or create a new key pair". Inside the popup, there is a form that allows you to configure key pairs. It also contains a warning: "Download and store your private key file in a secure accessible location. You cannot download it again once it has been created"](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/08.key-pair.png)
 
 If you have an existing Key Pair, you can use that. Otherwise, select the option "Create a new key pair" and give it a name. Then, click on "Download Key Pair" and store this file somewhere safe.
 
@@ -98,11 +98,11 @@ Once you've downloaded your key pair (and only then), click on "Launch Instances
 
 Your instance may take a minute or two to get up and running (see the "Instance state" column).
 
-![AWS dashboard showing an active instance](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/09.launch.png)
+![AWS dashboard showing an active instance](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/09.launch.png)
 
 Once the "Instance state" is "Running", use your web browser to navigate to the "Public IPv4 address" or the "Public IPv4 DNS" displayed in your AWS instances dashboard. You should see the Meilisearch [search preview](/learn/what_is_meilisearch/search_preview).
 
-![Meilisearch search preview allowing users to search an example dataset](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/10.enjoy.png)
+![Meilisearch search preview allowing users to search an example dataset](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/10.enjoy.png)
 
 Your Meilisearch instance is now ready to use!
 
@@ -120,7 +120,7 @@ Configuring your Meilisearch instance in a production environment is not just st
 
 If you want to use your own domain name (or sub-domain), add an `A record` in your domain name provider account. Otherwise, **you can skip this step**.
 
-![An interface for editing DNS records with "Type": A, "Name": my-aws-instance, "IPv4 address": 35.180.61.104, and "TTL": Auto](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/aws/11.domain.png)
+![An interface for editing DNS records with "Type": A, "Name": my-aws-instance, "IPv4 address": 35.180.61.104, and "TTL": Auto](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/aws/11.domain.png)
 
 Your domain name should now be linked to your Meilisearch instance. Run a health check to verify that your instance is running and your DNS is well configured:
 

--- a/learn/deployment/azure.mdx
+++ b/learn/deployment/azure.mdx
@@ -16,7 +16,7 @@ You can deploy a Meilisearch instance via the official [Meilisearch Docker image
 
 [![Deploy To Azure](https://raw.githubusercontent.com/Azure/azure-quickstart-templates/master/1-CONTRIBUTION-GUIDE/images/deploytoazure.svg?sanitize=true)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fcmaneu%2Fmeilisearch-on-azure%2Fmain%2Fmain.json).
 
-![The Azure portal prompting for information to deploy Meilisearch](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/azure/01.azure-deploy-button.png)
+![The Azure portal prompting for information to deploy Meilisearch](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/azure/01.azure-deploy-button.png)
 
 When clicking this button, you'll be redirected to the Azure Portal and asked a few questions:
 
@@ -34,7 +34,7 @@ By default, the instance created is on a Standard plan. This will incur costs in
 
 After a few minutes, the deployment will be complete. You'll be able to access your instance URL by clicking on the "Outputs" tabs on the left.
 
-![The Azure portal showing information about your Meilisearch deployment](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/azure/02.azure-output.png)
+![The Azure portal showing information about your Meilisearch deployment](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/azure/02.azure-output.png)
 
 <Capsule intent="tip">
 While Meilisearch is usually exposed on port `7700`, this deployment will expose your instance on port `433`. An SSL certificate will be generated and managed for you by Azure.

--- a/learn/deployment/digitalocean.mdx
+++ b/learn/deployment/digitalocean.mdx
@@ -12,7 +12,7 @@ DigitalOcean Droplets are Linux-based virtual machines in which you can run your
 
 Once you log in to your DigitalOcean account, click the green "Create" button at the top-right of the page and select "Droplets".
 
-![Selecting "Droplets" from the "Create" dropdown](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/create.png)
+![Selecting "Droplets" from the "Create" dropdown](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/create.png)
 
 [Refer to DigitalOcean's documentation to learn more about creating and configuring Droplets.](https://docs.digitalocean.com/tutorials/droplets/)
 
@@ -20,25 +20,25 @@ Once you log in to your DigitalOcean account, click the green "Create" button at
 
 Select the region where you want to deploy your Droplet. Remember, the closer you are to your users, the better their search experience with Meilisearch will be.
 
-![Selecting the London data center region](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/select-region.png)
+![Selecting the London data center region](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/select-region.png)
 
 ### 3. Select Meilisearch image
 
 By default, DigitalOcean displays the "OS" tab. Select the "Marketplace" tab, search for "Meilisearch", and select the image.
 
-![Search results for 'Meilisearch' in Marketplace](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/marketplace.png)
+![Search results for 'Meilisearch' in Marketplace](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/marketplace.png)
 
 ### 4. Choose Droplet size
 
 This is where you choose the amount of RAM, storage, and CPU cores your Droplet will have. Select your plan based on your needs. Memory-optimized options will give you better results when working with big datasets.
 
-![Selecting the plan based on your usage](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/select-plan.png)
+![Selecting the plan based on your usage](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/select-plan.png)
 
 ### 5. Choose an authentication method
 
 You can either use SSH keys or a password to access your Droplet. We recommend using SSH keys as they are more secure.
 
-![Selecting SSH keys for authentication](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/add-ssh-key.png)
+![Selecting SSH keys for authentication](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/add-ssh-key.png)
 
 Select the SSH keys you want to add to your Droplet. If you don't have a key, [follow DigitalOcean's instructions on how to create one](https://www.digitalocean.com/docs/droplets/how-to/add-ssh-keys/to-account/).
 
@@ -46,25 +46,25 @@ Select the SSH keys you want to add to your Droplet. If you don't have a key, [f
 
 Here you can select the name that will be visible everywhere in your DigitalOcean account. Droplets can only contain alphanumeric characters, dashes, and periods.
 
-![Adding 'meilisearch-droplet-name' as the hostname](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/droplet-name.png)
+![Adding 'meilisearch-droplet-name' as the hostname](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/droplet-name.png)
 
 Tags are great for managing resources. They are custom labels you assign to droplets. Tags can contain letters, numbers, colons, dashes, and underscores. You can use multiple tags for a single resource. Try naming tags based on a droplet's function.
 
-![The search bar, meilisearch, and search-team tags](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/add-tags.png)
+![The search bar, meilisearch, and search-team tags](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/add-tags.png)
 
 ### 7. Click on "Create Droplet"
 
-![The "Create Droplet" button](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/create-droplet.png)
+![The "Create Droplet" button](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/create-droplet.png)
 
 ### 8. Test Meilisearch
 
 Once created, click on the Droplet's public IP address to copy it:
 
-![meilisearch-droplet-name instance's IP: 165.227.56.77](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/copy-ip.png)
+![meilisearch-droplet-name instance's IP: 165.227.56.77](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/copy-ip.png)
 
 Paste it into your browser. If you can access the search preview, Meilisearch is ready to use.
 
-![Meilisearch search preview](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/test-meili.png)
+![Meilisearch search preview](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/test-meili.png)
 
 ## Part 2: Configure production settings in your Meilisearch Droplet
 
@@ -74,11 +74,11 @@ To configure Meilisearch for **production** on a DigitalOcean Droplet, [use SSH 
 
 If you want to use your own domain, click the "Create" button and select "Domain/DNS".
 
-![Selecting Domain/DNS from the Create menu](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/domain.png)
+![Selecting Domain/DNS from the Create menu](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/domain.png)
 
 Type in your domain name in the "Enter domain field" and click "Add Domain".
 
-![Domains tab on the Networking page](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/digitalocean/add-domain.png)
+![Domains tab on the Networking page](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/digitalocean/add-domain.png)
 
 This should work out of the box. Your domain name should now be linked to your Meilisearch instance. Use `curl` to access it and verify DNS has been properly configured:
 

--- a/learn/deployment/gcp.mdx
+++ b/learn/deployment/gcp.mdx
@@ -14,11 +14,11 @@ The following guide will walk you through every step to deploy Meilisearch in a 
 
 - Navigate to "Compute Engine" -> "Images"
 
-![Page titled 'Images'](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/01.compute-engine.png)
+![Page titled 'Images'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/01.compute-engine.png)
 
 - Click on "[+] CREATE IMAGE"
 
-![Adding image name(permanent), source, and cloud storage file](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/02.image-info.png)
+![Adding image name(permanent), source, and cloud storage file](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/02.image-info.png)
 
 - Give it a name (`meilisearch-example`)
 
@@ -36,31 +36,31 @@ meilisearch-image/meilisearch-v1.0.2-debian-10.vmdk
 
 - Click on "Create". You may have to wait up to 6 minutes while the Meilisearch custom image imports to your account
 
-![meilisearch-example successfully imported](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/03.import-image.png)
+![meilisearch-example successfully imported](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/03.import-image.png)
 
 ### 2. Create a new GCP Compute Engine instance from the imported image
 
 - Open the tab "Images" and click on the name of the image that you just imported, and click on the "[+] Create instance" button
 
-![The meilisearch-v-X-X-X instance](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/04.create-instance.png)
+![The meilisearch-v-X-X-X instance](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/04.create-instance.png)
 
 - Give your instance a name
 
 - In the "Machine configuration" section, make sure to pick a "Machine type" with enough memory to run Meilisearch according to your needs. More memory means faster searching
 
-![Selecting the 'E2' series and 'e2-medium (2 vCPU, 4 GB memory)' machine type](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/05.machine-configuration.png)
+![Selecting the 'E2' series and 'e2-medium (2 vCPU, 4 GB memory)' machine type](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/05.machine-configuration.png)
 
 - In the "Boot disk" section, click the "Change" button
 
 - From the "Custom images" tab, select the image that you just imported in the previous steps (meilisearch-vX-X-X) from the drop down menu. Don't forget to set the "Size" of the disk to an amount corresponding to your needs. When you are done, click on "Select"
 
-![Selecting the 'Balanced persistent disk' Boot disk type and 10GB Size](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/06.boot-disk.png)
+![Selecting the 'Balanced persistent disk' Boot disk type and 10GB Size](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/06.boot-disk.png)
 
 - In the "Firewall" section, make sure to check the "Allow HTTP traffic" and "Allow HTTPS traffic" boxes so that your Meilisearch instance can communicate with the internet
 
 - Finally, click on the "Create" button. After a minute or two, your Meilisearch instance should be up and running
 
-![The meilisearch-gcp-test instance running successfully](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/07.instance-running.png)
+![The meilisearch-gcp-test instance running successfully](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/07.instance-running.png)
 
 You can check that your instance is running correctly by copying and pasting the "External IP" address provided by GCP into your browser, or by typing the following command on your terminal:
 
@@ -82,7 +82,7 @@ Configuring your Meilisearch instance in a production environment is not just st
 
 If you want to use a custom domain name (or sub-domain), add an `A record` in your domain name provider account. Otherwise, you can skip this step.
 
-![The my-gcp-instance domain](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/gcp/08.domain.png)
+![The my-gcp-instance domain](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/gcp/08.domain.png)
 
 Your domain name should now be linked to your Meilisearch instance. Run a health check to verify that your instance is running and your DNS is well configured:
 

--- a/learn/deployment/railway.mdx
+++ b/learn/deployment/railway.mdx
@@ -46,7 +46,7 @@ Setting a master key is optional, but without it, your server will accept uniden
 
 Copy the public URL (for example, `meilisearch-production-up.railway.app`) of your project from your [Railway account dashboard](https://railway.app/dashboard) and paste it into your browser.
 
-![Railway dashboard](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/railway/public-url.png)
+![Railway dashboard](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/railway/public-url.png)
 
 You should land on the Meilisearch [search preview](/learn/what_is_meilisearch/search_preview), where you will be asked to enter your master key.
 

--- a/learn/getting_started/quick_start.mdx
+++ b/learn/getting_started/quick_start.mdx
@@ -151,13 +151,13 @@ To search on multiple indexes at the same time with a single request, use the [`
 
 Meilisearch offers a browser-based search preview where you can search through a selected index. You can access it any time Meilisearch is running at `http://localhost:7700`.
 
-![Meilisearch's search preview showing the movies index](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/search_preview/default.png)
+![Meilisearch's search preview showing the movies index](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/search_preview/default.png)
 
 For security reasons, the search preview is only available in [development mode.](/learn/configuration/instance_options#environment)
 
 If you have multiple indexes, you can switch between them using the indexes dropdown.
 
-![Meilisearch's search preview indicating the indexes dropdown in the upper right corner](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/search_preview/multiple_indexes.png)
+![Meilisearch's search preview indicating the indexes dropdown in the upper right corner](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/search_preview/multiple_indexes.png)
 
 ## Customization
 

--- a/learn/meilisearch_101/filtering_and_sorting.mdx
+++ b/learn/meilisearch_101/filtering_and_sorting.mdx
@@ -2,7 +2,7 @@
 
 Welcome to the Meilisearch 101! This guide aims to introduce you to the main features of Meilisearch as efficiently as possible. It assumes that you have completed the [Quick start](/learn/getting_started/quick_start) and already have a running Meilisearch instance.
 
-This chapter uses a dataset of meteorites to demonstrate filtering, sorting, and geosearch. To follow along, first click this link to download the file: <a id="downloadmeteorites" href="https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/datasets/meteorites.json" download="meteorites.json">meteorites.json</a>. Then, move it into your working directory and run the following command:
+This chapter uses a dataset of meteorites to demonstrate filtering, sorting, and geosearch. To follow along, first click this link to download the file: <a id="downloadmeteorites" href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/datasets/meteorites.json" download="meteorites.json">meteorites.json</a>. Then, move it into your working directory and run the following command:
 
 <CodeSamples id="getting_started_add_meteorites" />
 

--- a/learn/update_and_migration/updating.mdx
+++ b/learn/update_and_migration/updating.mdx
@@ -24,11 +24,11 @@ If you're using Meilisearch Cloud, you don't need to follow the rest of this gui
 
 Click on the project you want to update. Look for the "Project overview" section at the top of the page. Once a new version of Meilisearch is available, you should see an update button next to the "Meilisearch version" field.
 
-![Button to update Meilisearch version to 1.0.2](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/updating/update-button.png)
+![Button to update Meilisearch version to 1.0.2](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/updating/update-button.png)
 
 Clicking the button will open a pop-up warning. Once you agree to the update, the "Status" of your project will change from "running" to "updating".
 
-![Project update in progress](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/updating/update-in-progress.png)
+![Project update in progress](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/updating/update-in-progress.png)
 
 Once the project has been successfully updated, you will receive an email confirming the update and the "Status" will change back to "running".
 

--- a/learn/what_is_meilisearch/overview.mdx
+++ b/learn/what_is_meilisearch/overview.mdx
@@ -12,7 +12,7 @@ Our solution delivers an **instant search experience** including **typo handling
 
 ## Demo
 
-![Search bar updating results](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/crates-io-demo.gif)
+![Search bar updating results](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/crates-io-demo.gif)
 _Meilisearch helps the Rust community find crates on [crates.meilisearch.com](https://crates.meilisearch.com)._
 
 ## Features
@@ -50,4 +50,4 @@ Instead of showing you examples, why not just invite you to test Meilisearch int
 
 There's no need to write a single line of front-end code. All you need to do is follow [this guide](/learn/getting_started/quick_start) to give the search engine a try!
 
-![Meilisearch search preview](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/search_preview/no_documents.png)
+![Meilisearch search preview](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/search_preview/no_documents.png)

--- a/learn/what_is_meilisearch/search_preview.mdx
+++ b/learn/what_is_meilisearch/search_preview.mdx
@@ -4,7 +4,7 @@ After adding documents to your Meilisearch instance, you can immediately start s
 
 If your Meilisearch instance does not have any indexes, you should see this screen.
 
-![Meilisearch search preview instructing the user to set an API key and configure an index](https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/images/search_preview/no_documents.png)
+![Meilisearch search preview instructing the user to set an API key and configure an index](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/search_preview/no_documents.png)
 
 To access the search preview in your browser, navigate to the address and port specified in the command line argument `--http-addr`. If you did not configure `--http-addr` when launching your instance, [Meilisearch's default address for the search preview is localhost:7700](/learn/configuration/instance_options#http-address-port-binding).
 


### PR DESCRIPTION
This PR updates all asset links from `https://raw.githubusercontent.com/meilisearch/documentation/new-docs-content-migration/assets/...` to `https://raw.githubusercontent.com/meilisearch/documentation/main/assets/...`