### PR TITLE
Update supported_os.mdx

### DIFF
--- a/learn/self_hosted/supported_os.mdx
+++ b/learn/self_hosted/supported_os.mdx
@@ -15,7 +15,7 @@ Use [Meilisearch Cloud](https://www.meilisearch.com/cloud?utm_campaign=oss&utm_s
 
 ## Linux
 
-The Meilisearch binary works on all Linux distributions with `amd64/x86_64` or `aarch64/arm64` architecture using glibc 2.28 and later. You can check your glibc version using:
+The Meilisearch binary works on all Linux distributions with `amd64/x86_64` or `aarch64/arm64` architecture using glibc 2.31 and later. You can check your glibc version using:
 
 ```
 ldd --version


### PR DESCRIPTION
Update the minimal version of the glibc required to run meilisearch

See https://github.com/meilisearch/meilisearch/issues/4914 for more info
