### PR TITLE
Update systemd service template

### DIFF
--- a/guides/running_production.mdx
+++ b/guides/running_production.mdx
@@ -112,6 +112,7 @@ WorkingDirectory=/var/lib/meilisearch
 ExecStart=/usr/local/bin/meilisearch --config-file-path /etc/meilisearch.toml
 User=meilisearch
 Group=meilisearch
+Restart=always
 
 [Install]
 WantedBy=multi-user.target

--- a/guides/running_production.mdx
+++ b/guides/running_production.mdx
@@ -112,7 +112,7 @@ WorkingDirectory=/var/lib/meilisearch
 ExecStart=/usr/local/bin/meilisearch --config-file-path /etc/meilisearch.toml
 User=meilisearch
 Group=meilisearch
-Restart=always
+Restart=on-failure
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
# Pull Request

## What does this PR do?
- It adds automatic restart to the systemd service template in the "Running in Production" section

The motivation is that if the service crashes (like from 6/ABRT errors during memory allocation, something I've seen several times during the last week) it should restart automatically and not stay dead until manual intervention.

## Feedback wanted
- I set it to `Restart=always` because that is what I needed for my usage, but I know some maintainers prefer the more conservative `on-failure` or `on-abort` behavior. I can substitute that if you'd rather have that.
- The fix for the `too_many_open_files` error described in the [docs here](https://www.meilisearch.com/docs/reference/errors/error_codes#too_many_open_files) also requires a fix in this file, basically you have to set `LimitNOFILE=<howevermanyfilesyouwant>` should I add that in this PR as well?