### PR TITLE
Updated cancel tasks API reference

### DIFF
--- a/reference/api/tasks.mdx
+++ b/reference/api/tasks.mdx
@@ -343,7 +343,7 @@ If you try retrieving a deleted task, Meilisearch will return a [`task_not_found
 
 <RouteHighlighter method="POST" route="/tasks/cancel?{query_parameter}"/>
 
-Cancel any number of `enqueued` or `processing` tasks based on their `uid`, `status`, `type`, `indexUid`, or the date at which they were enqueued, processed, or completed.
+Cancel any number of `enqueued` or `processing` tasks based on their `uid`, `status`, `type`, `indexUid`, or the date at which they were enqueued (`enqueuedAt`) or processed (`startedAt`).
 
 Task cancellation is an atomic transaction: **either all tasks are successfully canceled or none are**.
 


### PR DESCRIPTION
Fixes #2818 

Currently [cancel tasks API reference](https://www.meilisearch.com/docs/reference/api/tasks#cancel-tasks) incorrectly mentions that even completed tasks can be cancelled. Updated the documentation to rectify that. Additionally added clarifications for which dates can be used for cancelling tasks.

Things to check:

1. Shouldn't we use the word **timestamp** instead of **date**? [`enqueuedAt`](https://www.meilisearch.com/docs/reference/api/tasks#enqueuedat) and [`startedAt`](https://www.meilisearch.com/docs/reference/api/tasks#startedat) are timestamps as per the documentation. Would writing it as timestamps contradict with the similar usage of dates everywhere else in the documentation?
2. Does the suggested change clearly convey the dates that can be used for task cancellation criteria?
3. Is there any ambiguity left here for the first time reader that needs addressal?