### PR TITLE
v1.5: Activate `/metrics` via API route

### DIFF
--- a/learn/experimental/overview.mdx
+++ b/learn/experimental/overview.mdx
@@ -44,7 +44,7 @@ Activating or deactivating experimental features this way does not require you t
 
 | Name                                                                             | Description                                                | How to configure                                  |
 |----------------------------------------------------------------------------------|------------------------------------------------------------|---------------------------------------------------|
-| [Metrics API](/learn/experimental/metrics)                                       | Exposes Prometheus-compatible analytics data               | At launch with a CLI flag or environment variable |
+| [Metrics API](/learn/experimental/metrics)                                       | Exposes Prometheus-compatible analytics data               | At launch with a CLI flag or environment variable, during runtime with the API route |
 | [Ranking score details](/learn/experimental/ranking_rule_score_details)          | Exposes advanced result ranking score data                 | During runtime with the API route                 |
 | [Reduce indexing memory usage](/learn/experimental/reduce-indexing-memory-usage) | Optimizes indexing performance                             | At launch with a CLI flag or environment variable |
 | [Vector search](/learn/experimental/vector_search)                               | Allows Meilisearch to function as a vector embedding store | During runtime with the API route                 |

--- a/reference/api/experimental_features.mdx
+++ b/reference/api/experimental_features.mdx
@@ -17,6 +17,7 @@ The experimental API route is not compatible with all experimental features. Con
 
 ```json
 {
+  "metrics": false,
   "scoreDetails": false,
   "vectorSearch": false
 }
@@ -24,9 +25,9 @@ The experimental API route is not compatible with all experimental features. Con
 
 | Name               | Type    | Description                                                               |
 | :----------------- | :------ | :--------------------------------------------- |
+| **`metrics`**      | Boolean | `true` if feature is active, `false` otherwise |
 | **`scoreDetails`** | Boolean | `true` if feature is active, `false` otherwise |
 | **`vectorSearch`** | Boolean | `true` if feature is active, `false` otherwise |
-
 
 ## Get all experimental features
 
@@ -42,6 +43,7 @@ Get a list of all experimental features that can be activated via the `/experime
 
 ```json
 {
+  "metrics": false,
   "scoreDetails": false,
   "vectorSearch": false
 }
@@ -67,6 +69,7 @@ Setting a field to `null` leaves its value unchanged.
 
 ```json
 {
+  "metrics": false,
   "scoreDetails": true,
   "vectorSearch": false
 }


### PR DESCRIPTION
Closes #2593 