### PR TITLE
Document userProvided embedders have no templates

### DIFF
--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -2527,7 +2527,9 @@ If a `field` does not exist in a document, its `value` is `nil`.
 
 For best results, build short templates that only contain highly relevant data. If working with a long field, consider [truncating it](https://shopify.github.io/liquid/filters/truncatewords/). If you do not manually set it, `documentTemplate` will include all searchable and non-null document fields. This may lead to suboptimal performance and relevancy.
 
-This field is optional but strongly encouraged for all embedders.
+This field is incompatible with `userProvided` embedders.
+
+This field is optional but strongly encouraged for all other embedders.
 
 ##### `documentTemplateMaxBytes`
 
@@ -2535,7 +2537,10 @@ The maximum size of a rendered document template. Longer texts are truncated to 
 
 `documentTemplateMaxBytes` must be an integer. It defaults to `400`.
 
-This field is optional for all embedders.
+This field is incompatible with `userProvided` embedders.
+
+This field is optional for all other embedders.
+
 
 ##### `dimensions`
 


### PR DESCRIPTION
Really small thing, didn't make an issue for it.

```sh
curl \
  -X PATCH 'localhost:7700/indexes/books/settings/embedders' \
  -H 'Content-Type: application/json' \
  --data-binary '{
    "default": {
      "source":  "userProvided",
      "documentTemplate": "heya",
      "dimensions": 3
    }
  }' \
-H 'Authorization: Bearer masterKey'
```
```json
{
  "message": "`.embedders.default`: Field `documentTemplate` unavailable for source `userProvided` (only available for sources: `huggingFace`, `openAi`, `ollama`, `rest`). Available fields: `source`, `dimensions`, `distribution`, `binaryQuantized`",
  "code": "invalid_settings_embedders",
  "type": "invalid_request",
  "link": "https://docs.meilisearch.com/errors#invalid_settings_embedders"
}
```