### PR TITLE
Added missing `distinct` param in search parameters overview

### DIFF
--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -248,6 +248,7 @@ This is not necessary when using the `POST` route or one of our [SDKs](/learn/re
 | **[`page`](#page)**                                     | Integer          | `1`           | Request a specific page of results                  |
 | **[`filter`](#filter)**                                 | Array of strings | `null`        | Filter queries by an attribute's value              |
 | **[`facets`](#facets)**                                 | Array of strings | `null`        | Display the count of matches per facet              |
+| **[`distinct`](#distinct-attributes-at-search-time)**   | String           | `null`        | limit search to return one (most relevant) document per each value of specified attribute |
 | **[`attributesToRetrieve`](#attributes-to-retrieve)**   | Array of strings | `["*"]`       | Attributes to display in the returned documents     |
 | **[`attributesToCrop`](#attributes-to-crop)**           | Array of strings | `null`        | Attributes whose values have to be cropped          |
 | **[`cropLength`](#crop-length)**                        | Integer          | `10`          | Maximum length of cropped value in words            |

--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -248,7 +248,7 @@ This is not necessary when using the `POST` route or one of our [SDKs](/learn/re
 | **[`page`](#page)**                                     | Integer          | `1`           | Request a specific page of results                  |
 | **[`filter`](#filter)**                                 | Array of strings | `null`        | Filter queries by an attribute's value              |
 | **[`facets`](#facets)**                                 | Array of strings | `null`        | Display the count of matches per facet              |
-| **[`distinct`](#distinct-attributes-at-search-time)**   | String           | `null`        | limit search to return one (most relevant) document per each value of specified attribute |
+| **[`distinct`](#distinct-attributes-at-search-time)**   | String           | `null`        | Restrict search to documents with unique values of the attribute defined as distinct. |
 | **[`attributesToRetrieve`](#attributes-to-retrieve)**   | Array of strings | `["*"]`       | Attributes to display in the returned documents     |
 | **[`attributesToCrop`](#attributes-to-crop)**           | Array of strings | `null`        | Attributes whose values have to be cropped          |
 | **[`cropLength`](#crop-length)**                        | Integer          | `10`          | Maximum length of cropped value in words            |


### PR DESCRIPTION
Fixes #3029

Added missing `distinct` param in search parameters overview table in `reference/api/search.mdx` file

Things to check:
1. Should the default value for `distinct` parameter be `null` or `""` empty string?
2. Is the description technically correct?  -> ` limit search to return one (most relevant) document per each value of specified attribute`
