### PR TITLE
Update `relevancy.mdx` to remove h3s from containers+add missing tab

### DIFF
--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -83,7 +83,7 @@ Results are sorted by **the similarity of the matched words with the query words
 
 ![Demonstrating the typo ranking rule by searching for 'vogli'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/vogli3.png)
 
-**Typo**
+##### Typo
 
 - `vogli`: 0 typo
 - `volli`: 1 typo
@@ -95,7 +95,7 @@ The `typo` rule sorts the results by increasing number of typos on matched query
 <Tabs.Content label="Proximity">
 ![Demonstrating the proximity ranking rule by searching for 'new road'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/new_road.png)
 
-**Proximity**
+##### Proximity
 
 The reason why `Creature` is listed before `Mississippi Grind` is because of the `proximity` rule. The smallest **distance** between the matching words in `creature` is smaller than the smallest **distance** between the matching words in `Mississippi Grind`.
 
@@ -105,7 +105,7 @@ The `proximity` rule sorts the results by increasing distance between matched qu
 <Tabs.Content label="Attribute">
 ![Demonstrating the attribute ranking rule by searching for 'belgium'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/belgium.png)
 
-**Attribute**
+##### Attribute
 
 `If It's Tuesday, This must be Belgium` is the first document because the matched word `Belgium` is found in the `title` attribute and not the `overview`.
 
