### PR TITLE
Fix language settings code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1381,7 +1381,7 @@ search_parameter_reference_locales_1: |-
 get_localized_attribute_settings_1: |-
   curl \
     -X GET 'http://localhost:7700/indexes/INDEX_NAME/settings/localized-attributes'
-update_distinct_attribute_1: |-
+update_localized_attribute_settings_1: |-
   curl \
     -X PUT 'http://localhost:7700/indexes/INDEX_NAME/settings/localized-attributes' \
     -H 'Content-Type: application/json' \
@@ -1390,6 +1390,6 @@ update_distinct_attribute_1: |-
         {"locales": ["jpn"], "attributePatterns": ["*_ja"]}
       ]
     }'
-reset_distinct_attribute_1: |-
+reset_localized_attribute_settings_1: |-
   curl \
     -X DELETE 'http://localhost:7700/indexes/INDEX_NAME/settings/localized-attributes'


### PR DESCRIPTION
Fixing wrong code sample namings following: https://github.com/meilisearch/documentation/pull/2950/files#diff-65d25ef75b16ef426e9e9d93d4ab97e174f75dd16ca8e4c0d7f4b7ca03173516