### PR TITLE
Update updating.mdx respective custom data paths

### DIFF
--- a/learn/update_and_migration/updating.mdx
+++ b/learn/update_and_migration/updating.mdx
@@ -285,6 +285,8 @@ Execute the command below to import the dump at launch:
 ```bash
 # replace {dump_uid.dump} with the name of your dump file
 ./meilisearch --import-dump dumps/{dump_uid.dump} --master-key="MASTER_KEY"
+# Or, if you chose another location for data files and dumps before the update, also add the same parameters
+./meilisearch --import-dump dumps/{dump_uid.dump} --master-key="MASTER_KEY" --db-path {your/path/to}/data.ms --dump-dir {your/path/to}/dumps
 ```
 
 </Tabs.Content>

--- a/learn/update_and_migration/updating.mdx
+++ b/learn/update_and_migration/updating.mdx
@@ -286,7 +286,7 @@ Execute the command below to import the dump at launch:
 # replace {dump_uid.dump} with the name of your dump file
 ./meilisearch --import-dump dumps/{dump_uid.dump} --master-key="MASTER_KEY"
 # Or, if you chose another location for data files and dumps before the update, also add the same parameters
-./meilisearch --import-dump dumps/{dump_uid.dump} --master-key="MASTER_KEY" --db-path {your/path/to}/data.ms --dump-dir {your/path/to}/dumps
+./meilisearch --import-dump dumps/{dump_uid.dump} --master-key="MASTER_KEY" --db-path PATH_TO_DB_DIR/data.ms --dump-dir path PATH_TO_DUMP_DIR/dumps
 ```
 
 </Tabs.Content>


### PR DESCRIPTION
When importing the data during an upgrade and the instance has used different data and dump directories before, the import step also needs to use those or they will get created at the default location

# Pull Request

## Related issue
Fixes #2701

## What does this PR do?
- Clarifies the custom path parameters have to be added

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!