### PR TITLE
Remove trailing comma

### DIFF
--- a/docs-scraper.config.json
+++ b/docs-scraper.config.json
@@ -44,7 +44,7 @@
       ],
       "synonyms": {
           "large language model": [
-            "llm",
+            "llm"
           ],
           "llm": [
             "large language model"


### PR DESCRIPTION
# Pull Request
Scraper is failing because of parse error, there's trailing comma that should be removed.
