### PR TITLE
Add Hugging Face Inference Endpoints as a rest embedder guide

### DIFF
--- a/config/sidebar-guides.json
+++ b/config/sidebar-guides.json
@@ -66,7 +66,7 @@
         "slug": "langchain"
       },
       {
-        "source": "guides/huggingface.mdx",
+        "source": "guides/embedders/huggingface.mdx",
         "label": "Implementing semantic search with Hugging Face Inference Endpoints",
         "slug": "huggingface"
       },

--- a/config/sidebar-guides.json
+++ b/config/sidebar-guides.json
@@ -56,14 +56,19 @@
     "slug": "ai",
     "routes": [
       {
+        "source": "guides/embedders/openai.mdx",
+        "label": "Semantic search with OpenAI embeddings",
+        "slug": "openai"
+      },
+      {
         "source": "guides/langchain.mdx",
         "label": "Implementing semantic search with LangChain",
         "slug": "langchain"
       },
       {
-        "source": "guides/computing_hugging_face_embeddings_gpu.mdx",
-        "label": "Computing Hugging Face embeddings with the GPU",
-        "slug": "computing_hugging_face_embeddings_gpu"
+        "source": "guides/huggingface.mdx",
+        "label": "Implementing semantic search with Hugging Face Inference Endpoints",
+        "slug": "huggingface"
       },
       {
         "source": "guides/embedders/cloudflare.mdx",
@@ -81,14 +86,14 @@
         "slug": "mistral"
       },
       {
-        "source": "guides/embedders/openai.mdx",
-        "label": "Semantic search with OpenAI embeddings",
-        "slug": "openai"
-      },
-      {
         "source": "guides/embedders/voyage.mdx",
         "label": "Semantic search with Voyage embeddings",
         "slug": "voyage"
+      },
+      {
+        "source": "guides/computing_hugging_face_embeddings_gpu.mdx",
+        "label": "Computing Hugging Face embeddings with the GPU",
+        "slug": "computing_hugging_face_embeddings_gpu"
       }
     ]
   },

--- a/guides/embedders/cloudflare.mdx
+++ b/guides/embedders/cloudflare.mdx
@@ -88,7 +88,7 @@ In this request:
 - `q`: Represents the user's search query.
 - `hybrid`: Specifies the configuration for the hybrid search.
   - `semanticRatio`: Allows you to control the balance between semantic search and traditional search. A value of 1 indicates pure semantic search, while a value of 0 represents full-text search. You can adjust this parameter to achieve a hybrid search experience.
-  - `embedder`: The name of the embedder used for generating embeddings. Make sure to use the same name as specified in the embedder configuration, which in this case is "cf-bge-small-en-v1.5".
+  - `embedder`: The name of the embedder used for generating embeddings. Make sure to use the same name as specified in the embedder configuration, which in this case is "cloudflare".
 
 You can use the Meilisearch API or client libraries to perform searches and retrieve the relevant documents based on semantic similarity.
 

--- a/guides/embedders/huggingface.mdx
+++ b/guides/embedders/huggingface.mdx
@@ -20,7 +20,7 @@ To follow this guide, you'll need:
 
 ## Setting up Meilisearch
 
