### PR TITLE
New usage of OpenAPI

### DIFF
--- a/reference/api/overview.mdx
+++ b/reference/api/overview.mdx
@@ -11,10 +11,7 @@ Meilisearch is a RESTful API. This page describes the general behavior of the AP
 
 ### OpenAPI
 
-You can download the Meilisearch OpenAPI specifications at:
-
-- [YAML](https://bump.sh/doc/meilisearch.yaml)
-- [JSON](https://bump.sh/doc/meilisearch.json)
+You can get the [Meilisearch OpenAPI specifications here](https://github.com/meilisearch/open-api/blob/main/open-api.yaml).
 
 ## Document conventions
 


### PR DESCRIPTION
New file use for OpenAPI will be here: https://github.com/meilisearch/open-api/blob/main/open-api.yaml

We will stop to bump.sh soon -> too expensive, almost 2000$/year for no immediate impact