### PR TITLE
Updated `expected values` for limit in search.mdx

### DIFF
--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -373,7 +373,7 @@ If you want to skip the **first** result in a query, set `offset` to `1`:
 ### Limit
 
 **Parameter**: `limit`<br />
-**Expected value**: Any positive integer<br />
+**Expected value**: Any positive integer or zero<br />
 **Default value**: `20`
 
 Sets the maximum number of documents returned by a single query.


### PR DESCRIPTION
Fixes #2774

Updated `expected values` for limit in `reference/api/search.mdx` file to include zero as a valid input to the limit parameter.