### PR TITLE
Add warning to settings and multi search API reference

### DIFF
--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -66,7 +66,7 @@ Each search result object is composed of the following fields:
 <CodeSamples id="multi_search_1" />
 
 <Capsule intent="warning">
-If one or more sent queries have an error, Meilisearch will not return any results.
+If one or more sent queries have an error, Meilisearch will not return any results. In case of multiple errors, the error message will only address the first erroneous query.
 </Capsule>
 
 #### Response: `200 Ok`

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -65,6 +65,10 @@ Each search result object is composed of the following fields:
 
 <CodeSamples id="multi_search_1" />
 
+<Capsule intent="warning">
+If one or more sent queries have an error, Meilisearch will not return any results.
+</Capsule>
+
 #### Response: `200 Ok`
 
 ```json

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -66,7 +66,7 @@ Each search result object is composed of the following fields:
 <CodeSamples id="multi_search_1" />
 
 <Capsule intent="warning">
-If one or more sent queries have an error, Meilisearch will not return any results. In case of multiple errors, the error message will only address the first erroneous query.
+If one or more sent queries are badly formatted or cause an error, Meilisearch will throw an error. In case of multiple errors in the query, the error message will only address the first erroneous query.
 </Capsule>
 
 #### Response: `200 Ok`

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -66,7 +66,7 @@ Each search result object is composed of the following fields:
 <CodeSamples id="multi_search_1" />
 
 <Capsule intent="warning">
-If one or more sent queries are badly formatted or cause an error, Meilisearch will throw an error. In case of multiple errors in the query, the error message will only address the first erroneous query.
+If Meilisearch encounters an error when processing any of the queries in a multi-search request, it immediately interrupts the process and returns an error message. In case of multiple errors in the query, the error message will only address the first erroneous query.
 </Capsule>
 
 #### Response: `200 Ok`

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -66,7 +66,7 @@ Each search result object is composed of the following fields:
 <CodeSamples id="multi_search_1" />
 
 <Capsule intent="warning">
-If Meilisearch encounters an error when handling any of the queries in a multi-search request, it immediately stops processing the request and returns an error message. If a request contains multiple issues, the returned message will only address the first error.
+If Meilisearch encounters an error when handling any of the queries in a multi-search request, it immediately stops processing the request and returns an error message. The returned message will only address the first error encountered.
 </Capsule>
 
 #### Response: `200 Ok`

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -66,7 +66,7 @@ Each search result object is composed of the following fields:
 <CodeSamples id="multi_search_1" />
 
 <Capsule intent="warning">
-If Meilisearch encounters an error when processing any of the queries in a multi-search request, it immediately interrupts the process and returns an error message. In case of multiple errors in the query, the error message will only address the first erroneous query.
+If Meilisearch encounters an error when handling any of the queries in a multi-search request, it immediately stops processing the request and returns an error message. If a request contains multiple issues, the returned message will only address the first error.
 </Capsule>
 
 #### Response: `200 Ok`

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -153,7 +153,7 @@ If the provided index does not exist, it will be created.
 <CodeSamples id="update_settings_1" />
 
 <Capsule intent="warning">
-If one or more settings are badly formatted or cause an error, Meilisearch will throw an error. In case of multiple errors in the settings, the error message will only address the first erroneous setting.
+If Meilisearch encounters an error when updating any of the settings in a request, it immediately interrupts the process and returns an error message. If one or more settings are badly formatted or cause an error, Meilisearch will throw an error. In case of multiple errors in the settings, the error message will only address the first erroneous setting.
 </Capsule>
 
 ##### Response: `202 Accepted`

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -153,7 +153,7 @@ If the provided index does not exist, it will be created.
 <CodeSamples id="update_settings_1" />
 
 <Capsule intent="warning">
-If Meilisearch encounters an error when updating any of the settings in a request, it immediately interrupts the process and returns an error message. If one or more settings are badly formatted or cause an error, Meilisearch will throw an error. In case of multiple errors in the settings, the error message will only address the first erroneous setting.
+If Meilisearch encounters an error when updating any of the settings in a request, it immediately stops processing the request and returns an error message. In this case, the database settings remain unchanged. If a request contains multiple issues, the returned message only addresses the first error. 
 </Capsule>
 
 ##### Response: `202 Accepted`

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -153,7 +153,7 @@ If the provided index does not exist, it will be created.
 <CodeSamples id="update_settings_1" />
 
 <Capsule intent="warning">
-If Meilisearch encounters an error when updating any of the settings in a request, it immediately stops processing the request and returns an error message. In this case, the database settings remain unchanged. If a request contains multiple issues, the returned message only addresses the first error. 
+If Meilisearch encounters an error when updating any of the settings in a request, it immediately stops processing the request and returns an error message. In this case, the database settings remain unchanged. The returned error message will only address the first error encountered.
 </Capsule>
 
 ##### Response: `202 Accepted`

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -153,7 +153,7 @@ If the provided index does not exist, it will be created.
 <CodeSamples id="update_settings_1" />
 
 <Capsule intent="warning">
-If one or more settings have an error, Meilisearch will not return any results. In case of multiple errors, the error message will only address the first erroneous setting.
+If one or more settings are badly formatted or cause an error, Meilisearch will throw an error. In case of multiple errors in the settings, the error message will only address the first erroneous setting.
 </Capsule>
 
 ##### Response: `202 Accepted`

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -153,7 +153,7 @@ If the provided index does not exist, it will be created.
 <CodeSamples id="update_settings_1" />
 
 <Capsule intent="warning">
-If one or more settings have an error, Meilisearch will not return any results.
+If one or more settings have an error, Meilisearch will not return any results. In case of multiple errors, the error message will only address the first erroneous setting.
 </Capsule>
 
 ##### Response: `202 Accepted`

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -152,6 +152,10 @@ If the provided index does not exist, it will be created.
 
 <CodeSamples id="update_settings_1" />
 
+<Capsule intent="warning">
+If one or more settings have an error, Meilisearch will not return any results.
+</Capsule>
+
 ##### Response: `202 Accepted`
 
 ```json


### PR DESCRIPTION
closes #2326 

This PR adds a warning that if one or more query/setting is badly formatted, or has a typo or error, Meilisearch will thrown an error. In case of multiple errors in the  query/setting, the error only addresses the first erroneous query/setting.