### PR TITLE
Add missing search parameters to `/multi-search` reference

### DIFF
--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -159,7 +159,12 @@ There is no way to specify that two documents should be treated as the same acro
 | **[`sort`](/reference/api/search#sort)**                                     | Array of strings | `null`        | Sort search results by an attribute's value         |
 | **[`matchingStrategy`](/reference/api/search#matching-strategy)**            | String           | `last`        | Strategy used to match query terms within documents |
 | **[`showRankingScore`](/reference/api/search#ranking-score)**                | Boolean          | `false`       | Display the global ranking score of a document      |
-| **[`attributesToSearchOn`](/reference/api/search#customize-attributes-to-search-on-at-search-time)**            | Array of strings           | `["*"]`        | Restrict search to the specified attributes |
+| **[`showRankingScoreDetails`](/reference/api/search#ranking-score-details)** | Boolean          | `false`       | Adds a detailed global ranking score field          |
+| **[`attributesToSearchOn`](/reference/api/search#customize-attributes-to-search-on-at-search-time)** | Array of strings | `["*"]` | Restrict search to the specified attributes |
+| **[`hybrid`](/reference/api/search#hybrid-search)**                          | Object           | `null`        | Return results based on query keywords and meaning  |
+| **[`vector`](/reference/api/search#vector)**                                 | Array of numbers | `null`        | Search using a custom query vector                  |
+| **[`retrieveVectors`](/reference/api/search#display-_vectors-in-response)**  | Boolean          | `false`       | Return document vector data                         |
+| **[`locales`](/reference/api/search#query-locales)**                         | Array of strings | `null`        | Explicitly specify languages used in a query        |
 
 Unless otherwise noted, search parameters for multi-search queries function exactly like [search parameters for the `/search` endpoint](/reference/api/search#search-parameters).
 

--- a/reference/api/multi_search.mdx
+++ b/reference/api/multi_search.mdx
@@ -160,6 +160,7 @@ There is no way to specify that two documents should be treated as the same acro
 | **[`matchingStrategy`](/reference/api/search#matching-strategy)**            | String           | `last`        | Strategy used to match query terms within documents |
 | **[`showRankingScore`](/reference/api/search#ranking-score)**                | Boolean          | `false`       | Display the global ranking score of a document      |
 | **[`showRankingScoreDetails`](/reference/api/search#ranking-score-details)** | Boolean          | `false`       | Adds a detailed global ranking score field          |
+| **[`rankingScoreThreshold`](/reference/api/search#ranking-score-threshold)** | Number           | `null`        | Excludes results with low ranking scores            |
 | **[`attributesToSearchOn`](/reference/api/search#customize-attributes-to-search-on-at-search-time)** | Array of strings | `["*"]` | Restrict search to the specified attributes |
 | **[`hybrid`](/reference/api/search#hybrid-search)**                          | Object           | `null`        | Return results based on query keywords and meaning  |
 | **[`vector`](/reference/api/search#vector)**                                 | Array of numbers | `null`        | Search using a custom query vector                  |


### PR DESCRIPTION
Closes #3122, #2929, #3052