### PR TITLE
Update the env variable for the experimental logs mode

### DIFF
--- a/learn/self_hosted/configure_meilisearch_at_launch.mdx
+++ b/learn/self_hosted/configure_meilisearch_at_launch.mdx
@@ -322,7 +322,7 @@ Meilisearch currently supports five log levels, listed in order of increasing ve
 
 ### Customize log output <NoticeTag type="experimental" label="experimental" />
 
-**Environment variable**: `MEILI_LOGS_MODE`<br />
+**Environment variable**: `MEILI_EXPERIMENTAL_LOGS_MODE`<br />
 **CLI option**: `--experimental-logs-mode`<br />
 **Default value**: `'human'`<br />
 **Expected value**: one of `human` or `json`


### PR DESCRIPTION
Someone noticed that the env variable was not working when updating the logs mode, and that’s the fix 🌟 

Context: https://github.com/meilisearch/meilisearch/issues/5459