### PR TITLE
Fix vectorSearch key name to vectorStore

### DIFF
--- a/reference/api/experimental_features.mdx
+++ b/reference/api/experimental_features.mdx
@@ -19,7 +19,7 @@ The experimental API route is not compatible with all experimental features. Con
 {
   "metrics": false,
   "logsRoute": true,
-  "vectorSearch": false,
+  "vectorStore": false,
   "exportPuffinReports": false
 }
 ```
@@ -29,7 +29,7 @@ The experimental API route is not compatible with all experimental features. Con
 | **`metrics`**             | Boolean | `true` if feature is active, `false` otherwise |
 | **`scoreDetails`**        | Boolean | `true` if feature is active, `false` otherwise |
 | **`logsRoute`**           | Boolean | `true` if feature is active, `false` otherwise |
-| **`vectorSearch`**        | Boolean | `true` if feature is active, `false` otherwise |
+| **`vectorStore`**         | Boolean | `true` if feature is active, `false` otherwise |
 | **`exportPuffinReports`** | Boolean | `true` if feature is active, `false` otherwise |
 
 ## Get all experimental features


### PR DESCRIPTION
Setting `vectorSearch` results in an error: `{"message":"Unknown field vectorSearch: expected one of vectorStore, metrics, logsRoute, exportPuffinReports","code":"bad_request","type":"invalid_request","link":"https://docs.meilisearch.com/errors#bad_request"}`. It should instead be `vectorStore`

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Changes `vectorSearch` to `vectorStore`

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
