### PR TITLE
remove SQL from filter expressions

### DIFF
--- a/learn/advanced/filtering.mdx
+++ b/learn/advanced/filtering.mdx
@@ -336,7 +336,7 @@ If you only want recent `Planet of the Apes` movies that weren't directed by `Ti
 
 `NOT director = "Tim Burton"` will include both documents that do not contain `"Tim Burton"` in its `director` field and documents without a `director` field. To return only documents that have a `director` field, expand the filter expression with the `EXISTS` operator:
 
-```SQL
+```
 release_date > 1577884550 AND (NOT director = "Tim Burton" AND director EXISTS)
 ```
 

--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -439,7 +439,7 @@ For more information on how to use filters and build filter expressions, [read o
 
 You can write a filter expression in string syntax using logical connectives:
 
-```SQL
+```
 "(genres = horror OR genres = mystery) AND director = 'Jordan Peele'"
 ```
 


### PR DESCRIPTION
This PR removes "```SQL" from filter expressions that aren't using SQL.