### PR TITLE
Fix relative link on `geosearch.mdx`

### DIFF
--- a/learn/fine_tuning_results/geosearch.mdx
+++ b/learn/fine_tuning_results/geosearch.mdx
@@ -370,5 +370,5 @@ When using `_geoPoint`, all returned documents will contain one extra field: `_g
 <Capsule intent="warning">
 Using `_geoRadius` filter will not cause results to include `_geoDistance`.
 
-`_geoDistance` will only be computed in a returned document if the query uses `_geoPoint` and the `sort` search parameter. Additionally, returned documents will only include `_geoDistance` if `_geo` is present in the [`displayedAttributes` list](learn/configuration/displayed_searchable_attributes).
+`_geoDistance` will only be computed in a returned document if the query uses `_geoPoint` and the `sort` search parameter. Additionally, returned documents will only include `_geoDistance` if `_geo` is present in the [`displayedAttributes` list](/learn/configuration/displayed_searchable_attributes).
 </Capsule>


### PR DESCRIPTION
Our link checker did not run in a PR that introduced a broken link. This PR fixes that link.