### PR TITLE
Remove warning on autobatching

### DIFF
--- a/learn/core_concepts/documents.mdx
+++ b/learn/core_concepts/documents.mdx
@@ -133,10 +133,6 @@ Since CSV does not support arrays or nested objects, `cast` cannot be converted 
 
 ### Auto-batching
 
-<Capsule intent="danger">
-Currently, auto-batching is disabled for document addition and deletion. See [this GitHub issue](https://github.com/meilisearch/meilisearch/issues/3664) for more details.
-</Capsule>
-
 Auto-batching combines consecutive document addition and deletion requests into a single batch and processes them together while respecting the order. This significantly speeds up the indexing process.
 
 Meilisearch batches document addition and deletion requests when they:


### PR DESCRIPTION
# Pull Request
Get rids of a warning on the autobatching of tasks not working with addition and deletions.

This has been fixed in https://github.com/meilisearch/meilisearch/pull/3670 a few months ago.
