### PR TITLE
fix: broken links in link checker

### DIFF
--- a/.github/actions/validate-docs-links/src/checker.ts
+++ b/.github/actions/validate-docs-links/src/checker.ts
@@ -161,16 +161,20 @@ async function prepareDocumentMapEntry(
 
 // Checks if the links point to existing documents
 function validateInternalLink(errors: Errors, href: string): void {
-  // /docs/api/example#heading -> ["api/example", "heading""]
-  const [link, hash] = href.split('#')
+  // Split the href into link and hash
+  // href could be: /reference/api/settings?utm_campaign=...#hash
+  const [linkWithQueryAndHash, hash] = href.split('#')
+
+  // Remove query parameters from the link
+  const linkWithQuery = linkWithQueryAndHash
+  const link = linkWithQuery.split('?')[0]
 
   if (EXCLUDED_PATHS.includes(link)) return
 
-  if(link.startsWith('/assets')) return
+  if (link.startsWith('/assets')) return
 
-  // check if doc page exists
+  // Check if doc page exists
   const foundPage = documentMap.get(link.replace(/^\/+/, ''))
-
 
   if (!foundPage) {
     errors.link.push(href)


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #[NOT-78](https://linear.app/notum-meili/issue/NOT-78/docs-broken-links-checker-giving-false-positives-when-links-contain)

# PR: Fix Link Checker for Query Parameters and Anchor Links

## Overview

This PR fixes the issue where the link checker incorrectly flags valid links containing query parameters or hash anchors as broken.

## Changes

1. **Query Parameters Handling:**
   - Strips query parameters (e.g., `?utm_campaign=...`) from internal links before validation.
   
2. **Anchor Links Validation:**
   - Ensures hash-based links (e.g., `#heading`) are correctly validated against document headings.

3. **No Changes to External or Static Asset Links:**
   - External links and static assets continue to be ignored.

## Why

Previously, valid links with query parameters or hash fragments were incorrectly reported as broken. This fix improves the accuracy of the link checker.

## Testing

- Links with query parameters are no longer flagged.
- Hash-based links (anchors) are correctly validated.
- External and static asset links are ignored as expected.


## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
