### PR TITLE
Updated Proximity precision API reference in settings.mdx

### DIFF
--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -1071,10 +1071,8 @@ Get the proximity precision settings of an index.
 
 ##### Response: `200 OK`
 
-```json
-{
-  "proximityPrecision": "byWord"
-}
+```
+"byWord"
 ```
 
 ### Update proximity precision settings


### PR DESCRIPTION
Fixes #2693 

Currently the documentation states the response for /indexes/{index_uid}/settings/proximity-precision is a JSON object:
```
{
  "proximityPrecision": "byWord"
}
```
But the actual response is a string:
```
"byWord"
```

Updated Proximity precision API reference in settings.mdx to reflect the same.

Things to check:
1. The documentation mentions **{index_uid}** whereas the issue mentions **INDEX_NAME** in the query. I am assuming these are used interchangeably. Please confirm this assumption.
2. Could you please double check if the response is indeed a string? Thanks!

