### PR TITLE
fix: case sensitivity

### DIFF
--- a/learn/ai_powered_search/getting_started_with_ai_search.mdx
+++ b/learn/ai_powered_search/getting_started_with_ai_search.mdx
@@ -77,7 +77,7 @@ Add a new `source` field to your embedder object:
 ```json
 {
   "products-openai": {
-    "source": "openai"
+    "source": "openAi"
   }
 }
 ```
@@ -93,7 +93,7 @@ Add a new `model` field to your embedder object:
 ```json
 {
   "products-openai": {
-    "source": "openai",
+    "source": "openAi",
     "model": "text-embedding-3-small"
   }
 }
@@ -110,7 +110,7 @@ Add the `apiKey` field to your embedder:
 ```json
 {
   "products-openai": {
-    "source": "openai",
+    "source": "openAi",
     "model": "text-embedding-3-small",
     "apiKey": "OPEN_AI_API_KEY",
   }
@@ -132,7 +132,7 @@ A good template should be short and only include the most important information 
 ```json
 {
   "products-openai": {
-    "source": "openai",
+    "source": "openAi",
     "model": "text-embedding-3-small",
     "apiKey": "OPEN_AI_API_KEY",
     "documentTemplate": "An object used in a kitchen named '{{doc.name}}'"


### PR DESCRIPTION
# Pull Request

## What does this PR do?
This PR corrects the source key in the Meilisearch Getting Started guide, where the embedder source for OpenAI was incorrectly documented as `openai` instead of the correct `openAi`. Since embedder sources are case-sensitive, this fix ensures accuracy and prevents potential misconfigurations.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
