### PR TITLE
Fix the known limitation around the size of faceted values

### DIFF
--- a/learn/resources/known_limitations.mdx
+++ b/learn/resources/known_limitations.mdx
@@ -76,9 +76,9 @@ If your query is `Hello - World`:
 
 ## Length of individual `filterableAttributes` values
 
-**Limitation:** Individual `filterableAttributes` values are limited to 512 bytes.
+**Limitation:** Individual `filterableAttributes` values are limited to 480 bytes.
 
-**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to 512 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 512 bytes.
+**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to 512 bytes, to which Meilisearch adds a margin of 32 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 480 bytes.
 
 ## Maximum filter depth
 

--- a/learn/resources/known_limitations.mdx
+++ b/learn/resources/known_limitations.mdx
@@ -76,9 +76,9 @@ If your query is `Hello - World`:
 
 ## Length of individual `filterableAttributes` values
 
-**Limitation:** Individual `filterableAttributes` values are limited to 480 bytes.
+**Limitation:** Individual `filterableAttributes` values are limited to 468 bytes.
 
-**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to 512 bytes, to which Meilisearch adds a margin of 32 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 480 bytes.
+**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to 512 bytes, to which Meilisearch adds a margin of 44 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 468 bytes.
 
 ## Maximum filter depth
 


### PR DESCRIPTION
The limitation was slightly wrong, as you can see in meilisearch we keep a « safe margin of 32 bytes »:
https://github.com/meilisearch/meilisearch/blob/db0cf3b2ed0ca6cf6549510bf373681e83b775dd/milli/src/lib.rs#L106-L110

Discovered while trying to understand https://github.com/meilisearch/meilisearch/issues/4915