### PR TITLE
replace the deprecated docker-compose

### DIFF
--- a/learn/primary_db_sync/meilisync_postgresql.mdx
+++ b/learn/primary_db_sync/meilisync_postgresql.mdx
@@ -40,7 +40,7 @@ If your project already has a `docker-compose.yml`, add the `meilisync` settings
 When you are done, open your console, navigate to your Docker project directory, and run the following command:
 
 ```sh
-docker-compose pull
+docker compose pull
 ```
 
 After a few seconds, Docker will inform you it has successfully pulled `meilisync`'s image.
@@ -183,7 +183,7 @@ With the configuration done, open your command-line prompt once again and run `m
   <Tabs.Content label="Docker">
 
 ```sh
-docker-compose up
+docker compose up
 ```
 
   </Tabs.Content>


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?
docker-compose is old and deprecated and now we should use "docker compose" instead.
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [y] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [y] Have you read the contributing guidelines?
- [y] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