@@ -116,7 +116,7 @@ The `attribute` rule sorts the results by [attribute importance](/learn/core_con
 <Tabs.Content label="Exactness">
 ![Demonstrating the exactness ranking rule by searching for 'Knight'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/knight.png?raw=true)
 
-**Exactness**
+##### Exactness
 
 `Knight Moves` is displayed before `Knights of Badassdom`. `Knight` is exactly the same as the search query `Knight` whereas there is a letter of difference between `Knights` and the search query `Knight`.
 

--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -83,7 +83,7 @@ Results are sorted by **the similarity of the matched words with the query words
 
 ![Demonstrating the typo ranking rule by searching for 'vogli'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/vogli3.png)
 
-**Typo**
+##### Typo
 
 - `vogli`: 0 typo
 - `volli`: 1 typo

--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -83,7 +83,7 @@ Results are sorted by **the similarity of the matched words with the query words
 
 ![Demonstrating the typo ranking rule by searching for 'vogli'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/vogli3.png)
 
-##### Typo
+**Typo**
 
 - `vogli`: 0 typo
 - `volli`: 1 typo
@@ -95,7 +95,7 @@ The `typo` rule sorts the results by increasing number of typos on matched query
 <Tabs.Content label="Proximity">
 ![Demonstrating the proximity ranking rule by searching for 'new road'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/new_road.png)
 
-##### Proximity
+**Proximity**
 
 The reason why `Creature` is listed before `Mississippi Grind` is because of the `proximity` rule. The smallest **distance** between the matching words in `creature` is smaller than the smallest **distance** between the matching words in `Mississippi Grind`.
 
@@ -105,7 +105,7 @@ The `proximity` rule sorts the results by increasing distance between matched qu
 <Tabs.Content label="Attribute">
 ![Demonstrating the attribute ranking rule by searching for 'belgium'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/belgium.png)
 
-##### Attribute
+**Attribute**
 
 `If It's Tuesday, This must be Belgium` is the first document because the matched word `Belgium` is found in the `title` attribute and not the `overview`.
 
@@ -116,7 +116,7 @@ The `attribute` rule sorts the results by [attribute importance](/learn/core_con
 <Tabs.Content label="Exactness">
 ![Demonstrating the exactness ranking rule by searching for 'Knight'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/knight.png?raw=true)
 
-##### Exactness
+**Exactness**
 
 `Knight Moves` is displayed before `Knights of Badassdom`. `Knight` is exactly the same as the search query `Knight` whereas there is a letter of difference between `Knights` and the search query `Knight`.
 

--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -95,7 +95,7 @@ The `typo` rule sorts the results by increasing number of typos on matched query
 <Tabs.Content label="Proximity">
 ![Demonstrating the proximity ranking rule by searching for 'new road'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/new_road.png)
 
-**Proximity**
+##### Proximity
 
 The reason why `Creature` is listed before `Mississippi Grind` is because of the `proximity` rule. The smallest **distance** between the matching words in `creature` is smaller than the smallest **distance** between the matching words in `Mississippi Grind`.
 
@@ -105,7 +105,7 @@ The `proximity` rule sorts the results by increasing distance between matched qu
 <Tabs.Content label="Attribute">
 ![Demonstrating the attribute ranking rule by searching for 'belgium'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/belgium.png)
 
-**Attribute**
+##### Attribute
 
 `If It's Tuesday, This must be Belgium` is the first document because the matched word `Belgium` is found in the `title` attribute and not the `overview`.
 
@@ -116,7 +116,7 @@ The `attribute` rule sorts the results by [attribute importance](/learn/core_con
 <Tabs.Content label="Exactness">
 ![Demonstrating the exactness ranking rule by searching for 'Knight'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/knight.png?raw=true)
 
-**Exactness**
+##### Exactness
 
 `Knight Moves` is displayed before `Knights of Badassdom`. `Knight` is exactly the same as the search query `Knight` whereas there is a letter of difference between `Knights` and the search query `Knight`.
 

--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -77,7 +77,7 @@ Results are sorted by **the similarity of the matched words with the query words
 
 #### Examples
 
-<Tabs.Container labels={["Typo", "Proximity", "Attribute"]}>
+<Tabs.Container labels={["Typo", "Proximity", "Attribute", "Exactness"]}>
 
 <Tabs.Content label="Typo">
 

--- a/learn/core_concepts/relevancy.mdx
+++ b/learn/core_concepts/relevancy.mdx
@@ -83,7 +83,7 @@ Results are sorted by **the similarity of the matched words with the query words
 
 ![Demonstrating the typo ranking rule by searching for 'vogli'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/vogli3.png)
 
-### Typo
+**Typo**
 
 - `vogli`: 0 typo
 - `volli`: 1 typo
@@ -95,7 +95,7 @@ The `typo` rule sorts the results by increasing number of typos on matched query
 <Tabs.Content label="Proximity">
 ![Demonstrating the proximity ranking rule by searching for 'new road'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/new_road.png)
 
-### Proximity
+**Proximity**
 
 The reason why `Creature` is listed before `Mississippi Grind` is because of the `proximity` rule. The smallest **distance** between the matching words in `creature` is smaller than the smallest **distance** between the matching words in `Mississippi Grind`.
 
@@ -105,7 +105,7 @@ The `proximity` rule sorts the results by increasing distance between matched qu
 <Tabs.Content label="Attribute">
 ![Demonstrating the attribute ranking rule by searching for 'belgium'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/belgium.png)
 
-### Attribute
+**Attribute**
 
 `If It's Tuesday, This must be Belgium` is the first document because the matched word `Belgium` is found in the `title` attribute and not the `overview`.
 
@@ -116,7 +116,7 @@ The `attribute` rule sorts the results by [attribute importance](/learn/core_con
 <Tabs.Content label="Exactness">
 ![Demonstrating the exactness ranking rule by searching for 'Knight'](https://raw.githubusercontent.com/meilisearch/documentation/main/assets/images/ranking-rules/knight.png?raw=true)
 
-### Exactness
+**Exactness**
 
 `Knight Moves` is displayed before `Knights of Badassdom`. `Knight` is exactly the same as the search query `Knight` whereas there is a letter of difference between `Knights` and the search query `Knight`.
 


### PR DESCRIPTION
1. This PR removes the following headings from containers:
![Screenshot 2023-06-07 at 16 35 38](https://github.com/meilisearch/documentation/assets/90181761/c26958e7-010b-4991-a04e-1b3e72355d12)
These headings appear in the sidebar when they shouldn't

2. Updates `Tabs.Container labels` to add "Exactness". The "Exactness" tab is currently missing from the container:
![Screenshot 2023-06-08 at 12 18 04](https://github.com/meilisearch/documentation/assets/90181761/748b5c5a-5473-4983-a7b5-c3ebcb35a680)
