### PR TITLE
Distance is the sum, not the max of distance values between words

### DIFF
--- a/learn/inner_workings/datatypes.mdx
+++ b/learn/inner_workings/datatypes.mdx
@@ -32,7 +32,7 @@ To demonstrate how a string is split by space, let's say you have the following 
 "Bruce Willis,Vin Diesel"
 ```
 
-In the example above, the distance between `Bruce` and `Willis` is equal to **1**. The distance between `Vin` and `Diesel` is also **1**. However, the distance between `Willis` and `Vin` is equal to **8**. The same calculations apply to `Bruce` and `Diesel` (10),  `Bruce` and `Vin` (9), or also `Willis` and `Diesel` (9).
+In the example above, the distance between `Bruce` and `Willis` is equal to **1**. The distance between `Vin` and `Diesel` is also **1**. However, the distance between `Willis` and `Vin` is equal to **8**. The same calculations apply to `Bruce` and `Diesel` (10),  `Bruce` and `Vin` (9), and `Willis` and `Diesel` (9).
 
 Let's see another example. Given two documents:
 

--- a/learn/inner_workings/datatypes.mdx
+++ b/learn/inner_workings/datatypes.mdx
@@ -32,7 +32,7 @@ To demonstrate how a string is split by space, let's say you have the following 
 "Bruce Willis,Vin Diesel"
 ```
 
-In the example above, the distance between `Bruce` and `Willis` is equal to **1**. The distance between `Vin` and `Diesel` is also **1**. However, the distance between `Bruce` and `Vin` is equal to **9**. The same goes for `Bruce` and `Diesel` (10), or `Willis` and `Vin` (8), or also `Willis` and `Diesel` (9).
+In the example above, the distance between `Bruce` and `Willis` is equal to **1**. The distance between `Vin` and `Diesel` is also **1**. However, the distance between `Willis` and `Vin` is equal to **8**. The same calculations apply to `Bruce` and `Diesel` (10),  `Bruce` and `Vin` (9), or also `Willis` and `Diesel` (9).
 
 Let's see another example. Given two documents:
 

--- a/learn/inner_workings/datatypes.mdx
+++ b/learn/inner_workings/datatypes.mdx
@@ -32,7 +32,7 @@ To demonstrate how a string is split by space, let's say you have the following 
 "Bruce Willis,Vin Diesel"
 ```
 
-In the example above, the distance between `Bruce` and `Willis` is equal to **1**. The distance between `Vin` and `Diesel` is also **1**. However, the distance between `Bruce` and `Vin` is equal to **8**. The same goes for `Bruce` and `Diesel`, or `Willis` and `Vin`, or also `Willis` and `Diesel`.
+In the example above, the distance between `Bruce` and `Willis` is equal to **1**. The distance between `Vin` and `Diesel` is also **1**. However, the distance between `Bruce` and `Vin` is equal to **9**. The same goes for `Bruce` and `Diesel` (10), or `Willis` and `Vin` (8), or also `Willis` and `Diesel` (9).
 
 Let's see another example. Given two documents:
 


### PR DESCRIPTION
In the example "Bruce Willis,Vin Diesel" there is not only a comma (8) but also a space (1) between Bruce and Vin, hence a distance of 9 instead of 8. Same applies to the subsequent examples in the following sentence. Otherwise it would be inconsistent with the next JSON example and the general concept of proximity outlined elsewhere in the documentation in which distances are plausibly characterized as additive.