### PR TITLE
doc(vector): update Ollama endpoint

### DIFF
--- a/learn/experimental/vector_search.mdx
+++ b/learn/experimental/vector_search.mdx
@@ -116,7 +116,7 @@ curl \
     "embedders": {
       "default": {
         "source": "ollama",
-        "url": "http://localhost:11434/api/embeddings",
+        "url": "http://localhost:11434/api/embed",
         "apiKey": "OLLAMA_API_KEY",
         "model": "MODEL_NAME",
         "documentTemplate": "A document titled {{doc.title}} whose description starts with {{doc.overview|truncatewords: 20}}"


### PR DESCRIPTION
Hi 👋🏻 

As stated in the official Ollama documentation, the endpoint is `/api/embed` and not `/api/embeddings`.

Doc: https://github.com/ollama/ollama/blob/main/docs/api.md#generate-embeddings

# Pull Request

## Related issue
Fixes #<issue_number>

## What does this PR do?

Update on the embeddings endpoints for Ollama

## PR checklist

Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?
