### PR TITLE
Update railway.mdx to reference production-ready Railway template

### DIFF
--- a/learn/deployment/railway.mdx
+++ b/learn/deployment/railway.mdx
@@ -16,9 +16,13 @@ To follow along, you need a [Railway account](https://railway.app). If you don't
 
 Click the button below to deploy a Meilisearch instance to Railway quickly.
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/TXxa09?referralCode=YltNo3)
+[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/new/template/meilisearch)
 
-Do not forget to replace the `MEILI_MASTER_KEY` environment variable with a strong key to secure your Meilisearch instance.
+### Environment Variables
+
+`MEILI_ENV` - By default, this template sets the `MEILI_ENV` environment variable to `production`.  If you would like access to the Meilisearch [search preview](/learn/getting_started/search_preview), update `MEILI_ENV` to `development`.
+
+`MEILI_MASTER_KEY` - Replace the `MEILI_MASTER_KEY` environment variable with a strong key to secure your Meilisearch instance.
 
 If you want to quickly generate a secure random key, you can run the following command from your terminal:
 
@@ -43,6 +47,8 @@ Setting a master key is optional, but without it, your server will accept uniden
 </Capsule>
 
 ### Test Meilisearch
+
+If you have updated the `MEILI_ENV` environment variable to `development` in the Railway service, you will have access to the Meilisearch [search preview](/learn/getting_started/search_preview).
 
 Copy the public URL (for example, `meilisearch-production-up.railway.app`) of your project from your [Railway account dashboard](https://railway.app/dashboard) and paste it into your browser.
 

--- a/learn/deployment/railway.mdx
+++ b/learn/deployment/railway.mdx
@@ -48,7 +48,7 @@ Setting a master key is optional, but without it, your server will accept uniden
 
 ### Test Meilisearch
 
-If you have updated the `MEILI_ENV` environment variable to `development` in the Railway service, you will have access to the Meilisearch [search preview](/learn/getting_started/search_preview).
+If you have set the `MEILI_ENV` environment variable to `development` in the Railway service, you will have access to the Meilisearch [search preview](/learn/getting_started/search_preview).
 
 Copy the public URL (for example, `meilisearch-production-up.railway.app`) of your project from your [Railway account dashboard](https://railway.app/dashboard) and paste it into your browser.
 

--- a/learn/deployment/railway.mdx
+++ b/learn/deployment/railway.mdx
@@ -22,7 +22,7 @@ Click the button below to deploy a Meilisearch instance to Railway quickly.
 
 `MEILI_ENV`: by default, this template sets the `MEILI_ENV` environment variable to `production`.  If you would like access to the Meilisearch [search preview](/learn/getting_started/search_preview), update `MEILI_ENV` to `development`.
 
-`MEILI_MASTER_KEY` - Replace the `MEILI_MASTER_KEY` environment variable with a strong key to secure your Meilisearch instance.
+`MEILI_MASTER_KEY`: replace the `MEILI_MASTER_KEY` environment variable with a strong key to secure your Meilisearch instance.
 
 If you want to quickly generate a secure random key, you can run the following command from your terminal:
 

--- a/learn/deployment/railway.mdx
+++ b/learn/deployment/railway.mdx
@@ -20,7 +20,7 @@ Click the button below to deploy a Meilisearch instance to Railway quickly.
 
 ### Environment Variables
 
-`MEILI_ENV` - By default, this template sets the `MEILI_ENV` environment variable to `production`.  If you would like access to the Meilisearch [search preview](/learn/getting_started/search_preview), update `MEILI_ENV` to `development`.
+`MEILI_ENV`: by default, this template sets the `MEILI_ENV` environment variable to `production`.  If you would like access to the Meilisearch [search preview](/learn/getting_started/search_preview), update `MEILI_ENV` to `development`.
 
 `MEILI_MASTER_KEY` - Replace the `MEILI_MASTER_KEY` environment variable with a strong key to secure your Meilisearch instance.
 


### PR DESCRIPTION
# Pull Request

## Related issue
No open issue.  This change is being proposed because the template that is currently being deployed from the Deploy to Railway button on this page is not production ready - it does not have a volume attached meaning data will not be persisted between deploys, and the MEILI_ENV environment variable is set to development by default.

## What does this PR do?
Update railway.mdx to point to a template that provides a production-ready instance of Meilisearch.  This Railways template includes default environment variables are production-ready and a volume attached for persisted data.
This change also updates the content to reflect that Meilisearch search preview is only available if you set your environment variable to "development" instead of the default "production"

## PR checklist
Please check if your PR fulfills the following requirements:
- [ x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x ] Have you read the contributing guidelines?
- [x ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

Thank you!!