### PR TITLE
add not-enough swapfile error to known errors

### DIFF
--- a/reference/errors/error_codes.mdx
+++ b/reference/errors/error_codes.mdx
@@ -490,3 +490,7 @@ Indexing a large batch of documents, such as a JSON file over 3.5GB in size, can
 ## `unretrievable_document`
 
 The document exists in store, but there was an error retrieving it. This probably comes from an inconsistent state in the database.
+
+## `os 1455`
+
+Error on windows regarding `The swap file is too small to perform this operation` - you have not enough free memory to run meilisearch with your workload.


### PR DESCRIPTION
This happens on any operation where meilisearch is running on windows and the remaining memory is too low.

# Pull Request

## Related issue
-

## What does this PR do?
- add cryptic windows out-of-memory message to known errors

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

