### PR TITLE
v1.3: Update Postman for sort and search facets+showRankingScore

### DIFF
--- a/assets/misc/meilisearch-collection-postman.json
+++ b/assets/misc/meilisearch-collection-postman.json
@@ -2160,7 +2160,7 @@
 							"raw": "{ \n      \"facetQuery\": \"adventure\",\n      \"facetName\": \"genre\",\n      \"q\": \"prinec\"\n}"
 						},
 						"url": {
-							"raw": "{{url}}/facet-search",
+							"raw": "{{url}}/indexes/{{indexUID}}//facet-search",
 							"host": [
 								"{{url}}"
 							],

--- a/assets/misc/meilisearch-collection-postman.json
+++ b/assets/misc/meilisearch-collection-postman.json
@@ -398,6 +398,10 @@
 									"key": "hitsPerPage",
 									"value": "50",
 									"disabled": true
+								},
+								{
+									"key": "showRankingScore",
+									"value": "true"
 								}
 							]
 						}
@@ -1767,7 +1771,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n    \"maxValuesPerFacet\": 3000\n}"
+									"raw": "{\n    \"maxValuesPerFacet\": 3000,\n    \"sortFacetValuesBy\": {\n        \"*\": \"alpha\",\n        \"genre\": \"count\"\n      }\n}"
 								},
 								"url": {
 									"raw": "{{url}}/indexes/{{indexUID}}/settings/faceting",
@@ -2134,6 +2138,38 @@
 							""
 						]
 					}
+				}
+			]
+		},
+		{
+			"name": "Facet search",
+			"item": [
+				{
+					"name": "Search for facet values",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{ \n      \"facetQuery\": \"adventure\",\n      \"facetName\": \"genre\",\n      \"q\": \"prinec\"\n}"
+						},
+						"url": {
+							"raw": "{{url}}/facet-search",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"facet-search"
+							]
+						}
+					},
+					"response": []
 				}
 			]
 		}


### PR DESCRIPTION


This PR updates `meilisearch-collection-postman.json` to add:
- New `facet-search` route
- Updates faceting settings route to add `sortFacetValuesBy`
- Adds new `showRankingScore` search parameter