### PR TITLE
Move warning in `multi-search.mdx` to main endpoint description

### DIFF
--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -14,6 +14,10 @@ Bundle multiple search queries in a single API request. Use this endpoint to sea
 | :------------ | :--------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`queries`** | Array of objects | Contains the list of search queries to perform. The [`indexUid`](#search-parameters) search parameter is required, all other parameters are optional |
 
+<Capsule intent="warning">
+If Meilisearch encounters an error when handling any of the queries in a multi-search request, it immediately stops processing the request and returns an error message. The returned message will only address the first error encountered.
+</Capsule>
+
 #### Search parameters
 
 | Search parameter                                                                | Type             | Default value | Description                                         |
@@ -66,10 +70,6 @@ Each search result object is composed of the following fields:
 ### Example
 
 <CodeSamples id="multi_search_1" />
-
-<Capsule intent="warning">
-If Meilisearch encounters an error when handling any of the queries in a multi-search request, it immediately stops processing the request and returns an error message. The returned message will only address the first error encountered.
-</Capsule>
 
 #### Response: `200 Ok`
 


### PR DESCRIPTION
This PR updates `/reference/api/multi_search` to move the warning added in https://github.com/meilisearch/documentation/pull/2370 to the main endpoint description