-To set up an embedder in Meilisearch, you need to configure it to your settings. You can refer to the [Meilisearch documentation](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#update-embedder-settings) for more details on updating the embedder settings.
+To set up an embedder in Meilisearch, you need to configure it to your settings. You can refer to the [Meilisearch documentation](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#update-embedder-settings) for more details on updating the embedder settings.
 
 Hugging Face offers a [wide variety of embedding models](https://ui.endpoints.huggingface.co/catalog?task=sentence-embeddings) you can deploy to embed the content of your documents.
 
@@ -48,13 +48,13 @@ In this configuration:
 - `url`: Replace `<Endpoint URL>` with your actual deployed model endpoint on Hugging Face.
 - `apiKey`: Replace `<API Key>` with your actual Hugging Face API key.
 - `dimensions`: Specifies the dimensions of the embeddings. Set to 384 for `baai/bge-small-en-v1.5` in our example.
-- `documentTemplate`: Optionally, you can provide a [custom template](/learn/ai_powered_search/getting_started_with_ai_search?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#documenttemplate) for generating embeddings from your documents.
+- `documentTemplate`: Optionally, you can provide a [custom template](/learn/ai_powered_search/getting_started_with_ai_search?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#documenttemplate) for generating embeddings from your documents.
 - `request`: Defines the request structure for the deployed model API, including the input parameters.
 - `response`: Defines the expected response structure from the deployed model API, including the embedding data.
 
 Once you've configured the embedder settings, Meilisearch will automatically generate embeddings for your documents and store them in the vector store.
 
-It's recommended to monitor the tasks queue to ensure everything is running smoothly. You can access the tasks queue using the Cloud UI or the [Meilisearch API](/reference/api/tasks?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#get-tasks).
+It's recommended to monitor the tasks queue to ensure everything is running smoothly. You can access the tasks queue using the Cloud UI or the [Meilisearch API](/reference/api/tasks?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#get-tasks).
 
 ## Testing semantic search
 
@@ -84,4 +84,4 @@ You can use the Meilisearch API or client libraries to perform searches and retr
 
 By following this guide, you should now have Meilisearch set up with Hugging Face Inference Endpoints, enabling you to leverage semantic search capabilities in your application. Meilisearch's auto-batching and efficient handling of embeddings make it a powerful choice for integrating semantic search into your project.
 
-To explore further configuration options for embedders, consult the [detailed documentation about the embedder setting possibilities](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#embedders-experimental).
+To explore further configuration options for embedders, consult the [detailed documentation about the embedder setting possibilities](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#embedders-experimental).

--- a/guides/embedders/huggingface.mdx
+++ b/guides/embedders/huggingface.mdx
@@ -34,7 +34,8 @@ Set up an embedder using the update settings endpoint:
     "dimensions": 384,
     "documentTemplate": "CUSTOM_LIQUID_TEMPLATE",
     "request": {
-      "inputs": ["{{text}}", "{{..}}"]
+      "inputs": ["{{text}}", "{{..}}"],
+      "model": "baai/bge-small-en-v1.5"
     },
     "response": ["{{embedding}}", "{{..}}"]
   }

--- a/guides/embedders/huggingface.mdx
+++ b/guides/embedders/huggingface.mdx
@@ -1,0 +1,87 @@
+---
+title: Semantic Search with Hugging Face Inference Endpoints - Meilisearch documentation
+description: This guide will walk you through the process of setting up Meilisearch with Hugging Face Inference Endpoints to enable semantic search capabilities.
+---
+
+# Semantic search with Hugging Face Inference Endpoints
+
+## Introduction
+
+This guide will walk you through the process of setting up Meilisearch with [Hugging Face Inference Endpoints](https://ui.endpoints.huggingface.co/) embeddings to enable semantic search capabilities. By leveraging Meilisearch's AI features and Hugging Face Inference Endpoints, you can enhance your search experience and retrieve more relevant results.
+
+## Requirements
+
+To follow this guide, you'll need:
+
+- A [Meilisearch Cloud](https://www.meilisearch.com/cloud?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide) project running version 1.10 or above with the Vector store activated.
+- An Hugging Face account with a deployed inference endpoint. You can sign up for a Hugging Face account at [Hugging Face](https://huggingface.co/).
+- The endpoint url and API key of the deployed model on your Hugging Face account.
+- No backend required.
+
+## Setting up Meilisearch
+
+To set up an embedder in Meilisearch, you need to configure it to your settings. You can refer to the [Meilisearch documentation](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#update-embedder-settings) for more details on updating the embedder settings.
+
+Hugging Face offers a [wide variety of embedding models](https://ui.endpoints.huggingface.co/catalog?task=sentence-embeddings) you can deploy to embed the content of your documents.
+
+Here's an example of embedder settings using [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) model:
+
+```json
+{
+  "hf-inference": {
+    "source": "rest",
+    "url": "<ENDPOINT URL>",
+    "apiKey": "<API Key>",
+    "dimensions": 384,
+    "documentTemplate": "<Custom template (Optional, but recommended)>",
+    "request": {
+      "inputs": ["{{text}}", "{{..}}"]
+    },
+    "response": ["{{embedding}}", "{{..}}"]
+  }
+}
+```
+
+In this configuration:
+
+- `source`: Specifies the source of the embedder, which is set to "rest" for using a REST API.
+- `url`: Replace `<Endpoint URL>` with your actual deployed model endpoint on Hugging Face.
+- `apiKey`: Replace `<API Key>` with your actual Hugging Face API key.
+- `dimensions`: Specifies the dimensions of the embeddings. Set to 384 for `baai/bge-small-en-v1.5` in our example.
+- `documentTemplate`: Optionally, you can provide a [custom template](/learn/ai_powered_search/getting_started_with_ai_search?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#documenttemplate) for generating embeddings from your documents.
+- `request`: Defines the request structure for the deployed model API, including the input parameters.
+- `response`: Defines the expected response structure from the deployed model API, including the embedding data.
+
+Once you've configured the embedder settings, Meilisearch will automatically generate embeddings for your documents and store them in the vector store.
+
+It's recommended to monitor the tasks queue to ensure everything is running smoothly. You can access the tasks queue using the Cloud UI or the [Meilisearch API](/reference/api/tasks?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#get-tasks).
+
+## Testing semantic search
+
+With the embedder set up, you can now perform semantic searches using Meilisearch. When you send a search query, Meilisearch will generate an embedding for the query using the configured embedder and then use it to find the most semantically similar documents in the vector store.
+To perform a semantic search, you simply need to make a normal search request but include the hybrid parameter:
+
+```json
+{
+  "q": "<Query made by the user>",
+  "hybrid": {
+    "semanticRatio": 1,
+    "embedder": "hf-inference"
+  }
+}
+```
+
+In this request:
+
+- `q`: Represents the user's search query.
+- `hybrid`: Specifies the configuration for the hybrid search.
+  - `semanticRatio`: Allows you to control the balance between semantic search and traditional search. A value of 1 indicates pure semantic search, while a value of 0 represents full-text search. You can adjust this parameter to achieve a hybrid search experience.
+  - `embedder`: The name of the embedder used for generating embeddings. Make sure to use the same name as specified in the embedder configuration, which in this case is "hf-inference".
+
+You can use the Meilisearch API or client libraries to perform searches and retrieve the relevant documents based on semantic similarity.
+
+## Conclusion
+
+By following this guide, you should now have Meilisearch set up with Hugging Face Inference Endpoints, enabling you to leverage semantic search capabilities in your application. Meilisearch's auto-batching and efficient handling of embeddings make it a powerful choice for integrating semantic search into your project.
+
+To explore further configuration options for embedders, consult the [detailed documentation about the embedder setting possibilities](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=cloudflare-embeddings-guide#embedders-experimental).

--- a/guides/embedders/huggingface.mdx
+++ b/guides/embedders/huggingface.mdx
@@ -1,39 +1,34 @@
 ---
 title: Semantic Search with Hugging Face Inference Endpoints - Meilisearch documentation
-description: This guide will walk you through the process of setting up Meilisearch with Hugging Face Inference Endpoints to enable semantic search capabilities.
+description: This guide will walk you through the process of setting up Meilisearch with Hugging Face Inference Endpoints.
 ---
 
 # Semantic search with Hugging Face Inference Endpoints
 
 ## Introduction
 
-This guide will walk you through the process of setting up Meilisearch with [Hugging Face Inference Endpoints](https://ui.endpoints.huggingface.co/) embeddings to enable semantic search capabilities. By leveraging Meilisearch's AI features and Hugging Face Inference Endpoints, you can enhance your search experience and retrieve more relevant results.
+This guide will walk you through the process of setting up Meilisearch with [Hugging Face Inference Endpoints](https://ui.endpoints.huggingface.co/) embeddings to enable semantic search capabilities.
 
 ## Requirements
 
 To follow this guide, you'll need:
 
-- A [Meilisearch Cloud](https://www.meilisearch.com/cloud?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide) project running version 1.10 or above with the Vector store activated.
-- An Hugging Face account with a deployed inference endpoint. You can sign up for a Hugging Face account at [Hugging Face](https://huggingface.co/).
-- The endpoint url and API key of the deployed model on your Hugging Face account.
-- No backend required.
+- A [Meilisearch Cloud](https://www.meilisearch.com/cloud) project running version 1.10 or above with the Vector store activated
+- A [Hugging Face account](https://huggingface.co/) with a deployed inference endpoint
+- The endpoint URL and API key of the deployed model on your Hugging Face account
 
-## Setting up Meilisearch
+## Configure the embedder
 
-To set up an embedder in Meilisearch, you need to configure it to your settings. You can refer to the [Meilisearch documentation](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#update-embedder-settings) for more details on updating the embedder settings.
-
-Hugging Face offers a [wide variety of embedding models](https://ui.endpoints.huggingface.co/catalog?task=sentence-embeddings) you can deploy to embed the content of your documents.
-
-Here's an example of embedder settings using [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) model:
+Set up an embedder using the update settings endpoint:
 
 ```json
 {
   "hf-inference": {
     "source": "rest",
-    "url": "<ENDPOINT URL>",
-    "apiKey": "<API Key>",
+    "url": "ENDPOINT_URL",
+    "apiKey": "API_KEY",
     "dimensions": 384,
-    "documentTemplate": "<Custom template (Optional, but recommended)>",
+    "documentTemplate": "CUSTOM_LIQUID_TEMPLATE",
     "request": {
       "inputs": ["{{text}}", "{{..}}"]
     },
@@ -56,14 +51,13 @@ Once you've configured the embedder settings, Meilisearch will automatically gen
 
 It's recommended to monitor the tasks queue to ensure everything is running smoothly. You can access the tasks queue using the Cloud UI or the [Meilisearch API](/reference/api/tasks?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#get-tasks).
 
-## Testing semantic search
+## Perform a semantic search
 
-With the embedder set up, you can now perform semantic searches using Meilisearch. When you send a search query, Meilisearch will generate an embedding for the query using the configured embedder and then use it to find the most semantically similar documents in the vector store.
-To perform a semantic search, you simply need to make a normal search request but include the hybrid parameter:
+With the embedder set up, you can now perform semantic searches. Make a search request with the `hybrid` search parameter, setting `semanticRatio` to `1`:
 
 ```json
 {
-  "q": "<Query made by the user>",
+  "q": "QUERY_TERMS",
   "hybrid": {
     "semanticRatio": 1,
     "embedder": "hf-inference"
@@ -73,15 +67,13 @@ To perform a semantic search, you simply need to make a normal search request bu
 
 In this request:
 
-- `q`: Represents the user's search query.
-- `hybrid`: Specifies the configuration for the hybrid search.
-  - `semanticRatio`: Allows you to control the balance between semantic search and traditional search. A value of 1 indicates pure semantic search, while a value of 0 represents full-text search. You can adjust this parameter to achieve a hybrid search experience.
-  - `embedder`: The name of the embedder used for generating embeddings. Make sure to use the same name as specified in the embedder configuration, which in this case is "hf-inference".
-
-You can use the Meilisearch API or client libraries to perform searches and retrieve the relevant documents based on semantic similarity.
+- `q`: the search query
+- `hybrid`: enables AI-powered search functionality
+  - `semanticRatio`: controls the balance between semantic search and full-text search. Setting it to `1` means you will only receive semantic search results
+  - `embedder`: the name of the embedder used for generating embeddings
 
 ## Conclusion
 
 By following this guide, you should now have Meilisearch set up with Hugging Face Inference Endpoints, enabling you to leverage semantic search capabilities in your application. Meilisearch's auto-batching and efficient handling of embeddings make it a powerful choice for integrating semantic search into your project.
 
-To explore further configuration options for embedders, consult the [detailed documentation about the embedder setting possibilities](/reference/api/settings?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#embedders-experimental).
+Consult the [embedder setting documentation](/reference/api/settings#embedders-experimental) for more information on other embedder configuration options.

--- a/guides/embedders/huggingface.mdx
+++ b/guides/embedders/huggingface.mdx
@@ -39,17 +39,19 @@ Set up an embedder using the update settings endpoint:
 
 In this configuration:
 
-- `source`: Specifies the source of the embedder, which is set to "rest" for using a REST API.
-- `url`: Replace `<Endpoint URL>` with your actual deployed model endpoint on Hugging Face.
-- `apiKey`: Replace `<API Key>` with your actual Hugging Face API key.
-- `dimensions`: Specifies the dimensions of the embeddings. Set to 384 for `baai/bge-small-en-v1.5` in our example.
-- `documentTemplate`: Optionally, you can provide a [custom template](/learn/ai_powered_search/getting_started_with_ai_search?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#documenttemplate) for generating embeddings from your documents.
-- `request`: Defines the request structure for the deployed model API, including the input parameters.
-- `response`: Defines the expected response structure from the deployed model API, including the embedding data.
+- `source`: declares Meilisearch should connect to this embedder via its REST API
+- `url`: replace `ENDPOINT_URL` with the address of your Hugging Face model endpoint
+- `apiKey`: replace `API_KEY` with your Hugging Face API key
+- `dimensions`: specifies the dimensions of the embeddings, which are 384 for `baai/bge-small-en-v1.5`
+- `documentTemplate`: an optional but recommended [template](/learn/ai_powered_search/getting_started_with_ai_search) for the data you will send the embedder
+- `request`: defines the structure and parameters of the request Meilisearch will send to the embedder
+- `response`: defines the structure of the embedder's  response
 
-Once you've configured the embedder settings, Meilisearch will automatically generate embeddings for your documents and store them in the vector store.
+Once you've configured the embedder, Meilisearch will automatically generate embeddings for your documents. You monitor the task using the Cloud UI or the [get task endpoint](/reference/api/tasks).
 
-It's recommended to monitor the tasks queue to ensure everything is running smoothly. You can access the tasks queue using the Cloud UI or the [Meilisearch API](/reference/api/tasks?utm_campaign=vector-search&utm_source=docs&utm_medium=huggingface-embeddings-guide#get-tasks).
+<Capsule intent="note">
+This example uses [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) as its model, but Hugging Face offers [other options that my fit your dataset better](https://ui.endpoints.huggingface.co/catalog?task=sentence-embeddings).
+</Capsule>
 
 ## Perform a semantic search
 
@@ -74,6 +76,6 @@ In this request:
 
 ## Conclusion
 
-By following this guide, you should now have Meilisearch set up with Hugging Face Inference Endpoints, enabling you to leverage semantic search capabilities in your application. Meilisearch's auto-batching and efficient handling of embeddings make it a powerful choice for integrating semantic search into your project.
+You have set up with an embedder using Hugging Face Inference Endpoints. This allows you to use pure semantic search capabilities in your application.
 
 Consult the [embedder setting documentation](/reference/api/settings#embedders-experimental) for more information on other embedder configuration options.

--- a/guides/embedders/huggingface.mdx
+++ b/guides/embedders/huggingface.mdx
@@ -7,7 +7,11 @@ description: This guide will walk you through the process of setting up Meilisea
 
 ## Introduction
 
-This guide will walk you through the process of setting up Meilisearch with [Hugging Face Inference Endpoints](https://ui.endpoints.huggingface.co/) embeddings to enable semantic search capabilities.
+This guide will walk you through the process of setting up a Meilisearch REST embedder with [Hugging Face Inference Endpoints](https://ui.endpoints.huggingface.co/) to enable semantic search capabilities.
+
+<Capsule intent="note" title="`rest` or `huggingface`?">
+You can use Hugging Face and Meilisearch in two ways: running the model locally by setting the embedder source to `huggingface`, or remotely in Hugging Face's servers by setting the embeder source to `rest`.
+</Capsule>
 
 ## Requirements
 
@@ -47,10 +51,10 @@ In this configuration:
 - `request`: defines the structure and parameters of the request Meilisearch will send to the embedder
 - `response`: defines the structure of the embedder's  response
 
-Once you've configured the embedder, Meilisearch will automatically generate embeddings for your documents. You monitor the task using the Cloud UI or the [get task endpoint](/reference/api/tasks).
+Once you've configured the embedder, Meilisearch will automatically generate embeddings for your documents. Monitor the task using the Cloud UI or the [get task endpoint](/reference/api/tasks).
 
 <Capsule intent="note">
-This example uses [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) as its model, but Hugging Face offers [other options that my fit your dataset better](https://ui.endpoints.huggingface.co/catalog?task=sentence-embeddings).
+This example uses [BAAI/bge-small-en-v1.5](https://huggingface.co/BAAI/bge-small-en-v1.5) as its model, but Hugging Face offers [other options that may fit your dataset better](https://ui.endpoints.huggingface.co/catalog?task=sentence-embeddings).
 </Capsule>
 
 ## Perform a semantic search


### PR DESCRIPTION
## What does this PR do?

- Add a guide on how to use a model deployed on Hugging Face using Meilisearch rest embedder setting
- Fix a minor mistake in the Cloudflare one