### PR TITLE
Fix confusing index name

### DIFF
--- a/learn/engine/datatypes.mdx
+++ b/learn/engine/datatypes.mdx
@@ -257,7 +257,7 @@ The following query returns patients `0` and `1`:
 
 ```sh
 curl \
-  -X POST 'http://localhost:7700/indexes/movie_ratings/search' \
+  -X POST 'http://localhost:7700/indexes/clinic_patients/search' \
   -H 'Content-Type: application/json' \
   --data-binary '{
     "q": "",


### PR DESCRIPTION
Index name `movies_ratings` is not in the context of the filters in curl command, when there is filters with "appointments.date" and "appointments.doctor" and the results of patients

The index name `clinic_patients` would be much more relevant to this context

# Pull Request

## Related issue
Fixes #2999 

## What does this PR do?
- Replace `movies_ratings` to `clinic_patients` according to the context

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
