### PR TITLE
Correct example names for localizedAttributes

### DIFF
--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -892,7 +892,7 @@ Update the localized attributes settings of an index.
 
 #### Example
 
-<CodeSamples id="update_localized_attributes_settings_1" />
+<CodeSamples id="update_localized_attribute_settings_1" />
 
 ##### Response: `202 Accepted`
 
@@ -922,7 +922,7 @@ Reset an index's localized attributes to their [default value](#localized-attrib
 
 #### Example
 
-<CodeSamples id="reset_localized_attributes_settings_1" />
+<CodeSamples id="reset_localized_attribute_settings_1" />
 
 ##### Response: `202 Accepted`
 


### PR DESCRIPTION
Currently, the examples are missing due to being referred to by the wrong names. See the correct names in [meilisearch-js](https://github.com/meilisearch/meilisearch-js/blob/896b5c0cf3479a04a1b137394796a5f34b161210/.code-samples.meilisearch.yaml#L802).

Links to the live site for convenience:
https://www.meilisearch.com/docs/reference/api/settings#example-19
https://www.meilisearch.com/docs/reference/api/settings#example-20