### PR TITLE
Reduce containers

### DIFF
--- a/learn/cookbooks/postman_collection.mdx
+++ b/learn/cookbooks/postman_collection.mdx
@@ -4,9 +4,7 @@ Are you tired of using the `curl` command in your terminal to test Meilisearch? 
 
 Postman is a platform that lets you create HTTP requests you can easily reuse and share with everyone. We provide a <a href="https://raw.githubusercontent.com/meilisearch/documentation/main/assets/misc/meilisearch-collection-postman.json" download="meilisearch-collection-postman.json">Postman collection</a> containing all the routes of the Meilisearch API! 🚀
 
-<Capsule intent="tip">
 If you don't have Postman already, you can [download it here](https://www.postman.com/downloads/). It's free and available on many OS distributions.
-</Capsule>
 
 ## Import the collection
 

--- a/learn/fine_tuning_results/faceted_search.mdx
+++ b/learn/fine_tuning_results/faceted_search.mdx
@@ -116,21 +116,15 @@ The following response shows the facet distribution when searching for `classics
 }
 ```
 
-`facetDistribution` contains an object for every attribute passed to the `facets` parameter. Each object contains the different values for that attribute and the count of matching documents with that value. Meilisearch does not return empty facets: if there are no results for the Arabic language, it will not be present in `facetDistribution`.
+`facetDistribution` contains an object for every attribute passed to the `facets` parameter. Each object contains different values for that attribute and the count of matching documents with that value. Meilisearch does not return empty facets: if there are no results for the Arabic language, it will not be present in `facetDistribution`.
 
