### PR TITLE
update `searchableAttributes` in `docs-scraper.config.json`

### DIFF
--- a/docs-scraper.config.json
+++ b/docs-scraper.config.json
@@ -26,7 +26,13 @@
   "scrap_start_urls": true,
   "custom_settings": {
       "searchableAttributes": [
-          "*"
+          "content",
+          "hierarchy_lvl0",
+          "hierarchy_lvl1",
+          "hierarchy_lvl2",
+          "hierarchy_lvl3",
+          "hierarchy_lvl4",
+          "hierarchy_lvl5"
       ],
       "synonyms": {
           "relevancy": [

--- a/docs-scraper.config.json
+++ b/docs-scraper.config.json
@@ -26,13 +26,13 @@
   "scrap_start_urls": true,
   "custom_settings": {
       "searchableAttributes": [
-          "content",
-          "hierarchy_lvl0",
           "hierarchy_lvl1",
           "hierarchy_lvl2",
           "hierarchy_lvl3",
           "hierarchy_lvl4",
-          "hierarchy_lvl5"
+          "hierarchy_lvl5",
+          "content",
+          "hierarchy_lvl0",
       ],
       "synonyms": {
           "relevancy": [


### PR DESCRIPTION
Updates the `searchableAttributes` from `"*"` to:

-  "content" -> content in the docs. `null` for all heading levels
-  "hierarchy_lvl0" -> the section name
-  "hierarchy_lvl1" -> H1
-  "hierarchy_lvl2" -> H2
-  "hierarchy_lvl3" -> H3
-  "hierarchy_lvl4" -> H4
-  "hierarchy_lvl5" -> H5


