### PR TITLE
update multi-search API page

### DIFF
--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -4,7 +4,7 @@ The `/multi-search` route allows you to perform multiple search queries on one o
 
 ## Search with `multi-search`
 
-Search for documents matching a specific query in one or more indexes.
+Perform multiple searches in a single request.
 
 <RouteHighlighter method="POST" route="/multi-search"/>
 

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -2,7 +2,7 @@
 
 The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-search is also known as federated search.
 
-## Search with `multi-search`
+## Search with `/multi-search` route
 
 Perform multiple searches in a single request.
 

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -2,9 +2,9 @@
 
 The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-search is also known as federated search.
 
-## Search with `/multi-search` route
+## Perform a multi-search
 
-Perform multiple searches in a single request.
+Bundle multiple search queries in a single API request.
 
 <RouteHighlighter method="POST" route="/multi-search"/>
 

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -2,15 +2,19 @@
 
 The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-search is also known as federated search.
 
+## Search with `multi-search`
+
+Search for documents matching a specific query in one or more indexes.
+
 <RouteHighlighter method="POST" route="/multi-search"/>
 
-## Body
+### Body
 
 | Name          | Type             | Description                                                                                                                                          |
 | :------------ | :--------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`queries`** | Array of objects | Contains the list of search queries to perform. The [`indexUid`](#search-parameters) search parameter is required, all other parameters are optional |
 
-### Search parameters
+#### Search parameters
 
 | Search parameter                                                                | Type             | Default value | Description                                         |
 | :------------------------------------------------------------------------------ | :--------------- | :------------ | :-------------------------------------------------- |
@@ -35,7 +39,7 @@ The `/multi-search` route allows you to perform multiple search queries on one o
 
 [Learn more about how to use each search parameter](/reference/api/search#search-parameters).
 
-## Response
+### Response
 
 | Name          | Type             | Description                                                            |
 | :------------ | :--------------- | :--------------------------------------------------------------------- |
@@ -59,11 +63,11 @@ Each search result object is composed of the following fields:
 | **`processingTimeMs`**   | Number           | Processing time of the query                                                            |
 | **`query`**              | String           | Query originating the response                                                          |
 
-## Example
+### Example
 
 <CodeSamples id="multi_search_1" />
 
-### Response: `200 Ok`
+#### Response: `200 Ok`
 
 ```json
 {

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -2,17 +2,15 @@
 
 The `/multi-search` route allows you to perform multiple search queries on one or more indexes by bundling them into a single HTTP request. Multi-search is also known as federated search.
 
-## POST route
-
 <RouteHighlighter method="POST" route="/multi-search"/>
 
-### Body
+## Body
 
 | Name          | Type             | Description                                                                                                                                          |
 | :------------ | :--------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`queries`** | Array of objects | Contains the list of search queries to perform. The [`indexUid`](#search-parameters) search parameter is required, all other parameters are optional |
 
-#### Search parameters
+### Search parameters
 
 | Search parameter                                                                | Type             | Default value | Description                                         |
 | :------------------------------------------------------------------------------ | :--------------- | :------------ | :-------------------------------------------------- |
@@ -37,7 +35,7 @@ The `/multi-search` route allows you to perform multiple search queries on one o
 
 [Learn more about how to use each search parameter](/reference/api/search#search-parameters).
 
-### Response
+## Response
 
 | Name          | Type             | Description                                                            |
 | :------------ | :--------------- | :--------------------------------------------------------------------- |
@@ -61,11 +59,11 @@ Each search result object is composed of the following fields:
 | **`processingTimeMs`**   | Number           | Processing time of the query                                                            |
 | **`query`**              | String           | Query originating the response                                                          |
 
-### Example
+## Example
 
 <CodeSamples id="multi_search_1" />
 
-#### Response: `200 Ok`
+### Response: `200 Ok`
 
 ```json
 {

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -4,7 +4,7 @@ The `/multi-search` route allows you to perform multiple search queries on one o
 
 ## Perform a multi-search
 
-Bundle multiple search queries in a single API request.
+Bundle multiple search queries in a single API request. Use this endpoint to search through multiple indexes at once.
 
 <RouteHighlighter method="POST" route="/multi-search"/>
 


### PR DESCRIPTION
Updates the multi-search API page to:
- Rename "POST route" to "Perform a multi-search"
- Add a description for the route 

Related to: https://github.com/meilisearch/documentation/pull/2370#issuecomment-1521539855

## To do:

- [ ] Move warning added in https://github.com/meilisearch/documentation/pull/2370 to main endpoint description

## Redirects
Added in https://github.com/meilisearch/meilisearch.com/pull/122

