### PR TITLE
v1.2: New experimental instance option `--experimental-reduce-indexing-memory-usage`

### DIFF
--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -375,6 +375,11 @@
 							"source": "learn/experimental/metrics.mdx",
 							"label": "Metrics",
 							"slug": "metrics"
+					},
+					{
+							"source": "learn/experimental/reduce-indexing-memory-usage.mdx",
+							"label": "Reduce indexing memory usage",
+							"slug": "reduce-indexing-memory-usage"
 					}
 			]
 	},

--- a/learn/experimental/metrics.mdx
+++ b/learn/experimental/metrics.mdx
@@ -4,10 +4,10 @@ The `/metrics` endpoint exposes data compatible with [Prometheus](https://promet
 
 [Visit the GitHub discussion to learn how to use this feature](https://github.com/meilisearch/product/discussions/625).
 
-Are you using this feature? Meilisearch wants to hear from you! Tell us about your experience in the [GitHub discussion](https://github.com/meilisearch/product/discussions/625). All feedback is useful and helps make Meilisearch better and easier-to-use.
+Are you using this feature? Meilisearch wants to hear from you! Tell us about your experience in the [GitHub discussion](https://github.com/meilisearch/product/discussions/625). All feedback is useful and helps make Meilisearch better and easier to use.
 
 <Capsule intent="warning">
 `/metrics` is an experimental feature. Experimental features are unstable: their API might significantly change and become incompatible between releases. Meilisearch does not recommend using experimental features in a production environment.
 
-Meilisearch makes experimental features available with the expectation they will become stable in future releases. However, it is not possible to guarantee when and if this will happen.
+Meilisearch makes experimental features available expecting they will become stable in a future release. However, it is not possible to guarantee when and if this will happen.
 </Capsule>

--- a/learn/experimental/reduce-indexing-memory-usage.mdx
+++ b/learn/experimental/reduce-indexing-memory-usage.mdx
@@ -1,6 +1,6 @@
 # Reduce indexing memory usage
 
-The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LMDB option. Activating it can help reduce RAM usage in some UNIX and UNIX-like setups. However, it may also negatively impact write speeds and overall performance.
+The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LMDB option. Activating it can reduce RAM usage in some UNIX and UNIX-like setups. However, it may also negatively impact write speeds and overall performance.
 
 [Visit the GitHub discussion to learn how to use this feature](https://github.com/meilisearch/product/discussions/652).
 

--- a/learn/experimental/reduce-indexing-memory-usage.mdx
+++ b/learn/experimental/reduce-indexing-memory-usage.mdx
@@ -1,13 +1,13 @@
 # Reduce indexing memory usage
 
-The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LLMDB option. Activating it can help reducing RAM usage in some setups. However, it may also negatively impact write speeds and overall performance.
+The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LLMDB option. Activating it can help reducing RAM usage in some UNIX and UNIX-like setups. However, it may also negatively impact write speeds and overall performance.
 
 [Visit the GitHub discussion to learn how to use this feature](https://github.com/meilisearch/product/discussions/652).
 
-Are you using `--experimental-reduce-indexing-memory-usage`? Meilisearch wants to hear from you! Tell us about your experience in the [GitHub discussion](https://github.com/meilisearch/product/discussions/652). All feedback is useful and helps make Meilisearch better and easier-to-use.
+Are you using `--experimental-reduce-indexing-memory-usage`? Meilisearch wants to hear from you! Tell us about your experience in the [GitHub discussion](https://github.com/meilisearch/product/discussions/652). All feedback is useful and helps make Meilisearch better and easier to use.
 
 <Capsule intent="warning">
 This is an experimental feature. Experimental features are unstable: their implementation might significantly change and become incompatible between releases. Meilisearch does not recommend using experimental features in a production environment.
 
-Meilisearch makes experimental features available with the expectation they will become stable in future releases. However, it is not possible to guarantee when and if this will happen.
+Meilisearch makes experimental features available expecting they will become stable in a future release. However, it is not possible to guarantee when and if this will happen.
 </Capsule>

--- a/learn/experimental/reduce-indexing-memory-usage.mdx
+++ b/learn/experimental/reduce-indexing-memory-usage.mdx
@@ -1,6 +1,6 @@
 # Reduce indexing memory usage
 
-The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LLMDB option. Activating it can help reducing RAM usage in some UNIX and UNIX-like setups. However, it may also negatively impact write speeds and overall performance.
+The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LMDB option. Activating it can help reduce RAM usage in some UNIX and UNIX-like setups. However, it may also negatively impact write speeds and overall performance.
 
 [Visit the GitHub discussion to learn how to use this feature](https://github.com/meilisearch/product/discussions/652).
 

--- a/learn/experimental/reduce-indexing-memory-usage.mdx
+++ b/learn/experimental/reduce-indexing-memory-usage.mdx
@@ -1,0 +1,13 @@
+# Reduce indexing memory usage
+
+The `--experimental-reduce-indexing-memory-usage` configuration option enables `MDB_WRITEMAP`, an LLMDB option. Activating it can help reducing RAM usage in some setups. However, it may also negatively impact write speeds and overall performance.
+
+[Visit the GitHub discussion to learn how to use this feature](https://github.com/meilisearch/product/discussions/652).
+
+Are you using `--experimental-reduce-indexing-memory-usage`? Meilisearch wants to hear from you! Tell us about your experience in the [GitHub discussion](https://github.com/meilisearch/product/discussions/652). All feedback is useful and helps make Meilisearch better and easier-to-use.
+
+<Capsule intent="warning">
+This is an experimental feature. Experimental features are unstable: their implementation might significantly change and become incompatible between releases. Meilisearch does not recommend using experimental features in a production environment.
+
+Meilisearch makes experimental features available with the expectation they will become stable in future releases. However, it is not possible to guarantee when and if this will happen.
+</Capsule>


### PR DESCRIPTION
Create page introducing `--experimental-reduce-indexing-memory-usage` to docs users and redirecting them to the feature discussion in the product repository for usage instructions.

Closes #2427 