### PR TITLE
Add batch_not_found error code documentation

### DIFF
--- a/reference/errors/error_codes.mdx
+++ b/reference/errors/error_codes.mdx
@@ -19,6 +19,10 @@ The requested API key could not be found.
 
 The request is invalid, check the error message for more information.
 
+## `batch_not_found`
+
+The requested batch does not exist. Please ensure that you are using the correct [`uid`](/reference/api/batches#uid).
+
 ## `database_size_limit_reached`
 
 The requested database has reached its maximum size.


### PR DESCRIPTION
It was linked before but did not exist. Copied word for word from tasks_not_found (with replacements of course), sorted alphabetically.

Fixes #3120