### PR TITLE
The max size of a key in LMDB is actually 511, not 512.

### DIFF
--- a/learn/resources/known_limitations.mdx
+++ b/learn/resources/known_limitations.mdx
@@ -70,15 +70,15 @@ If your query is `Hello - World`:
 
 ## Length of primary key values
 
-**Limitation:** Primary key values are limited to 512 bytes.
+**Limitation:** Primary key values are limited to 511 bytes.
 
-**Explanation:** Meilisearch stores primary key values as LMDB keys, a data type whose size is limited to 512 bytes. If a primary key value exceeds 512 bytes, the task containing these documents will fail.
+**Explanation:** Meilisearch stores primary key values as LMDB keys, a data type whose size is limited to 511 bytes. If a primary key value exceeds 511 bytes, the task containing these documents will fail.
 
 ## Length of individual `filterableAttributes` values
 
 **Limitation:** Individual `filterableAttributes` values are limited to 468 bytes.
 
-**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to 512 bytes, to which Meilisearch adds a margin of 44 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 468 bytes.
+**Explanation:** Meilisearch stores `filterableAttributes` values as keys in LMDB, a data type whose size is limited to 511 bytes, to which Meilisearch adds a margin of 44 bytes. Note that this only applies to individual values—for example, a `genres` attribute can contain any number of values such as `horror`, `comedy`, or `cyberpunk` as long as each one of them is smaller than 468 bytes.
 
 ## Maximum filter depth
 


### PR DESCRIPTION
# Pull Request

The documentation currently informs users of limitations on the size of various data to 512 bytes, due to the maximum size of a LMDB key.

That maximum size is actually 511, as evidenced by https://github.com/meilisearch/meilisearch/issues/5050.

This documentation PR indicates the correct value for all involved values, while the companion code PR (https://github.com/meilisearch/meilisearch/pull/5144) replaces an internal error by a user error by checking against the correct value.