### PR TITLE
Fix typo in task webhook authorization header reference

### DIFF
--- a/learn/self_hosted/configure_meilisearch_at_launch.mdx
+++ b/learn/self_hosted/configure_meilisearch_at_launch.mdx
@@ -429,7 +429,7 @@ The webhook payload contains the list of finished tasks in [ndjson](https://gith
 
 ### Task webhook authorization header
 
-**Environment variable**: `MEILI_TASK_AUTHORIZATION_HEADER`<br />
+**Environment variable**: `MEILI_TASK_WEBHOOK_AUTHORIZATION_HEADER`<br />
 **CLI option**: `--task-webhook-authorization-header`<br />
 **Default value**: `None`<br />
 **Expected value**: an authentication token string


### PR DESCRIPTION
# Pull Request
 Fix typo in task webhook authorization header reference 
## Related issue
Fixes #2949 

## What does this PR do?
-Fix typo in task webhook authorization header reference  becuase of this typo mistake 
- changed `MEILI_TASK_AUTHORIZATION_HEADER` to `MEILI_TASK_WEBHOOK_AUTHORIZATION_HEADER`

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
