### PR TITLE
Breakdown Advanced topics: Add Tasks and async workflow section

### DIFF
--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -109,7 +109,7 @@
         "routes": [
             {
                 "source": "learn/async/asynchronous_operations.mdx",
-                "label": "Task and asynchronous operations",
+                "label": "Tasks and asynchronous operations",
                 "slug": "asynchronous_operations"
             },
             {

--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -104,6 +104,22 @@
       ]
   },
   {
+        "title": "Tasks and asynchronous workflow",
+        "slug": "async",
+        "routes": [
+            {
+                "source": "learn/async/asynchronous_operations.mdx",
+                "label": "Asynchronous operations",
+                "slug": "asynchronous_operations"
+            },
+            {
+                "source": "learn/async/filtering_and_paginating_tasks.mdx",
+                "label": "Filtering and paginating tasks",
+                "slug": "filtering_and_paginating_tasks"
+            }
+    ]
+  }, 
+  {
       "title": "Configuration",
       "slug": "configuration",
       "routes": [
@@ -191,11 +207,6 @@
 			"title": "Advanced topics",
 			"slug": "advanced",
 			"routes": [
-					{
-							"source": "learn/advanced/asynchronous_operations.mdx",
-							"label": "Tasks and asynchronous operations",
-							"slug": "asynchronous_operations"
-					},
 					{
 							"source": "learn/advanced/filtering.mdx",
 							"label": "Filtering",

--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -109,7 +109,7 @@
         "routes": [
             {
                 "source": "learn/async/asynchronous_operations.mdx",
-                "label": "Asynchronous operations",
+                "label": "Task and asynchronous operations",
                 "slug": "asynchronous_operations"
             },
             {

--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -113,9 +113,9 @@
                 "slug": "asynchronous_operations"
             },
             {
-                "source": "learn/async/filtering_and_paginating_tasks.mdx",
-                "label": "Filtering and paginating tasks",
-                "slug": "filtering_and_paginating_tasks"
+                "source": "learn/async/managing_tasks.mdx",
+                "label": "Managing the task database",
+                "slug": "managing_tasks"
             }
     ]
   }, 

--- a/learn/async/asynchronous_operations.mdx
+++ b/learn/async/asynchronous_operations.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarDepth: 3
 ---
-# Tasks and asynchronous operations
+# Asynchronous operations
 
 Many operations in Meilisearch are processed **asynchronously**. These API requests are not handled immediately—instead, Meilisearch places them in a queue and processes them in the order they were received.
 
@@ -81,9 +81,9 @@ Tasks always contain a field indicating the task's current `status`. This field 
 - **`failed`**: a failure occurred when processing the task. No changes were made to the database
 - **`canceled`**: the task was canceled
 
-`succeeded`, `failed`, and `canceled` tasks are finished tasks. Meilisearch keeps them in the task database, but has finished processing these tasks.
+`succeeded`, `failed`, and `canceled` tasks are finished tasks. Meilisearch keeps them in the task database but has finished processing these tasks.
 
-`enqueued` and `processing` tasks are unfinished tasks. Meilisearch is either processing them, or will do so in the future.
+`enqueued` and `processing` tasks are unfinished tasks. Meilisearch is either processing them or will do so in the future.
 
 #### Global tasks
 
@@ -126,7 +126,7 @@ All other tasks are processed in the order they were enqueued.
 
 When you make a [request for an asynchronous operation](#which-operations-are-asynchronous), Meilisearch processes all tasks following the same steps:
 
-1. Meilisearch creates a task, puts it in the task queue, and returns a [summarized `task` object](/learn/advanced/asynchronous_operations#summarized-task-objects). Task `status` set to `enqueued`
+1. Meilisearch creates a task, puts it in the task queue, and returns a [summarized `task` object](/learn/async/asynchronous_operations#summarized-task-objects). Task `status` set to `enqueued`
 2. When your task reaches the front of the queue, Meilisearch begins working on it. Task `status` set to `processing`
 3. Meilisearch finishes the task. Status set to `succeeded` if task was successfully processed, or `failed` if there was an error
 
@@ -223,98 +223,3 @@ Had the task failed, the response would have included a detailed `error` object:
 If the task had been [canceled](/reference/api/tasks#cancel-tasks) while it was `enqueued` or `processing`, it would have the `canceled` status and a non-`null` value for the `canceledBy` field.
 
 After a task has been [deleted](/reference/api/tasks#delete-tasks), trying to access it returns a [`task_not_found`](/reference/errors/error_codes#task-not-found) error.
-
-## Filtering tasks
-
-Querying the [get tasks endpoint](/reference/api/tasks#get-tasks) returns all tasks that have not been deleted. Use query parameters to filter tasks based on `uid`, `status`, `type`, `indexUid`, `canceledBy`, or date. Separate multiple values with a comma (`,`).
-
-### Filter by `uid`
-
-The following code sample returns tasks with `uid`s `5`, `10`, and `13`:
-
-<CodeSamples id="async_guide_filter_by_ids_1" />
-
-### Filter by `status`
-
-The following code sample returns tasks with the `failed` and `canceled` statuses:
-
-<CodeSamples id="async_guide_filter_by_statuses_1" />
-
-### Filter by `type`
-
-The following code sample returns `dumpCreation` and `indexSwap` tasks:
-
-<CodeSamples id="async_guide_filter_by_types_1" />
-
-### Filter by `indexUid`
-
-The following command returns all tasks belonging to the index `movies`. Note that the `indexUid` is case-sensitive:
-
-<CodeSamples id="async_guide_filter_by_index_uids_1" />
-
-### Filter by `canceledBy`
-
-Use the `canceledBy` filter to view all tasks canceled by one or more `taskCancelation` tasks:
-
-<CodeSamples id="async_guide_canceled_by_1" />
-
-### Filter by date
-
-You can filter tasks by their `enqueuedAt`, `startedAt`, and `finishedAt` fields. To do so, prepend either `before` or `after` to each field name:
-
-- `enqueuedAt` → `beforeEnqueuedAt` or `afterEnqueuedAt`
-- `startedAt` → `beforeStartedAt` or `afterStartedAt`
-- `finishedAt` →`beforeFinishedAt`  or `afterFinishedAt`
-
-This filter accepts dates formatted according to [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt):
-
-- `YYYY-MM-DD`
-- `YYYY-MM-DDTHH:MM:SSZ`
-- `YYYY-MM-DDTHH:MM:SS+01:00`
-
-<CodeSamples id="async_guide_filter_by_date_1" />
-
-The above code sample will return all tasks `enqueued` **after** 11:49:53:00 on 11 Oct 2020.
-
-<Capsule intent="note">
-Date filters are equivalent to `<` or `>` operations and do not include the specified value. It is not possible to perform `≤` or `≥` operations with a task date filter.
-</Capsule>
-
-### Combine filters
-
-You can combine task filters. Use the ampersand character (`&`) to combine filters, equivalent to a logical `AND`.
-
-The following code sample returns all tasks in the `movies` index that have the type `documentAdditionOrUpdate` or `documentDeletion` and have the `status` of `processing`.
-
-<CodeSamples id="async_guide_multiple_filters_1" />
-
-**`OR` operations between different filters are not supported.** For example, you cannot view only tasks which have a type of `documentAddition` **or** a status of `failed`.
-
-## Paginating tasks
-
-By default, Meilisearch returns a list of 20 tasks for each request. You can adjust the number of tasks returned using the `limit` parameter, and control where the list begins using the `from` parameter.
-
-For each call to this endpoint, the response will include the `next` field. When you call the endpoint again, pass this value as the `from` parameter to view the next set of results.
-
-The following command returns two tasks at a time, starting from task `uid` `10`:
-
-<CodeSamples id="get_all_tasks_paginating_1" />
-
-**Response:**
-
-```json
-{
-  "results": [
-    …
-  ],
-  "limit": 2,
-  "from": 10,
-  "next": 8
-}
-```
-
-To view the next set of results, you would repeat the same query, replacing the value of `from` with the value of `next`:
-
-<CodeSamples id="get_all_tasks_paginating_2" />
-
-When the returned value of `next` is `null`, you have reached the final set of results.

--- a/learn/async/asynchronous_operations.mdx
+++ b/learn/async/asynchronous_operations.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarDepth: 3
 ---
-# Asynchronous operations
+# Task and asynchronous operations
 
 Many operations in Meilisearch are processed **asynchronously**. These API requests are not handled immediately—instead, Meilisearch places them in a queue and processes them in the order they were received.
 

--- a/learn/async/asynchronous_operations.mdx
+++ b/learn/async/asynchronous_operations.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarDepth: 3
 ---
-# Task and asynchronous operations
+# Tasks and asynchronous operations
 
 Many operations in Meilisearch are processed **asynchronously**. These API requests are not handled immediately—instead, Meilisearch places them in a queue and processes them in the order they were received.
 

--- a/learn/async/filtering_and_paginating_tasks.mdx
+++ b/learn/async/filtering_and_paginating_tasks.mdx
@@ -1,0 +1,99 @@
+---
+sidebarDepth: 3
+---
+# Filtering and paginating tasks
+
+## Filtering tasks
+
+Querying the [get tasks endpoint](/reference/api/tasks#get-tasks) returns all tasks that have not been deleted. Use query parameters to filter tasks based on `uid`, `status`, `type`, `indexUid`, `canceledBy`, or date. Separate multiple values with a comma (`,`).
+
+### Filter by `uid`
+
+The following code sample returns tasks with `uid`s `5`, `10`, and `13`:
+
+<CodeSamples id="async_guide_filter_by_ids_1" />
+
+### Filter by `status`
+
+The following code sample returns tasks with the `failed` and `canceled` statuses:
+
+<CodeSamples id="async_guide_filter_by_statuses_1" />
+
+### Filter by `type`
+
+The following code sample returns `dumpCreation` and `indexSwap` tasks:
+
+<CodeSamples id="async_guide_filter_by_types_1" />
+
+### Filter by `indexUid`
+
+The following command returns all tasks belonging to the index `movies`. Note that the `indexUid` is case-sensitive:
+
+<CodeSamples id="async_guide_filter_by_index_uids_1" />
+
+### Filter by `canceledBy`
+
+Use the `canceledBy` filter to view all tasks canceled by one or more `taskCancelation` tasks:
+
+<CodeSamples id="async_guide_canceled_by_1" />
+
+### Filter by date
+
+You can filter tasks by their `enqueuedAt`, `startedAt`, and `finishedAt` fields. To do so, prepend either `before` or `after` to each field name:
+
+- `enqueuedAt` → `beforeEnqueuedAt` or `afterEnqueuedAt`
+- `startedAt` → `beforeStartedAt` or `afterStartedAt`
+- `finishedAt` →`beforeFinishedAt`  or `afterFinishedAt`
+
+This filter accepts dates formatted according to [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt):
+
+- `YYYY-MM-DD`
+- `YYYY-MM-DDTHH:MM:SSZ`
+- `YYYY-MM-DDTHH:MM:SS+01:00`
+
+<CodeSamples id="async_guide_filter_by_date_1" />
+
+The above code sample will return all tasks `enqueued` **after** 11:49:53:00 on 11 Oct 2020.
+
+<Capsule intent="note">
+Date filters are equivalent to `<` or `>` operations and do not include the specified value. It is not possible to perform `≤` or `≥` operations with a task date filter.
+</Capsule>
+
+### Combine filters
+
+You can combine task filters. Use the ampersand character (`&`) to combine filters, equivalent to a logical `AND`.
+
+The following code sample returns all tasks in the `movies` index that have the type `documentAdditionOrUpdate` or `documentDeletion` and have the `status` of `processing`.
+
+<CodeSamples id="async_guide_multiple_filters_1" />
+
+**`OR` operations between different filters are not supported.** For example, you cannot view only tasks which have a type of `documentAddition` **or** a status of `failed`.
+
+## Paginating tasks
+
+By default, Meilisearch returns a list of 20 tasks for each request. You can adjust the number of tasks returned using the `limit` parameter, and control where the list begins using the `from` parameter.
+
+For each call to this endpoint, the response will include the `next` field. When you call the endpoint again, pass this value as the `from` parameter to view the next set of results.
+
+The following command returns two tasks at a time, starting from task `uid` `10`:
+
+<CodeSamples id="get_all_tasks_paginating_1" />
+
+**Response:**
+
+```json
+{
+  "results": [
+    …
+  ],
+  "limit": 2,
+  "from": 10,
+  "next": 8
+}
+```
+
+To view the next set of results, you would repeat the same query, replacing the value of `from` with the value of `next`:
+
+<CodeSamples id="get_all_tasks_paginating_2" />
+
+When the returned value of `next` is `null`, you have reached the final set of results.

--- a/learn/async/managing_tasks.mdx
+++ b/learn/async/managing_tasks.mdx
@@ -1,7 +1,7 @@
 ---
 sidebarDepth: 3
 ---
-# Filtering and paginating tasks
+# Managing the task database
 
 ## Filtering tasks
 

--- a/learn/data_backup/dumps.mdx
+++ b/learn/data_backup/dumps.mdx
@@ -12,7 +12,7 @@ To create a dump of your dataset, use the [create a dump endpoint](/reference/ap
 
 <CodeSamples id="post_dump_1" />
 
-The above code triggers a dump creation process. It also returns a [summarized task object](/learn/advanced/asynchronous_operations#summarized-task-objects) that you can use to check the status of your dump.
+The above code triggers a dump creation process. It also returns a [summarized task object](/learn/async/asynchronous_operations#summarized-task-objects) that you can use to check the status of your dump.
 
 ```json
 {

--- a/learn/getting_started/quick_start.mdx
+++ b/learn/getting_started/quick_start.mdx
@@ -107,7 +107,7 @@ Use the returned `taskUid` to [check the status](/reference/api/tasks) of your d
 <CodeSamples id="getting_started_check_task_status" />
 
 <Capsule intent="note">
-Most database operations in Meilisearch are [asynchronous](/learn/advanced/asynchronous_operations). Rather than being processed instantly, **API requests are added to a queue and processed one at a time**.
+Most database operations in Meilisearch are [asynchronous](/learn/async/asynchronous_operations). Rather than being processed instantly, **API requests are added to a queue and processed one at a time**.
 </Capsule>
 
 If the document addition is successful, the response should look like this:

--- a/learn/meilisearch_101/getting_ready_for_production.mdx
+++ b/learn/meilisearch_101/getting_ready_for_production.mdx
@@ -36,6 +36,6 @@ You can read more about tenant tokens and how to generate them in our [dedicated
 
 Hopefully, these chapters have given you a basic introduction to Meilisearch and some of the things it can do. Once you get the hang of the basics, the possibilities are endless. To continue exploring Meilisearch, check out:
 
-- [Advanced topics](/learn/advanced/asynchronous_operations)
+- [Tasks and asynchronous workflow](/learn/async/asynchronous_operations)
 - [API references](/reference/api/overview)
 - [Configuration](/learn/configuration/instance_options)

--- a/reference/api/dump.mdx
+++ b/reference/api/dump.mdx
@@ -12,7 +12,7 @@ Triggers a dump creation task. Once the process is complete, a dump is created i
 
 Dump tasks take priority over all other tasks in the queue. This means that a newly created dump task will be processed as soon as the current task is finished.
 
-[Learn more about asynchronous operations](/learn/advanced/asynchronous_operations).
+[Learn more about asynchronous operations](/learn/async/asynchronous_operations).
 
 ### Example
 

--- a/reference/api/indexes.mdx
+++ b/reference/api/indexes.mdx
@@ -258,7 +258,7 @@ You can swap multiple pairs of indexes with a single request. To do so, there mu
 ```
 
 <Capsule intent="note">
-Since `indexSwap` is a [global task](/learn/advanced/asynchronous_operations#global-tasks), the `indexUid` is always `null`.
+Since `indexSwap` is a [global task](/learn/async/asynchronous_operations#global-tasks), the `indexUid` is always `null`.
 </Capsule>
 
 You can use the response's `taskUid` to [track the status of your request](/reference/api/tasks#get-one-task).

--- a/reference/api/overview.mdx
+++ b/reference/api/overview.mdx
@@ -131,7 +131,7 @@ Meilisearch is an **asynchronous API**. This means that in response to most writ
 
 You can use this `taskUid` to get more details on [the status of the task](/reference/api/tasks#get-one-task).
 
-See more information about [asynchronous operations](/learn/advanced/asynchronous_operations).
+See more information about [asynchronous operations](/learn/async/asynchronous_operations).
 
 ## Data types
 

--- a/reference/api/tasks.mdx
+++ b/reference/api/tasks.mdx
@@ -208,7 +208,7 @@ List all tasks globally, regardless of index. The `task` objects are contained i
 
 Tasks are always returned in descending order of `uid`. This means that by default, **the most recently created `task` objects appear first**.
 
-Task results are [paginated](/learn/async/filtering_and_paginating_tasks#paginating-tasks) and can be [filtered](/learn/async/filtering_and_paginating_tasks#filtering-tasks).
+Task results are [paginated](/learn/async/managing_tasks#paginating-tasks) and can be [filtered](/learn/async/managing_tasks#filtering-tasks).
 
 ### Query parameters
 
@@ -216,17 +216,17 @@ Task results are [paginated](/learn/async/filtering_and_paginating_tasks#paginat
 | :--------------------- | :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`limit`**            | `20`                           | Number of tasks to return                                                                                                                                          |
 | **`from`**             | `uid` of the last created task | `uid` of the first task returned                                                                                                                                   |
-| **`uids`**             | `*` (all uids)                 | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `uid`. Separate multiple task `uids` with a comma (`,`)                           |
-| **`statuses`**         | `*` (all statuses)             | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `status`. Separate multiple task `statuses` with a comma (`,`)                    |
-| **`types`**            | `*` (all types)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `type`. Separate multiple task `types` with a comma (`,`)                         |
-| **`indexUids`**        | `*` (all indexes)              | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `indexUid`. Separate multiple task `indexUids` with a comma (`,`). Case-sensitive |
-| **`canceledBy`**       | N/A                            | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-canceledby) by their `canceledBy` field. Separate multiple task `uids` with a comma (`,`)         |
-| **`beforeEnqueuedAt`** | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `enqueuedAt` field                                                                 |
-| **`beforeStartedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `startedAt` field                                                                  |
-| **`beforeFinishedAt`** | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `finishedAt` field                                                                 |
-| **`afterEnqueuedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `enqueuedAt` field                                                                 |
-| **`afterStartedAt`**   | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `startedAt` field                                                                  |
-| **`afterFinishedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `finishedAt` field                                                                 |
+| **`uids`**             | `*` (all uids)                 | [Filter tasks](/learn/async/managing_tasks#filtering-tasks) by their `uid`. Separate multiple task `uids` with a comma (`,`)                           |
+| **`statuses`**         | `*` (all statuses)             | [Filter tasks](/learn/async/managing_tasks#filtering-tasks) by their `status`. Separate multiple task `statuses` with a comma (`,`)                    |
+| **`types`**            | `*` (all types)                | [Filter tasks](/learn/async/managing_tasks#filtering-tasks) by their `type`. Separate multiple task `types` with a comma (`,`)                         |
+| **`indexUids`**        | `*` (all indexes)              | [Filter tasks](/learn/async/managing_tasks#filtering-tasks) by their `indexUid`. Separate multiple task `indexUids` with a comma (`,`). Case-sensitive |
+| **`canceledBy`**       | N/A                            | [Filter tasks](/learn/async/managing_tasks#filter-by-canceledby) by their `canceledBy` field. Separate multiple task `uids` with a comma (`,`)         |
+| **`beforeEnqueuedAt`** | `*` (all tasks)                | [Filter tasks](/learn/async/managing_tasks#filter-by-date) by their `enqueuedAt` field                                                                 |
+| **`beforeStartedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/managing_tasks#filter-by-date) by their `startedAt` field                                                                  |
+| **`beforeFinishedAt`** | `*` (all tasks)                | [Filter tasks](/learn/async/managing_tasks#filter-by-date) by their `finishedAt` field                                                                 |
+| **`afterEnqueuedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/managing_tasks#filter-by-date) by their `enqueuedAt` field                                                                 |
+| **`afterStartedAt`**   | `*` (all tasks)                | [Filter tasks](/learn/async/managing_tasks#filter-by-date) by their `startedAt` field                                                                  |
+| **`afterFinishedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/managing_tasks#filter-by-date) by their `finishedAt` field                                                                 |
 
 ### Response
 
@@ -367,7 +367,7 @@ A valid `uids`, `statuses`, `types`, `indexUids`, or date(`beforeXAt` or `afterX
 Date filters are equivalent to `<` or `>` operations. At this time, there is no way to perform a `≤` or `≥` operations with a date filter.
 </Capsule>
 
-[To learn more about filtering tasks, refer to our dedicated guide.](/learn/async/filtering_and_paginating_tasks#filtering-tasks)
+[To learn more about filtering tasks, refer to our dedicated guide.](/learn/async/managing_tasks#filtering-tasks)
 
 ### Example
 
@@ -431,7 +431,7 @@ A valid `uids`, `statuses`, `types`, `indexUids`, `canceledBy`, or date(`beforeX
 Date filters are equivalent to `<` or `>` operations. At this time, there is no way to perform a `≤` or `≥` operations with a date filter.
 </Capsule>
 
-[To learn more about filtering tasks, refer to our dedicated guide.](/learn/async/filtering_and_paginating_tasks#filtering-tasks)
+[To learn more about filtering tasks, refer to our dedicated guide.](/learn/async/managing_tasks#filtering-tasks)
 
 ### Example
 

--- a/reference/api/tasks.mdx
+++ b/reference/api/tasks.mdx
@@ -1,6 +1,6 @@
 # Tasks
 
-The `/tasks` route gives information about the progress of [asynchronous operations](/learn/advanced/asynchronous_operations).
+The `/tasks` route gives information about the progress of [asynchronous operations](/learn/async/asynchronous_operations).
 
 ## Task object
 
@@ -42,7 +42,7 @@ The task `uid` is incremented **globally.**
 **Description**:  Unique identifier of the targeted index
 
 <Capsule intent="note">
-This value is always `null` for [global tasks](/learn/advanced/asynchronous_operations#global-tasks).
+This value is always `null` for [global tasks](/learn/async/asynchronous_operations#global-tasks).
 </Capsule>
 
 ### `status`
@@ -193,7 +193,7 @@ When an API request triggers an asynchronous process, Meilisearch returns a summ
 | Field            | Type    | Description                                                                                                                   |
 | :--------------- | :------ | :---------------------------------------------------------------------------------------------------------------------------- |
 | **`taskUid`**    | Integer | Unique sequential identifier                                                                                                  |
-| **`indexUid`**   | String  | Unique index identifier (always `null` for [global tasks](/learn/advanced/asynchronous_operations#global-tasks))              |
+| **`indexUid`**   | String  | Unique index identifier (always `null` for [global tasks](/learn/async/asynchronous_operations#global-tasks))              |
 | **`status`**     | String  | Status of the task. Value is `enqueued`                                                                                       |
 | **`type`**       | String  | Type of task                                                                                                                  |
 | **`enqueuedAt`** | String  | Represents the date and time in the [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format when the task has been `enqueued` |
@@ -208,7 +208,7 @@ List all tasks globally, regardless of index. The `task` objects are contained i
 
 Tasks are always returned in descending order of `uid`. This means that by default, **the most recently created `task` objects appear first**.
 
-Task results are [paginated](/learn/advanced/asynchronous_operations#paginating-tasks) and can be [filtered](/learn/advanced/asynchronous_operations#filtering-tasks).
+Task results are [paginated](/learn/async/filtering_and_paginating_tasks#paginating-tasks) and can be [filtered](/learn/async/filtering_and_paginating_tasks#filtering-tasks).
 
 ### Query parameters
 
@@ -216,17 +216,17 @@ Task results are [paginated](/learn/advanced/asynchronous_operations#paginating-
 | :--------------------- | :----------------------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **`limit`**            | `20`                           | Number of tasks to return                                                                                                                                          |
 | **`from`**             | `uid` of the last created task | `uid` of the first task returned                                                                                                                                   |
-| **`uids`**             | `*` (all uids)                 | [Filter tasks](/learn/advanced/asynchronous_operations#filtering-tasks) by their `uid`. Separate multiple task `uids` with a comma (`,`)                           |
-| **`statuses`**         | `*` (all statuses)             | [Filter tasks](/learn/advanced/asynchronous_operations#filtering-tasks) by their `status`. Separate multiple task `statuses` with a comma (`,`)                    |
-| **`types`**            | `*` (all types)                | [Filter tasks](/learn/advanced/asynchronous_operations#filtering-tasks) by their `type`. Separate multiple task `types` with a comma (`,`)                         |
-| **`indexUids`**        | `*` (all indexes)              | [Filter tasks](/learn/advanced/asynchronous_operations#filtering-tasks) by their `indexUid`. Separate multiple task `indexUids` with a comma (`,`). Case-sensitive |
-| **`canceledBy`**       | N/A                            | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-canceledby) by their `canceledBy` field. Separate multiple task `uids` with a comma (`,`)         |
-| **`beforeEnqueuedAt`** | `*` (all tasks)                | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-date) by their `enqueuedAt` field                                                                 |
-| **`beforeStartedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-date) by their `startedAt` field                                                                  |
-| **`beforeFinishedAt`** | `*` (all tasks)                | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-date) by their `finishedAt` field                                                                 |
-| **`afterEnqueuedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-date) by their `enqueuedAt` field                                                                 |
-| **`afterStartedAt`**   | `*` (all tasks)                | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-date) by their `startedAt` field                                                                  |
-| **`afterFinishedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/advanced/asynchronous_operations#filter-by-date) by their `finishedAt` field                                                                 |
+| **`uids`**             | `*` (all uids)                 | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `uid`. Separate multiple task `uids` with a comma (`,`)                           |
+| **`statuses`**         | `*` (all statuses)             | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `status`. Separate multiple task `statuses` with a comma (`,`)                    |
+| **`types`**            | `*` (all types)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `type`. Separate multiple task `types` with a comma (`,`)                         |
+| **`indexUids`**        | `*` (all indexes)              | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filtering-tasks) by their `indexUid`. Separate multiple task `indexUids` with a comma (`,`). Case-sensitive |
+| **`canceledBy`**       | N/A                            | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-canceledby) by their `canceledBy` field. Separate multiple task `uids` with a comma (`,`)         |
+| **`beforeEnqueuedAt`** | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `enqueuedAt` field                                                                 |
+| **`beforeStartedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `startedAt` field                                                                  |
+| **`beforeFinishedAt`** | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `finishedAt` field                                                                 |
+| **`afterEnqueuedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `enqueuedAt` field                                                                 |
+| **`afterStartedAt`**   | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `startedAt` field                                                                  |
+| **`afterFinishedAt`**  | `*` (all tasks)                | [Filter tasks](/learn/async/filtering_and_paginating_tasks#filter-by-date) by their `finishedAt` field                                                                 |
 
 ### Response
 
@@ -367,7 +367,7 @@ A valid `uids`, `statuses`, `types`, `indexUids`, or date(`beforeXAt` or `afterX
 Date filters are equivalent to `<` or `>` operations. At this time, there is no way to perform a `≤` or `≥` operations with a date filter.
 </Capsule>
 
-[To learn more about filtering tasks, refer to our dedicated guide.](/learn/advanced/asynchronous_operations#filtering-tasks)
+[To learn more about filtering tasks, refer to our dedicated guide.](/learn/async/filtering_and_paginating_tasks#filtering-tasks)
 
 ### Example
 
@@ -386,7 +386,7 @@ Date filters are equivalent to `<` or `>` operations. At this time, there is no 
 ```
 
 <Capsule intent="note">
-Since `taskCancelation` is a [global task](/learn/advanced/asynchronous_operations#global-tasks), its `indexUid` is always `null`.
+Since `taskCancelation` is a [global task](/learn/async/asynchronous_operations#global-tasks), its `indexUid` is always `null`.
 </Capsule>
 
 You can use this `taskUid` to get more details on the [status of the task](#get-one-task).
@@ -431,7 +431,7 @@ A valid `uids`, `statuses`, `types`, `indexUids`, `canceledBy`, or date(`beforeX
 Date filters are equivalent to `<` or `>` operations. At this time, there is no way to perform a `≤` or `≥` operations with a date filter.
 </Capsule>
 
-[To learn more about filtering tasks, refer to our dedicated guide.](/learn/advanced/asynchronous_operations#filtering-tasks)
+[To learn more about filtering tasks, refer to our dedicated guide.](/learn/async/filtering_and_paginating_tasks#filtering-tasks)
 
 ### Example
 
@@ -450,7 +450,7 @@ Date filters are equivalent to `<` or `>` operations. At this time, there is no 
 ```
 
 <Capsule intent="note">
-Since `taskDeletion` is a [global task](/learn/advanced/asynchronous_operations#global-tasks), its `indexUid` is always `null`.
+Since `taskDeletion` is a [global task](/learn/async/asynchronous_operations#global-tasks), its `indexUid` is always `null`.
 </Capsule>
 
 You can use this `taskUid` to get more details on the [status of the task](#get-one-task).

--- a/resources/faq.mdx
+++ b/resources/faq.mdx
@@ -67,7 +67,7 @@ Check your error message for more information.
 ## Is killing a Meilisearch process safe?
 
 Killing Meilisearch is **safe**, even in the middle of a process (ex: adding a batch of documents). When you restart the server, it will start the task from the beginning.
-More information in the [asynchronous operations guide](/learn/advanced/asynchronous_operations).
+More information in the [asynchronous operations guide](/learn/async/asynchronous_operations).
 
 ## Do you provide a public roadmap for Meilisearch and its integration tools?
 


### PR DESCRIPTION
closes https://github.com/meilisearch/documentation/issues/2434


This PR:
- Adds a new section called "Tasks and asynchronous workflow" after the "Core concepts" section
- Adds two new pages to this section:
  -  Asynchronous operations
  - Filtering and paginating tasks
- Moves both pages to a new `async` folder under `learn`

Redirects added in: https://github.com/meilisearch/meilisearch.com/pull/130/files