### PR TITLE
Update the embedder settings documentation

### DIFF
--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -2476,7 +2476,7 @@ Use `source` to configure an embedder's source. The following embedders can auto
 
 Additionally, use `rest` to auto-generate embeddings with any embedder offering a REST API.
 
-You may also configure a `userProvided` embedder. In this case, you must manually include vector data in your documents' `_vector` field. You must also manually generate vectors for search queries.
+You may also configure a `userProvided` embedder. In this case, you must manually include vector data in your documents' `_vectors` field. You must also manually generate vectors for search queries.
 
 This field is mandatory.
 


### PR DESCRIPTION
There seems to be an issue in the documentation as it refers to  the `_vector` field instead of the `_vectors` one.