### PR TITLE
Add notices about configuring Meilisync primary key

### DIFF
--- a/learn/primary_db_sync/meilisync_mysql.mdx
+++ b/learn/primary_db_sync/meilisync_mysql.mdx
@@ -153,7 +153,7 @@ sync:
 
 Replace `MYSQL_TABLE_NAME_1` and `MEILISEARCH_INDEX_NAME_1` with the names of your tables and indexes. As the above example demonstrates, you may sync multiple tables.
 
-**Primary key inference**
+### Primary key inference
 
 If your table contains multiple columns with `id` in their name, `meilisync` will not be able to infer which column is the primary key. In this case, you must specify the primary key manually by adding a `pk` field to the table's configuration.
 

--- a/learn/primary_db_sync/meilisync_mysql.mdx
+++ b/learn/primary_db_sync/meilisync_mysql.mdx
@@ -144,6 +144,7 @@ Open `config.yml` and append the following settings to the bottom of the file:
 sync:
   - table: MYSQL_TABLE_NAME_1
     index: MEILISEARCH_INDEX_NAME_1
+    pk: id # Read the "Primary key inference" section below
     full: true
   - table: MYSQL_TABLE_NAME_2
     index: MEILISEARCH_INDEX_NAME_2
@@ -151,6 +152,10 @@ sync:
 ```
 
 Replace `MYSQL_TABLE_NAME_1` and `MEILISEARCH_INDEX_NAME_1` with the names of your tables and indexes. As the above example demonstrates, you may sync multiple tables.
+
+**Primary key inference**
+
+If your table contains multiple columns with `id` in their name, `meilisync` will not be able to infer which column is the primary key. In this case, you must specify the primary key manually by adding a `pk` field to the table's configuration.
 
 <Capsule intent="tip" title="Customizing `meilisync`">
 This tutorial describes a fairly basic `meilisync` setup. For more customization options, consult [`meilisync`'s documentation](https://github.com/long2ice/meilisync#configuration).

--- a/learn/primary_db_sync/meilisync_postgresql.mdx
+++ b/learn/primary_db_sync/meilisync_postgresql.mdx
@@ -161,7 +161,7 @@ sync:
 
 Replace `POSTGRES_TABLE_NAME_1` and `MEILISEARCH_INDEX_NAME_1` with the names of your tables and indexes. As the above example demonstrates, you may sync multiple tables.
 
-**Primary key inference**
+### Primary key inference
 
 If your table contains multiple columns with `id` in their name, `meilisync` will not be able to infer which column is the primary key. In this case, you must specify the primary key manually by adding a `pk` field to the table's configuration.
 

--- a/learn/primary_db_sync/meilisync_postgresql.mdx
+++ b/learn/primary_db_sync/meilisync_postgresql.mdx
@@ -152,6 +152,7 @@ Open `config.yml` and append the following settings to the bottom of the file:
 sync:
   - table: POSTGRES_TABLE_NAME_1
     index: MEILISEARCH_INDEX_NAME_1
+    pk: id # Read the "Primary key inference" section below
     full: true
   - table: POSTGRES_TABLE_NAME_2
     index: MEILISEARCH_INDEX_NAME_2
@@ -159,6 +160,10 @@ sync:
 ```
 
 Replace `POSTGRES_TABLE_NAME_1` and `MEILISEARCH_INDEX_NAME_1` with the names of your tables and indexes. As the above example demonstrates, you may sync multiple tables.
+
+**Primary key inference**
+
+If your table contains multiple columns with `id` in their name, `meilisync` will not be able to infer which column is the primary key. In this case, you must specify the primary key manually by adding a `pk` field to the table's configuration.
 
 <Capsule intent="tip" title="Customizing `meilisync`">
   This tutorial describes a fairly basic `meilisync` setup. For more


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #2598 

## What does this PR do?
- Add a notice about the field to configure the primary key for meilisync
