### PR TITLE
Remove `chi` for `localizedAttributes`

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1240,7 +1240,7 @@ reset_embedders_1: |-
 search_parameter_guide_hybrid_1: |-
   curl -X POST 'localhost:7700/indexes/INDEX_NAME/search' \
     -H 'content-type: application/json' \
-    --data-binary '{ 
+    --data-binary '{
       "q": "kitchen utensils",
       "hybrid": {
         "semanticRatio": 0.9,
@@ -1319,7 +1319,7 @@ analytics_event_bind_event_1: |-
 search_parameter_reference_retrieve_vectors_1: |-
   curl -X POST 'localhost:7700/indexes/INDEX_NAME/search' \
     -H 'content-type: application/json' \
-    --data-binary '{ 
+    --data-binary '{
       "q": "kitchen utensils",
       "retrieveVectors": true,
       "hybrid": {
@@ -1385,12 +1385,11 @@ update_distinct_attribute_1: |-
   curl \
     -X PUT 'http://localhost:7700/indexes/INDEX_NAME/settings/localized-attributes' \
     -H 'Content-Type: application/json' \
-    --data-binary '{ 
-   "localizedAttributes": [
-      {"locales": ["jpn"], "attributePatterns": ["*_ja"]}, 
-      {"locales": ["chi"], "attributePatterns": ["*_cn"]}
-   ]
-  }'
+    --data-binary '{
+      "localizedAttributes": [
+        {"locales": ["jpn"], "attributePatterns": ["*_ja"]}
+      ]
+    }'
 reset_distinct_attribute_1: |-
   curl \
     -X DELETE 'http://localhost:7700/indexes/INDEX_NAME/settings/localized-attributes'

--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -821,7 +821,7 @@ You may also assign an empty array to `locales`. In this case, Meilisearch will 
 
 #### `attributePatterns`
 
-Attribute patterns may begin or end with a `*` wildcard to match multiple fields: `en_*`, `*-ar`. 
+Attribute patterns may begin or end with a `*` wildcard to match multiple fields: `en_*`, `*-ar`.
 
 You may also set `attributePatterns` to `*`, in which case Meilisearch will treat all fields as if they were in the associated locale.
 
@@ -846,8 +846,7 @@ Get the localized attributes settings of an index.
 ```json
 {
   "localizedAttributes": [
-    {"locales": ["jpn"], "attributePatterns": ["*_ja"]},
-    {"locales": ["chi"], "attributePatterns": ["*_cn"]}
+    {"locales": ["jpn"], "attributePatterns": ["*_ja"]}
   ]
 }
 ```
@@ -2243,7 +2242,7 @@ Partially update the embedder settings for an index. When this setting is update
     "apiKey": <String>,
     "model": <String>,
     "documentTemplate": <String>,
-    "dimensions": <Integer>, 
+    "dimensions": <Integer>,
     "revision": <String>,
     "distribution": {
       "mean": <Float>,


### PR DESCRIPTION
`chi` does not work with Meilisaerch (`cmn` does)

But I removed it because we want to avoid users to set multiple languages: it will add a detection phase when indexing, so can lead to performance lost