### PR TITLE
Update links to Meilisearch Cloud

### DIFF
--- a/home.mdx
+++ b/home.mdx
@@ -33,7 +33,7 @@ Learn how to use Meilisearch in your projects by exploring our guides and API re
     content: 'Announcing Meilisearch Cloud: the best way to add Meilisearch to your project',
     icon: 'cloud',
     size: 2,
-    link: 'https://cloud.meilisearch.com/register'
+    link: 'https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation'
   },
   {
     content:

--- a/home.mdx
+++ b/home.mdx
@@ -33,7 +33,7 @@ Learn how to use Meilisearch in your projects by exploring our guides and API re
     content: 'Announcing Meilisearch Cloud: the best way to add Meilisearch to your project',
     icon: 'cloud',
     size: 2,
-    link: 'https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation'
+    link: 'https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=home-page'
   },
   {
     content:

--- a/learn/getting_started/installation.mdx
+++ b/learn/getting_started/installation.mdx
@@ -152,7 +152,7 @@ chmod +x meilisearch
 
 ### Meilisearch Cloud
 
-[Meilisearch Cloud](https://www.meilisearch.com/pricing) is one of the easiest way to get started with Meilisearch. The Build plan allows you to index up to 100k documents and perform 10k search requests per month for free!
+[Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) is one of the easiest way to get started with Meilisearch. The Build plan allows you to index up to 100k documents and perform 10k search requests per month for free!
 
 ### Cloud deploy
 

--- a/learn/getting_started/installation.mdx
+++ b/learn/getting_started/installation.mdx
@@ -152,7 +152,7 @@ chmod +x meilisearch
 
 ### Meilisearch Cloud
 
-[Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) is one of the easiest way to get started with Meilisearch. The Build plan allows you to index up to 100k documents and perform 10k search requests per month for free!
+[Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=installation-guide) is one of the easiest way to get started with Meilisearch. The Build plan allows you to index up to 100k documents and perform 10k search requests per month for free!
 
 ### Cloud deploy
 

--- a/learn/getting_started/quick_start.mdx
+++ b/learn/getting_started/quick_start.mdx
@@ -5,7 +5,7 @@ This quick start walks you through installing Meilisearch, adding documents, and
 To follow this tutorial you need:
 
 - A [command line terminal](https://www.learnenough.com/command-line-tutorial#sec-running_a_terminal)
-- [cURL](https://curl.se) 
+- [cURL](https://curl.se)
 
 ## Setup and installation
 
@@ -16,7 +16,7 @@ First, you need to download and install Meilisearch. This command installs the l
 curl -L https://install.meilisearch.com | sh
 ```
 
-The rest of this guide assumes you are using Meilisearch locally, but you may also use Meilisearch over a cloud service such as [Meilisearch Cloud](https://www.meilisearch.com/pricing). 
+The rest of this guide assumes you are using Meilisearch locally, but you may also use Meilisearch over a cloud service such as [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation).
 
 Learn more about other installation options in the [installation guide](/learn/getting_started/installation).
 

--- a/learn/getting_started/quick_start.mdx
+++ b/learn/getting_started/quick_start.mdx
@@ -16,7 +16,7 @@ First, you need to download and install Meilisearch. This command installs the l
 curl -L https://install.meilisearch.com | sh
 ```
 
-The rest of this guide assumes you are using Meilisearch locally, but you may also use Meilisearch over a cloud service such as [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation).
+The rest of this guide assumes you are using Meilisearch locally, but you may also use Meilisearch over a cloud service such as [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=quick-start).
 
 Learn more about other installation options in the [installation guide](/learn/getting_started/installation).
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.mdx
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.mdx
@@ -115,8 +115,8 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 |---|:---:|:----:|:---:|:---:|
 | Self-hosted | ✅  | ❌  | ✅  | ✅ |
 | Official 1-click deploy | ✅ <br /> [DigitalOcean](https://marketplace.digitalocean.com/apps/meilisearch) <br /> [Platform.sh](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/meilisearch/.platform.template.yaml) <br /> [Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fcmaneu%2Fmeilisearch-on-azure%2Fmain%2Fmain.json) <br /> [Railway](https://railway.app/new/template/TXxa09?referralCode=YltNo3) <br /> [Koyeb](https://app.koyeb.com/deploy?type=docker&image=getmeili/meilisearch&name=meilisearch-on-koyeb&ports=7700;http;/&env%5BMEILI_MASTER_KEY%5D=REPLACE_ME_WITH_A_STRONG_KEY) | ❌ | 🔶 <br />Only for the cloud-hosted solution | ❌ |
-| Official cloud-hosted solution | [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) | ✅ | ✅ | ✅ |
-| High availability | Available with [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) | ✅ | ✅ | ✅ |
+| Official cloud-hosted solution | [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=comparison-table) | ✅ | ✅ | ✅ |
+| High availability | Available with [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=comparison-table) | ✅ | ✅ | ✅ |
 | Run-time dependencies | None | N/A | None | None |
 | Backward compatibility | ✅ | N/A | ✅ | ✅ |
 | Upgrade path | Documents are automatically reindexed on upgrade | N/A  | Documents are automatically reindexed on upgrade  | Documents are automatically reindexed on upgrade, up to 1 major version |
@@ -189,7 +189,7 @@ Additionally, Meilisearch is written in Rust, a modern systems-level programming
 
 The [pricing model for Algolia](https://www.algolia.com/pricing/) is based on the number of records kept and the number of API operations performed. It can be prohibitively expensive for small and medium-sized businesses.
 
-Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: [Meilisearch Cloud](https://cloud.meilisearch.com/register). Like Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) is based on the number of records stored and the number of search operations performed. However, Meilisearch offers a more generous free tier that allows more documents to be stored as well as fairer pricing for search usage. Meilisearch also offers a Pro tier for larger use cases to allow for more predictable pricing.
+Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: [Meilisearch Cloud](https://cloud.meilisearch.com/register). Like Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=comparison) is based on the number of records stored and the number of search operations performed. However, Meilisearch offers a more generous free tier that allows more documents to be stored as well as fairer pricing for search usage. Meilisearch also offers a Pro tier for larger use cases to allow for more predictable pricing.
 
 ## A quick look at the search engine landscape
 

--- a/learn/what_is_meilisearch/comparison_to_alternatives.mdx
+++ b/learn/what_is_meilisearch/comparison_to_alternatives.mdx
@@ -115,8 +115,8 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 |---|:---:|:----:|:---:|:---:|
 | Self-hosted | ✅  | ❌  | ✅  | ✅ |
 | Official 1-click deploy | ✅ <br /> [DigitalOcean](https://marketplace.digitalocean.com/apps/meilisearch) <br /> [Platform.sh](https://console.platform.sh/projects/create-project?template=https://raw.githubusercontent.com/platformsh/template-builder/master/templates/meilisearch/.platform.template.yaml) <br /> [Azure](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2Fcmaneu%2Fmeilisearch-on-azure%2Fmain%2Fmain.json) <br /> [Railway](https://railway.app/new/template/TXxa09?referralCode=YltNo3) <br /> [Koyeb](https://app.koyeb.com/deploy?type=docker&image=getmeili/meilisearch&name=meilisearch-on-koyeb&ports=7700;http;/&env%5BMEILI_MASTER_KEY%5D=REPLACE_ME_WITH_A_STRONG_KEY) | ❌ | 🔶 <br />Only for the cloud-hosted solution | ❌ |
-| Official cloud-hosted solution | [Meilisearch Cloud](https://cloud.meilisearch.com/register) | ✅ | ✅ | ✅ |
-| High availability | Available with [Meilisearch Cloud](https://cloud.meilisearch.com/register) | ✅ | ✅ | ✅ |
+| Official cloud-hosted solution | [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) | ✅ | ✅ | ✅ |
+| High availability | Available with [Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) | ✅ | ✅ | ✅ |
 | Run-time dependencies | None | N/A | None | None |
 | Backward compatibility | ✅ | N/A | ✅ | ✅ |
 | Upgrade path | Documents are automatically reindexed on upgrade | N/A  | Documents are automatically reindexed on upgrade  | Documents are automatically reindexed on upgrade, up to 1 major version |
@@ -189,7 +189,7 @@ Additionally, Meilisearch is written in Rust, a modern systems-level programming
 
 The [pricing model for Algolia](https://www.algolia.com/pricing/) is based on the number of records kept and the number of API operations performed. It can be prohibitively expensive for small and medium-sized businesses.
 
-Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: [Meilisearch Cloud](https://cloud.meilisearch.com/register). Like Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing) is based on the number of records stored and the number of search operations performed. However, Meilisearch offers a more generous free tier that allows more documents to be stored as well as fairer pricing for search usage. Meilisearch also offers a Pro tier for larger use cases to allow for more predictable pricing.
+Meilisearch is **open-source** and can be **self-hosted**, but also offers a cloud-hosted product analogous to Algolia's service: [Meilisearch Cloud](https://cloud.meilisearch.com/register). Like Algolia, [pricing of Meilisearch Cloud](https://www.meilisearch.com/pricing?utm_campaign=oss&utm_source=docs&utm_medium=documentation) is based on the number of records stored and the number of search operations performed. However, Meilisearch offers a more generous free tier that allows more documents to be stored as well as fairer pricing for search usage. Meilisearch also offers a Pro tier for larger use cases to allow for more predictable pricing.
 
 ## A quick look at the search engine landscape
 


### PR DESCRIPTION
- make them traceable -> Objective 1 of Q3
- make them consistent: redirect to the pricing page and not the register one. The Cloud register page does not give any information and can be confused for the users

Discussed with @gmourier 