### PR TITLE
v1.10: `glibc`version bump

### DIFF
--- a/learn/self_hosted/supported_os.mdx
+++ b/learn/self_hosted/supported_os.mdx
@@ -15,7 +15,7 @@ Use [Meilisearch Cloud](https://www.meilisearch.com/cloud?utm_campaign=oss&utm_s
 
 ## Linux
 
-The Meilisearch binary works on all Linux distributions with `amd64/x86_64` or `aarch64/arm64` architecture using glibc 2.27 and later. You can check your glibc version using:
+The Meilisearch binary works on all Linux distributions with `amd64/x86_64` or `aarch64/arm64` architecture using glibc 2.28 and later. You can check your glibc version using:
 
 ```
 ldd --version


### PR DESCRIPTION
We don't actually mention Ubuntu by its name, nor recommend a version, anywhere in the docs. Nothing to update there.

We do say Meilisearch self-hosted is compatible with any Linux machines with glibc 2.27, which this PR fixes.

Closes #2936.