### PR TITLE
Correct the location of the dumps folder

### DIFF
--- a/learn/data_backup/dumps.mdx
+++ b/learn/data_backup/dumps.mdx
@@ -63,7 +63,7 @@ This should return an object with detailed information about the dump operation:
 
 All indexes of the current instance are exported along with their documents and settings and saved as a single `.dump` file. The dump also includes any tasks registered before Meilisearch start processing the dump creation task.
 
-Once the task `status` changes to `succeeded`, find the dump file in [the dump directory](/learn/self_hosted/configure_meilisearch_at_launch#dump-directory). By default, this folder is named `dumps` and can be found in the working directory where Meilisearch was started.
+Once the task `status` changes to `succeeded`, find the dump file in [the dump directory](/learn/self_hosted/configure_meilisearch_at_launch#dump-directory). By default, this folder is named `dumps` and can be found in the same directory where you launched Meilisearch.
 
 If a dump file is visible in the file system, the dump process was successfully completed. **Meilisearch will never create a partial dump file**, even if you interrupt an instance while it is generating a dump.
 

--- a/learn/data_backup/dumps.mdx
+++ b/learn/data_backup/dumps.mdx
@@ -63,7 +63,7 @@ This should return an object with detailed information about the dump operation:
 
 All indexes of the current instance are exported along with their documents and settings and saved as a single `.dump` file. The dump also includes any tasks registered before Meilisearch start processing the dump creation task.
 
-Once the task `status` changes to `succeeded`, find the dump file in [the dump directory](/learn/self_hosted/configure_meilisearch_at_launch#dump-directory). By default, this folder is named `dumps` and can be found in the same directory as your Meilisearch binary.
+Once the task `status` changes to `succeeded`, find the dump file in [the dump directory](/learn/self_hosted/configure_meilisearch_at_launch#dump-directory). By default, this folder is named `dumps` and can be found in the working directory where Meilisearch was started.
 
 If a dump file is visible in the file system, the dump process was successfully completed. **Meilisearch will never create a partial dump file**, even if you interrupt an instance while it is generating a dump.
 


### PR DESCRIPTION
While this would be accurate if following the official instructions and running ./meilisearch right after downloading, there's nothing preventing someone from running the binary from a different directory.
