### PR TITLE
Update dependabot for GHA only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
+# Set update schedule for GitHub Actions only
+
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "04:00"
-  open-pull-requests-limit: 10
-  versioning-strategy: increase
-  rebase-strategy: disabled
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - 'dependencies'
+    rebase-strategy: disabled


### PR DESCRIPTION
Dependabot is not used anymore for npm since the website migration

I updated dependabot file to take care of github action dependencies only
We could also completely remove the file if you prefer @guimachiavelli 