### PR TITLE
Change docs-searchbar.js description to deprecated

### DIFF
--- a/learn/what_is_meilisearch/sdks.mdx
+++ b/learn/what_is_meilisearch/sdks.mdx
@@ -37,7 +37,7 @@ You can use Meilisearch API wrappers in your favorite language. These libraries 
 - [Vue](https://github.com/meilisearch/meilisearch-vue)
 - [Instant Meilisearch](https://github.com/meilisearch/meilisearch-js-plugins/tree/main/packages/instant-meilisearch)
 - [Autocomplete client](https://github.com/meilisearch/meilisearch-js-plugins/tree/main/packages/autocomplete-client)
-- [docs-searchbar.js](https://github.com/meilisearch/docs-searchbar.js): a search bar integration for all kinds of documentation.
+- [docs-searchbar.js](https://github.com/meilisearch/docs-searchbar.js) (deprecated)
 
 ## DevOps tools
 

--- a/learn/what_is_meilisearch/sdks.mdx
+++ b/learn/what_is_meilisearch/sdks.mdx
@@ -37,7 +37,7 @@ You can use Meilisearch API wrappers in your favorite language. These libraries 
 - [Vue](https://github.com/meilisearch/meilisearch-vue)
 - [Instant Meilisearch](https://github.com/meilisearch/meilisearch-js-plugins/tree/main/packages/instant-meilisearch)
 - [Autocomplete client](https://github.com/meilisearch/meilisearch-js-plugins/tree/main/packages/autocomplete-client)
-- [docs-searchbar.js](https://github.com/meilisearch/docs-searchbar.js) (deprecated)
+- [docs-searchbar.js](https://github.com/tauri-apps/meilisearch-docsearch)
 
 ## DevOps tools
 


### PR DESCRIPTION
# Pull Request

## Related issue

## What does this PR do?
- Change docs-searchbar.js description to deprecated following docs-searchbar.js repository

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
