### PR TITLE
Remove trailing comma docs-scraper config

### DIFF
--- a/docs-scraper.config.json
+++ b/docs-scraper.config.json
@@ -32,7 +32,7 @@
           "hierarchy_lvl4",
           "hierarchy_lvl5",
           "content",
-          "hierarchy_lvl0",
+          "hierarchy_lvl0"
       ],
       "synonyms": {
           "relevancy": [


### PR DESCRIPTION
This should fix the [failing scraper action](https://github.com/meilisearch/documentation/actions/runs/5257782790/jobs/9501194933#step:3:97) 🤞🏻 