-<Capsule intent="note">
 By default, `facets` returns a maximum of 100 facet values for each faceted field. You can change this value using the `maxValuesPerFacet` property of the [`faceting` index settings](/reference/api/settings#faceting).
-</Capsule>
 
 ### Facet stats
 
-When using the `facets` parameter, Meilisearch results include a `facetStats` object. `facetStats` contains the lowest (`min`) and highest (`max`) numerical values across all documents in each facet.
+When using the `facets` parameter, Meilisearch results include a `facetStats` object. `facetStats` contains the lowest (`min`) and highest (`max`) numerical values across all documents in each facet. Meilisearch ignores numeric strings like `"21"` when computing `facetStats`.
 
 `facetStats` is useful when creating UI components such as range sliders. These allow users to refine their search by selecting from a range of facet values.
-
-<Capsule intent="note">
-Meilisearch ignores numeric strings like `"21"` when computing `facetStats`.
-</Capsule>
 
 The following response shows the lowest and highest book ratings when searching for `"classic"`:
 

--- a/learn/fine_tuning_results/faceted_search.mdx
+++ b/learn/fine_tuning_results/faceted_search.mdx
@@ -116,7 +116,7 @@ The following response shows the facet distribution when searching for `classics
 }
 ```
 
-`facetDistribution` contains an object for every attribute passed to the `facets` parameter. Each object contains different values for that attribute and the count of matching documents with that value. Meilisearch does not return empty facets: if there are no results for the Arabic language, it will not be present in `facetDistribution`.
+`facetDistribution` contains an object for every attribute passed to the `facets` parameter. Each object contains the returned values for that attribute and the count of matching documents with that value. Meilisearch does not return empty facets: if there are no results for the Arabic language, it will not be present in `facetDistribution`.
 
 By default, `facets` returns a maximum of 100 facet values for each faceted field. You can change this value using the `maxValuesPerFacet` property of the [`faceting` index settings](/reference/api/settings#faceting).
 

--- a/learn/fine_tuning_results/faceted_search.mdx
+++ b/learn/fine_tuning_results/faceted_search.mdx
@@ -124,7 +124,7 @@ By default, `facets` returns a maximum of 100 facet values for each faceted fiel
 
 ### Facet stats
 
-When using the `facets` parameter, Meilisearch results include a `facetStats` object. `facetStats` contains the lowest (`min`) and highest (`max`) numerical values across all documents in each facet. Meilisearch ignores numeric strings like `"21"` when computing `facetStats`.
+When using the `facets` parameter, search results include a `facetStats` object. `facetStats` contains the lowest (`min`) and highest (`max`) numerical values across all documents in each facet. Only numeric values are considered; string values are ignored, even if the string contains a number.
 
 `facetStats` is useful when creating UI components such as range sliders. These allow users to refine their search by selecting from a range of facet values.
 

--- a/learn/fine_tuning_results/faceted_search.mdx
+++ b/learn/fine_tuning_results/faceted_search.mdx
@@ -118,7 +118,9 @@ The following response shows the facet distribution when searching for `classics
 
 `facetDistribution` contains an object for every attribute passed to the `facets` parameter. Each object contains the returned values for that attribute and the count of matching documents with that value. Meilisearch does not return empty facets: if there are no results for the Arabic language, it will not be present in `facetDistribution`.
 
+<Capsule intent="tip">
 By default, `facets` returns a maximum of 100 facet values for each faceted field. You can change this value using the `maxValuesPerFacet` property of the [`faceting` index settings](/reference/api/settings#faceting).
+</Capsule>
 
 ### Facet stats
 

--- a/learn/index_settings/distinct.mdx
+++ b/learn/index_settings/distinct.mdx
@@ -2,7 +2,7 @@
 
 The distinct attribute is a special, user-designated field. It is most commonly used to prevent Meilisearch from returning a set of several similar documents, instead forcing it to return only one.
 
-<Capsule intent="note">
+<Capsule intent="warning">
 There can be only one `distinctAttribute` per index. Trying to set multiple fields as a `distinctAttribute` will return an error.
 </Capsule>
 

--- a/learn/index_settings/synonyms.mdx
+++ b/learn/index_settings/synonyms.mdx
@@ -98,11 +98,12 @@ To create a mutual association between four words, this is the JSON syntax that 
 
 ## Multi-word synonyms
 
-Meilisearch treats multi-word synonyms as [phrases](/reference/api/search#phrase-search-2). Multi-word synonyms are limited to a maximum of **three words**. For example, although you could make `League of Legends` and `LOL` into synonyms, you could not do the same for `The Lord of the Rings` and `LOTR`.
+Multi-word synonyms follow a different set of rules than single-word synonyms:
 
-Take note that **multi-word phrases are treated differently** than associations between individual words.
+- When a multi-word phrase is set as a synonym, **the exact search query will always take precedence over its multi-word synonym(s)**
+- Meilisearch treats multi-word synonyms as [phrases](/reference/api/search#phrase-search-2)
+- Multi-word synonyms are limited to a maximum of three words
 
-When a multi-word phrase is considered the synonym of another word or phrase, the **exact search query will always take precedence over its synonym(s)**.
 
 #### Example
 

--- a/learn/index_settings/synonyms.mdx
+++ b/learn/index_settings/synonyms.mdx
@@ -98,16 +98,11 @@ To create a mutual association between four words, this is the JSON syntax that 
 
 ## Multi-word synonyms
 
-Meilisearch treats multi-word synonyms as [phrases](/reference/api/search#phrase-search-2).
+Meilisearch treats multi-word synonyms as [phrases](/reference/api/search#phrase-search-2). Multi-word synonyms are limited to a maximum of **three words**. For example, although you could make `League of Legends` and `LOL` into synonyms, you could not do the same for `The Lord of the Rings` and `LOTR`.
 
 Take note that **multi-word phrases are treated differently** than associations between individual words.
 
 When a multi-word phrase is considered the synonym of another word or phrase, the **exact search query will always take precedence over its synonym(s)**.
-
-<Capsule intent="note">
-Multi-word synonyms are limited to a maximum of **three words**.
-For example, although you could make `League of Legends` and `LOL` into synonyms, you could not do the same for `The Lord of the Rings` and `LOTR`.
-</Capsule>
 
 #### Example
 

--- a/learn/index_settings/typo_tolerance.mdx
+++ b/learn/index_settings/typo_tolerance.mdx
@@ -45,15 +45,11 @@ For more about typo calculations, [see below](#understanding-typo-calculations).
 
 ### `disableOnWords`
 
-You can disable typo tolerance for a list of query terms by adding them to `disableOnWords`.
+You can disable typo tolerance for a list of query terms by adding them to `disableOnWords`. `disableOnWords` is case insensitive.
 
 <CodeSamples id="typo_tolerance_guide_3" />
 
 Meilisearch won't apply typo tolerance on the query term `Shrek` or `shrek` at search time to match documents.
-
-<Capsule intent="note">
-`disableOnWords` is case insensitive.
-</Capsule>
 
 ### `disableOnAttributes`
 

--- a/learn/inner_workings/prefix.mdx
+++ b/learn/inner_workings/prefix.mdx
@@ -6,11 +6,9 @@ Prefix search is when document sorting starts by comparing the search query agai
 
 In other words, prefix search means that it's not necessary to type a word in its entirety to find documents containing that word—you can just type the first one or two letters.
 
-Note that prefix search is only performed on the last word in a search query—prior words must be typed out fully in order to get accurate results.
+Note that prefix search is only performed on the last word in a search query—prior words must be typed out fully to get accurate results.
 
-<Capsule intent="note">
 Searching by prefix (rather than using complete words) has a significant impact on search time. The shorter the query term, the more possible matches in the dataset.
-</Capsule>
 
 ### Example
 

--- a/learn/inner_workings/prefix.mdx
+++ b/learn/inner_workings/prefix.mdx
@@ -6,7 +6,7 @@ Prefix search is when document sorting starts by comparing the search query agai
 
 In other words, prefix search means that it's not necessary to type a word in its entirety to find documents containing that word—you can just type the first one or two letters.
 
-Note that prefix search is only performed on the last word in a search query—prior words must be typed out fully to get accurate results.
+Prefix search is only performed on the last word in a search query—prior words must be typed out fully to get accurate results.
 
 Searching by prefix (rather than using complete words) has a significant impact on search time. The shorter the query term, the more possible matches in the dataset.
 

--- a/learn/security/tenant_tokens.mdx
+++ b/learn/security/tenant_tokens.mdx
@@ -234,7 +234,7 @@ For security reasons, we strongly recommend you avoid exposing the API key whene
 
 When using an official Meilisearch SDK, you may indicate which API key you wish to use when generating a token. Consult the documentation of the SDK you are using for more specific instructions.
 
-<Capsule intent="note">
+<Capsule intent="warning">
 If an API key expires, any tenant tokens created with it will become invalid. The same applies if the API key is deleted or regenerated due to a changed master key.
 </Capsule>
 


### PR DESCRIPTION
Part of https://github.com/meilisearch/documentation/issues/2377

This PR reduces containers from the `learn` section. It moves any content from the container that isn't important and adds it as regular text.

Closes #2474