### PR TITLE
v1.1.1:disable auto-batching

### DIFF
--- a/learn/core_concepts/documents.mdx
+++ b/learn/core_concepts/documents.mdx
@@ -135,6 +135,10 @@ If you don't specify the data type for an attribute, it will default to `:string
 
 ### Auto-batching
 
+<Capsule intent="danger">
+Auto-batching has been disabled for document addition and deletion in v1.1.1. See [this GitHub issue](https://github.com/meilisearch/meilisearch/issues/3664) for more details.
+</Capsule>
+
 Auto-batching combines consecutive document addition and deletion requests into a single batch and processes them together while respecting the order. This significantly speeds up the indexing process.
 
 Meilisearch batches document addition and deletion requests when they:


### PR DESCRIPTION
Auto-batching has been disabled temporarily for document addition and deletion tasks in v1.1.1. See https://github.com/meilisearch/meilisearch/pull/3667 for more details