### PR TITLE
Fix instructions in Run in production guide

### DIFF
--- a/guides/running_production.mdx
+++ b/guides/running_production.mdx
@@ -46,7 +46,14 @@ Next, you need to make the binary accessible from anywhere in your system. Move 
 mv ./meilisearch /usr/local/bin/
 ```
 
-Meilisearch is now running, but it is not publicly accessible.
+Finally you need to ensure Meilisearch is executable.
+
+```sh
+chmod +x /usr/local/bin/meilisearch
+```
+
+We're now ready to move onto configuring how Meilisearch will run.
+
 
 ## Step 2: Create system user
 


### PR DESCRIPTION
# Pull Request

## Related issue
No issue raised for this. Just a fix.

## What does this PR do?
The guide did not mention to set the binary as executable, which is an issue when you're configuring the service to run as the created user. You'll end up seeing a failure:

```
# systemctl status meilisearch
× meilisearch.service - Meilisearch
     Loaded: loaded (/etc/systemd/system/meilisearch.service; enabled; vendor preset: enabled)
     Active: failed (Result: exit-code) since Tue 2024-09-17 09:00:06 UTC; 2min 37s ago
   Main PID: 22227 (code=exited, status=203/EXEC)
        CPU: 4ms

Sep 17 09:00:06 adam.edge.network systemd[1]: meilisearch.service: Scheduled restart job, restart counter is at 5.
Sep 17 09:00:06 adam.edge.network systemd[1]: Stopped Meilisearch.
Sep 17 09:00:06 adam.edge.network systemd[1]: meilisearch.service: Start request repeated too quickly.
Sep 17 09:00:06 adam.edge.network systemd[1]: meilisearch.service: Failed with result 'exit-code'.
Sep 17 09:00:06 adam.edge.network systemd[1]: Failed to start Meilisearch.
```

You can see here that following the previous instructions leads to a non-executable file (`-rwxr--r--`) when we're expecting `-rwxr-xr-x`:

```
# ls -l /usr/local/bin/meilisearch
-rwxr--r-- 1 root root 120750704 Sep 17 08:55 /usr/local/bin/meilisearch

# chmod +x /usr/local/bin/meilisearch

# ls -l /usr/local/bin/meilisearch
-rwxr-xr-x 1 root root 120750704 Sep 17 08:55 /usr/local/bin/meilisearch
```
