### PR TITLE
Fix typo - OpenAPI link reference(yaml -> json)

### DIFF
--- a/reference/api/overview.mdx
+++ b/reference/api/overview.mdx
@@ -11,7 +11,7 @@ If you are new to Meilisearch, check out the [getting started](/learn/self_hoste
 
 ### OpenAPI
 
-You can get the [Meilisearch OpenAPI specifications here](https://github.com/meilisearch/open-api/blob/main/open-api.yaml).
+You can get the [Meilisearch OpenAPI specifications here](https://github.com/meilisearch/open-api/blob/main/open-api.json).
 
 ## Document conventions
 


### PR DESCRIPTION
# Pull Request

## Related issue
No standing issue

## What does this PR do?
- simple fix of a typo in reference/api/overview.mdx
- fixed link - https://github.com/meilisearch/open-api/blob/main/open-api.yaml -> open-api.json