### PR TITLE
Add missing backlash in command for checking document status

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -472,7 +472,7 @@ getting_started_add_documents_md: |-
   ```
 getting_started_check_task_status: |-
   curl \
-    -X GET 'http://localhost:7700/tasks/0'
+    -X GET 'http://localhost:7700/tasks/0' \
     -H 'Authorization: Bearer aSampleMasterKey'
 getting_started_search_md: |-
   ```bash


### PR DESCRIPTION
# Pull Request

## Related issue
N/A

## What does this PR do?
Added the missing backslash for the CURL command to check document status. Without this, user will get error: "authorization header is missing".

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
