### PR TITLE
Update settings and parameters comparison in Algolia migration guide

### DIFF
--- a/learn/update_and_migration/algolia_migration.mdx
+++ b/learn/update_and_migration/algolia_migration.mdx
@@ -206,8 +206,8 @@ The below table compares Algolia's **API parameters** with the equivalent Meilis
 | `separatorsToIndex`                 | Not Supported                                                                    |
 | `disablePrefixOnAttributes`         | Not Supported                                                                    |
 | `relevancyStrictness`               | Not Supported                                                                    |
-| `maxValuesPerFacet`                 | Not Supported                                                                    |
-| `sortFacetValuesBy`                 | Not Supported                                                                    |
+| `maxValuesPerFacet`                 | `maxValuesPerFacet`                                                                    |
+| `sortFacetValuesBy`                 | `sortFacetValuesBy`                                                                  |
 | `restrictHighlightAndSnippetArrays` | Not Supported                                                                    |
 
 ## API methods


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- Updates settings and parameters comparison in Algolia migration guide: adds `maxValuesPerFacet` and `sortFacetValuesBy`
