### PR TITLE
changed useradd command flag '-b' to '-s'

### DIFF
--- a/guides/running_production.mdx
+++ b/guides/running_production.mdx
@@ -53,7 +53,7 @@ Meilisearch is now running, but it is not publicly accessible.
 Running applications as root exposes you to unnecessary security risks. To prevent that, create a dedicated user for Meilisearch:
 
 ```sh
-useradd -d /var/lib/meilisearch -b /bin/false -m -r meilisearch
+useradd -d /var/lib/meilisearch -s /bin/false -m -r meilisearch
 ```
 
 ## Step 3: Create a configuration file


### PR DESCRIPTION
Updated the useradd command to use the -s flag instead of -b when creating the meilisearch user

# Pull Request

## What does this PR do?
The flag for "/bin/false" should be "-s" , ensuring the user cannot log in.
