### PR TITLE
Add missing word to desc of locales search param

### DIFF
--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -59,7 +59,7 @@ By default, [this endpoint returns a maximum of 1000 results](/learn/resources/k
 | **[`hybrid`](#hybrid-search-experimental)**             | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](#vector-experimental)**                    | Array of numbers | `null`        | Search using a custom query vector                  |
 | **[`retrieveVectors`](#display-_vectors-in-response-experimental)** | Boolean          | `false`       | Return document vector data                         |
-| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly language used in a query                         |
+| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify language(s) used in a query              |
 
 [Learn more about how to use each search parameter](#search-parameters).
 
@@ -173,7 +173,7 @@ By default, [this endpoint returns a maximum of 1000 results](/learn/resources/k
 | **[`hybrid`](#hybrid-search-experimental)**             | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](#vector-experimental)**                    | Array of numbers | `null`        | Search using a custom query vector                  |
 | **[`retrieveVectors`](#display-_vectors-in-response-experimental)** | Boolean          | `false`       | Return document vector data                         |
-| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly language used in a query                         |
+| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify language(s) used in a query              |
 
 [Learn more about how to use each search parameter](#search-parameters).
 
@@ -263,7 +263,7 @@ This is not necessary when using the `POST` route or one of our [SDKs](/learn/re
 | **[`hybrid`](#hybrid-search-experimental)**             | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](#vector-experimental)**                    | Array of numbers | `null`        | Search using a custom query vector                  |
 | **[`retrieveVectors`](#display-_vectors-in-response-experimental)** | Boolean          | `false`       | Return document vector data                         |
-| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly language used in a query                         |
+| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify language(s) used in a query              |
 
 ### Query (q)
 

--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -59,7 +59,7 @@ By default, [this endpoint returns a maximum of 1000 results](/learn/resources/k
 | **[`hybrid`](#hybrid-search-experimental)**             | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](#vector-experimental)**                    | Array of numbers | `null`        | Search using a custom query vector                  |
 | **[`retrieveVectors`](#display-_vectors-in-response-experimental)** | Boolean          | `false`       | Return document vector data                         |
-| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify language(s) used in a query              |
+| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify languages used in a query              |
 
 [Learn more about how to use each search parameter](#search-parameters).
 
@@ -173,7 +173,7 @@ By default, [this endpoint returns a maximum of 1000 results](/learn/resources/k
 | **[`hybrid`](#hybrid-search-experimental)**             | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](#vector-experimental)**                    | Array of numbers | `null`        | Search using a custom query vector                  |
 | **[`retrieveVectors`](#display-_vectors-in-response-experimental)** | Boolean          | `false`       | Return document vector data                         |
-| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify language(s) used in a query              |
+| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify languages used in a query              |
 
 [Learn more about how to use each search parameter](#search-parameters).
 
@@ -263,7 +263,7 @@ This is not necessary when using the `POST` route or one of our [SDKs](/learn/re
 | **[`hybrid`](#hybrid-search-experimental)**             | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](#vector-experimental)**                    | Array of numbers | `null`        | Search using a custom query vector                  |
 | **[`retrieveVectors`](#display-_vectors-in-response-experimental)** | Boolean          | `false`       | Return document vector data                         |
-| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify language(s) used in a query              |
+| **[`locales`](#query-locales)** | Array of strings          | `null`       | Explicitly specify languages used in a query              |
 
 ### Query (q)
 


### PR DESCRIPTION
Currently, the description of the `locales` search param does not make sense. When I read it it felt like a word was missing. Apologies if this was intended and correct.

In addition changed "language" to "language(s)" since more than one language may be specified.