### PR TITLE
change "async" site route to "tasks"

### DIFF
--- a/config/sidebar-learn.json
+++ b/config/sidebar-learn.json
@@ -100,7 +100,7 @@
   },
   {
         "title": "Tasks and asynchronous workflow",
-        "slug": "async",
+        "slug": "tasks",
         "routes": [
             {
                 "source": "learn/async/asynchronous_operations.mdx",


### PR DESCRIPTION
Pages in our new "tasks and asynchronous operations" section are 404ing. We're not sure why, since the sidebar file appears to be well formatted. On the off chance that the error is being caused by our use of the word "async" in the URL, we will try changing it to "tasks"