### PR TITLE
Update comparison_to_alternatives.mdx

### DIFF
--- a/learn/resources/comparison_to_alternatives.mdx
+++ b/learn/resources/comparison_to_alternatives.mdx
@@ -99,7 +99,8 @@ Can't find a client you'd like us to support? [Submit your idea or vote for it](
 |   | Meilisearch | Algolia | Typesense | Elasticsearch |
 |---|:---:|:----:|:---:|:---:|
 | Placeholder search | ✅ | ✅ | ✅ | ✅ |
-| Multi-index search (Federated search) | ✅ | ✅ | ✅ | ✅ |
+| Multi-index search | ✅ | ✅ | ✅ | ✅ |
+| Federated search | ✅ | ❌ | ❌ | ✅ |
 | Exact phrase search | ✅ | ✅ | ✅ | ✅ |
 | Geo search |  ✅  | ✅ | ✅ | ✅ |
 | Sort by  |  ✅  | 🔶 <br /> Limited to one `sort_by` rule per index. Indexes may have to be duplicated for each sort field and sort order | ✅ <br /> Up to 3 sort fields per search query | ✅ |


### PR DESCRIPTION
This PR separates "federated search" from "multi-index search" in the comparison table.

According to the [Federated search PRD](https://www.notion.so/meilisearch/Federated-Search-PRD-07ff4017f65f4a42b577a7925e94e92d), only Meilisearch and Elasticsearch support federated search.