### PR TITLE
attributesToSearchOn not showing in right sidebar

### DIFF
--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -1051,7 +1051,7 @@ The code sample below returns the `_rankingScoreDetail` when searching for `drag
 }
 ```
 
-#### Customize attributes to search on at search time
+### Customize attributes to search on at search time
 
 **Parameter**: `attributesToSearchOn`<br />
 **Expected value**: A list of searchable attributes written as an array<br />


### PR DESCRIPTION
"Customize attributes to search on at search time" is not showing in the right sidebar  
[Webpage Link](https://www.meilisearch.com/docs/reference/api/search#customize-attributes-to-search-on-at-search-time)

# Pull Request

## Related issue
Fixes #2827 

## What does this PR do?
- removes the additional "#" which prevented the heading from showing in the right sidebar

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
