### PR TITLE
Fix redirects

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -77,7 +77,7 @@
 					},
 					{
 						"label": "Comparisons",
-						"href": "https://www.meilisearch.com/docs/learn/what_is_meilisearch/comparison_to_alternatives"
+						"href": "https://www.meilisearch.com/learn/what_is_meilisearch/comparison_to_alternatives"
 					},
 					{
 						"label": "Trust center",
@@ -449,500 +449,500 @@
   },
 	"redirects": [
 		{
-			"source": "/docs/reference/features/authentication",
-			"destination": "/docs/learn/security/master_api_keys"
+			"source": "/reference/features/authentication",
+			"destination": "/learn/security/master_api_keys"
 		},
 		{
-			"source": "/docs/errors",
-			"destination": "/docs/reference/errors/error_codes"
+			"source": "/errors",
+			"destination": "/reference/errors/error_codes"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/features",
-			"destination": "/docs/learn/what_is_meilisearch/overview#features"
+			"source": "/learn/what_is_meilisearch/features",
+			"destination": "/learn/what_is_meilisearch/overview#features"
 		},
 		{
-			"source": "/docs/learn/contributing/overview",
-			"destination": "/docs/learn/contributing/contributing_docs#contributing-to-meilisearch"
+			"source": "/learn/contributing/overview",
+			"destination": "/learn/contributing/contributing_docs#contributing-to-meilisearch"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/search_preview",
-			"destination": "/docs/learn/getting_started/search_preview"
+			"source": "/learn/what_is_meilisearch/search_preview",
+			"destination": "/learn/getting_started/search_preview"
 		},
 		{
-			"source": "/docs/learn/advanced/pagination",
-			"destination": "/docs/learn/front_end/pagination"
+			"source": "/learn/advanced/pagination",
+			"destination": "/learn/front_end/pagination"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations",
-			"destination": "/docs/learn/async/asynchronous_operations"
+			"source": "/learn/advanced/asynchronous_operations",
+			"destination": "/learn/async/asynchronous_operations"
 		},
 		{
-			"source": "/docs/learn/advanced/faceted_search",
-			"destination": "/docs/learn/fine_tuning_results/faceted_search"
+			"source": "/learn/advanced/faceted_search",
+			"destination": "/learn/fine_tuning_results/faceted_search"
 		},
 		{
-			"source": "/docs/learn/advanced/geosearch",
-			"destination": "/docs/learn/filtering_and_sorting/geosearch"
+			"source": "/learn/advanced/geosearch",
+			"destination": "/learn/filtering_and_sorting/geosearch"
 		},
 		{
-			"source": "/docs/learn/advanced/sorting",
-			"destination": "/docs/learn/filtering_and_sorting/sort_search_results"
+			"source": "/learn/advanced/sorting",
+			"destination": "/learn/filtering_and_sorting/sort_search_results"
 		},
 		{
-			"source": "/docs/learn/advanced/working_with_dates",
-			"destination": "/docs/learn/filtering_and_sorting/working_with_dates"
+			"source": "/learn/advanced/working_with_dates",
+			"destination": "/learn/filtering_and_sorting/working_with_dates"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/philosophy",
-			"destination": "/docs/learn/what_is_meilisearch/overview#philosophy"
+			"source": "/learn/what_is_meilisearch/philosophy",
+			"destination": "/learn/what_is_meilisearch/overview#philosophy"
 		},
 		{
-			"source": "/docs/learn/getting_started/quick_start#front-end-integration",
-			"destination": "/docs/learn/front_end/front_end_integration"
+			"source": "/learn/getting_started/quick_start#front-end-integration",
+			"destination": "/learn/front_end/front_end_integration"
 		},
 		{
-			"source": "/docs/reference/api/search#search-in-an-index-with-post-route",
-			"destination": "/docs/reference/api/search#search-in-an-index-with-post"
+			"source": "/reference/api/search#search-in-an-index-with-post-route",
+			"destination": "/reference/api/search#search-in-an-index-with-post"
 		},
 		{
-			"source": "/docs/reference/api/search#search-in-an-index-with-get-route",
-			"destination": "/docs/reference/api/search#search-in-an-index-with-get"
+			"source": "/reference/api/search#search-in-an-index-with-get-route",
+			"destination": "/reference/api/search#search-in-an-index-with-get"
 		},
 		{
-			"source": "/docs/reference/api/documents#get-documents",
-			"destination": "/docs/reference/api/documents#get-documents-with-get"
+			"source": "/reference/api/documents#get-documents",
+			"destination": "/reference/api/documents#get-documents-with-get"
 		},
 		{
-			"source": "/docs/reference/api/multi_search#post-route",
-			"destination": "/docs/reference/api/multi_search#perform-a-multi-search"
+			"source": "/reference/api/multi_search#post-route",
+			"destination": "/reference/api/multi_search#perform-a-multi-search"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/overview#sdks-and-integrations",
-			"destination": "/docs/learn/what_is_meilisearch/sdks"
+			"source": "/learn/what_is_meilisearch/overview#sdks-and-integrations",
+			"destination": "/learn/what_is_meilisearch/sdks"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/overview#alternatives",
-			"destination": "/docs/learn/what_is_meilisearch/comparison_to_alternatives"
+			"source": "/learn/what_is_meilisearch/overview#alternatives",
+			"destination": "/learn/what_is_meilisearch/comparison_to_alternatives"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filtering-tasks",
-			"destination": "/docs/learn/async/managing_tasks#filtering-tasks"
+			"source": "/learn/advanced/asynchronous_operations#filtering-tasks",
+			"destination": "/learn/async/managing_tasks#filtering-tasks"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#paginating-tasks",
-			"destination": "/docs/learn/async/managing_tasks#paginating-tasks"
+			"source": "/learn/advanced/asynchronous_operations#paginating-tasks",
+			"destination": "/learn/async/managing_tasks#paginating-tasks"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filter-by-uid",
-			"destination": "/docs/learn/async/managing_tasks#filter-by-uid"
+			"source": "/learn/advanced/asynchronous_operations#filter-by-uid",
+			"destination": "/learn/async/managing_tasks#filter-by-uid"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filter-by-status",
-			"destination": "/docs/learn/async/managing_tasks#filter-by-status"
+			"source": "/learn/advanced/asynchronous_operations#filter-by-status",
+			"destination": "/learn/async/managing_tasks#filter-by-status"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filter-by-type",
-			"destination": "/docs/learn/async/managing_tasks#filter-by-type"
+			"source": "/learn/advanced/asynchronous_operations#filter-by-type",
+			"destination": "/learn/async/managing_tasks#filter-by-type"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filter-by-indexuid",
-			"destination": "/docs/learn/async/managing_tasks#filter-by-indexuid"
+			"source": "/learn/advanced/asynchronous_operations#filter-by-indexuid",
+			"destination": "/learn/async/managing_tasks#filter-by-indexuid"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filter-by-canceledby",
-			"destination": "/docs/learn/async/managing_tasks#filter-by-canceledby"
+			"source": "/learn/advanced/asynchronous_operations#filter-by-canceledby",
+			"destination": "/learn/async/managing_tasks#filter-by-canceledby"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#filter-by-date",
-			"destination": "/docs/learn/async/managing_tasks#filter-by-date"
+			"source": "/learn/advanced/asynchronous_operations#filter-by-date",
+			"destination": "/learn/async/managing_tasks#filter-by-date"
 		},
 		{
-			"source": "/docs/learn/advanced/asynchronous_operations#combine-filters",
-			"destination": "/docs/learn/async/managing_tasks#combine-filters"
+			"source": "/learn/advanced/asynchronous_operations#combine-filters",
+			"destination": "/learn/async/managing_tasks#combine-filters"
 		},
 		{
-			"source": "/docs/learn/getting_started/filtering_and_sorting",
-			"destination": "/docs/learn/fine_tuning_results/filtering"
+			"source": "/learn/getting_started/filtering_and_sorting",
+			"destination": "/learn/fine_tuning_results/filtering"
 		},
 		{
-			"source": "/docs/learn/getting_started/customizing_relevancy",
-			"destination": "/docs/learn/configuration/settings"
+			"source": "/learn/getting_started/customizing_relevancy",
+			"destination": "/learn/configuration/settings"
 		},
 		{
-			"source": "/docs/learn/getting_started/getting_ready_for_production",
-			"destination": "/docs/learn/getting_started/cloud_quick_start"
+			"source": "/learn/getting_started/getting_ready_for_production",
+			"destination": "/learn/getting_started/cloud_quick_start"
 		},
 		{
-			"source": "/docs/learn/security/master_api_keys",
-			"destination": "/docs/learn/security/basic_security"
+			"source": "/learn/security/master_api_keys",
+			"destination": "/learn/security/basic_security"
 		},
 		{
-			"source": "/docs/learn/experimental/ranking_rule_score_details",
-			"destination": "/docs/reference/api/search#ranking_score_details"
+			"source": "/learn/experimental/ranking_rule_score_details",
+			"destination": "/reference/api/search#ranking_score_details"
 		},
 		{
-			"source": "/docs/learn/async/managing_tasks",
-			"destination": "/docs/learn/async/working_with_tasks"
+			"source": "/learn/async/managing_tasks",
+			"destination": "/learn/async/working_with_tasks"
 		},
 		{
-			"source": "/docs/learn/cookbooks/aws",
-			"destination": "/docs/guides/deployment/aws"
+			"source": "/learn/cookbooks/aws",
+			"destination": "/guides/deployment/aws"
 		},
 		{
-			"source": "/docs/learn/cookbooks/azure",
-			"destination": "/docs/guides/deployment/azure"
+			"source": "/learn/cookbooks/azure",
+			"destination": "/guides/deployment/azure"
 		},
 		{
-			"source": "/docs/learn/cookbooks/gcp",
-			"destination": "/docs/guides/deployment/gcp"
+			"source": "/learn/cookbooks/gcp",
+			"destination": "/guides/deployment/gcp"
 		},
 		{
-			"source": "/docs/learn/cookbooks/koyeb",
-			"destination": "/docs/guides/deployment/koyeb"
+			"source": "/learn/cookbooks/koyeb",
+			"destination": "/guides/deployment/koyeb"
 		},
 		{
-			"source": "/docs/learn/cookbooks/qovery",
-			"destination": "/docs/guides/deployment/qovery"
+			"source": "/learn/cookbooks/qovery",
+			"destination": "/guides/deployment/qovery"
 		},
 		{
-			"source": "/docs/learn/cookbooks/railway",
-			"destination": "/docs/guides/deployment/railway"
+			"source": "/learn/cookbooks/railway",
+			"destination": "/guides/deployment/railway"
 		},
 		{
-			"source": "/docs/learn/front_end/front_end_integration",
-			"destination": "/docs/guides/front_end/front_end_integration"
+			"source": "/learn/front_end/front_end_integration",
+			"destination": "/guides/front_end/front_end_integration"
 		},
 		{
-			"source": "/docs/learn/front_end/react_instantsearch",
-			"destination": "/docs/guides/front_end/react_quick_start"
+			"source": "/learn/front_end/react_instantsearch",
+			"destination": "/guides/front_end/react_quick_start"
 		},
 		{
-			"source": "/docs/guides/front_end/react_instantsearch",
-			"destination": "/docs/guides/front_end/react_quick_start"
+			"source": "/guides/front_end/react_instantsearch",
+			"destination": "/guides/front_end/react_quick_start"
 		},
 		{
-			"source": "/docs/learn/front_end/pagination",
-			"destination": "/docs/guides/front_end/pagination"
+			"source": "/learn/front_end/pagination",
+			"destination": "/guides/front_end/pagination"
 		},
 		{
-			"source": "/docs/learn/cookbooks/running_production",
-			"destination": "/docs/guides/deployment/running_production"
+			"source": "/learn/cookbooks/running_production",
+			"destination": "/guides/deployment/running_production"
 		},
 		{
-			"source": "/docs/learn/cookbooks/postman_collection",
-			"destination": "/docs/guides/misc/postman_collection"
+			"source": "/learn/cookbooks/postman_collection",
+			"destination": "/guides/misc/postman_collection"
 		},
 		{
-			"source": "/docs/learn/cookbooks/docker",
-			"destination": "/docs/guides/misc/docker"
+			"source": "/learn/cookbooks/docker",
+			"destination": "/guides/misc/docker"
 		},
 		{
-			"source": "/docs/learn/cookbooks/search_bar_for_docs",
-			"destination": "/docs/guides/front_end/search_bar_for_docs"
+			"source": "/learn/cookbooks/search_bar_for_docs",
+			"destination": "/guides/front_end/search_bar_for_docs"
 		},
 		{
-			"source": "/docs/learn/cookbooks/http2_ssl",
-			"destination": "/docs/guides/security/http2_ssl"
+			"source": "/learn/cookbooks/http2_ssl",
+			"destination": "/guides/security/http2_ssl"
 		},
 		{
-			"source": "/docs/learn/cookbooks/vercel",
-			"destination": "/docs/guides/integrations/vercel"
+			"source": "/learn/cookbooks/vercel",
+			"destination": "/guides/integrations/vercel"
 		},
 		{
-			"source": "/docs/learn/cookbooks/meilisync_mysql",
-			"destination": "/docs/guides/database/meilisync_mysql"
+			"source": "/learn/cookbooks/meilisync_mysql",
+			"destination": "/guides/database/meilisync_mysql"
 		},
 		{
-			"source": "/docs/learn/cookbooks/meilisync_postgresql",
-			"destination": "/docs/guides/database/meilisync_postgresql"
+			"source": "/learn/cookbooks/meilisync_postgresql",
+			"destination": "/guides/database/meilisync_postgresql"
 		},
 		{
-			"source": "/docs/learn/cookbooks/laravel_scout",
-			"destination": "/docs/guides/back_end/laravel_scout"
+			"source": "/learn/cookbooks/laravel_scout",
+			"destination": "/guides/back_end/laravel_scout"
 		},
 		{
-			"source": "/docs/learn/cookbooks/laravel_multitenancy",
-			"destination": "/docs/guides/security/laravel_multitenancy"
+			"source": "/learn/cookbooks/laravel_multitenancy",
+			"destination": "/guides/security/laravel_multitenancy"
 		},
 		{
-			"source": "/docs/learn/cookbooks/multitenancy_nodejs",
-			"destination": "/docs/guides/security/multitenancy_nodejs"
+			"source": "/learn/cookbooks/multitenancy_nodejs",
+			"destination": "/guides/security/multitenancy_nodejs"
 		},
 		{
-			"source": "/docs/learn/cookbooks/indexing_best_practices",
-			"destination": "/docs/guides/performance/indexing_best_practices"
+			"source": "/learn/cookbooks/indexing_best_practices",
+			"destination": "/guides/performance/indexing_best_practices"
 		},
 		{
-			"source": "/docs/learn/cookbooks/computing_hugging_face_embeddings_gpu",
-			"destination": "/docs/guides/ai/computing_hugging_face_embeddings_gpu"
+			"source": "/learn/cookbooks/computing_hugging_face_embeddings_gpu",
+			"destination": "/guides/ai/computing_hugging_face_embeddings_gpu"
 		},
 		{
-			"source": "/docs/learn/cookbooks/strapi_v4",
-			"destination": "/docs/guides/back_end/strapi_v4"
+			"source": "/learn/cookbooks/strapi_v4",
+			"destination": "/guides/back_end/strapi_v4"
 		},
 		{
-			"source": "/docs/learn/cookbooks/large_documents",
-			"destination": "/docs/guides/performance/large_documents"
+			"source": "/learn/cookbooks/large_documents",
+			"destination": "/guides/performance/large_documents"
 		},
 		{
-			"source": "/docs/learn/cookbooks/langchain",
-			"destination": "/docs/guides/ai/langchain"
+			"source": "/learn/cookbooks/langchain",
+			"destination": "/guides/ai/langchain"
 		},
 		{
-			"source": "/docs/learn/advanced/concat",
-			"destination": "/docs/learn/engine/concat"
+			"source": "/learn/advanced/concat",
+			"destination": "/learn/engine/concat"
 		},
 		{
-			"source": "/docs/learn/advanced/datatypes",
-			"destination": "/docs/learn/engine/datatypes"
+			"source": "/learn/advanced/datatypes",
+			"destination": "/learn/engine/datatypes"
 		},
 		{
-			"source": "/docs/learn/advanced/prefix",
-			"destination": "/docs/learn/engine/prefix"
+			"source": "/learn/advanced/prefix",
+			"destination": "/learn/engine/prefix"
 		},
 		{
-			"source": "/docs/learn/advanced/storage",
-			"destination": "/docs/learn/engine/storage"
+			"source": "/learn/advanced/storage",
+			"destination": "/learn/engine/storage"
 		},
 		{
-			"source": "/docs/learn/cloud/analytics",
-			"destination": "/docs/learn/analytics/configure_analytics"
+			"source": "/learn/cloud/analytics",
+			"destination": "/learn/analytics/configure_analytics"
 		},
 		{
-			"source": "/docs/learn/cloud/teams",
-			"destination": "/docs/learn/teams/teams"
+			"source": "/learn/cloud/teams",
+			"destination": "/learn/teams/teams"
 		},
 		{
-			"source": "/docs/learn/security/managing_api_keys",
-			"destination": "/docs/reference/api/keys"
+			"source": "/learn/security/managing_api_keys",
+			"destination": "/reference/api/keys"
 		},
 		{
-			"source": "/docs/learn/experimental/puffin_reports",
-			"destination": "/docs/learn/experimental/log_customization"
+			"source": "/learn/experimental/puffin_reports",
+			"destination": "/learn/experimental/log_customization"
 		},
 		{
-			"source": "/docs/learn/index_settings/distinct",
-			"destination": "/docs/learn/relevancy/distinct_attribute"
+			"source": "/learn/index_settings/distinct",
+			"destination": "/learn/relevancy/distinct_attribute"
 		},
 		{
-			"source": "/docs/learn/index_settings/displayed_searchable_attributes",
-			"destination": "/docs/learn/relevancy/displayed_searchable_attributes"
+			"source": "/learn/index_settings/displayed_searchable_attributes",
+			"destination": "/learn/relevancy/displayed_searchable_attributes"
 		},
 		{
-			"source": "/docs/learn/index_settings/synonyms",
-			"destination": "/docs/learn/relevancy/synonyms"
+			"source": "/learn/index_settings/synonyms",
+			"destination": "/learn/relevancy/synonyms"
 		},
 		{
-			"source": "/docs/learn/index_settings/typo_tolerance",
-			"destination": "/docs/learn/relevancy/typo_tolerance_settings"
+			"source": "/learn/index_settings/typo_tolerance",
+			"destination": "/learn/relevancy/typo_tolerance_settings"
 		},
 		{
-			"source": "/docs/learn/core_concepts/relevancy",
-			"destination": "/docs/learn/relevancy/relevancy"
+			"source": "/learn/core_concepts/relevancy",
+			"destination": "/learn/relevancy/relevancy"
 		},
 		{
-			"source": "/docs/learn/configuration/settings",
-			"destination": "/docs/reference/api/settings"
+			"source": "/learn/configuration/settings",
+			"destination": "/reference/api/settings"
 		},
 		{
-			"source": "/docs/learn/fine_tuning_results/faceted_search",
-			"destination": "/docs/learn/filtering_and_sorting/search_with_facet_filters"
+			"source": "/learn/fine_tuning_results/faceted_search",
+			"destination": "/learn/filtering_and_sorting/search_with_facet_filters"
 		},
 		{
-			"source": "/docs/learn/fine_tuning_results/filtering",
-			"destination": "/docs/learn/filtering_and_sorting/filter_search_results"
+			"source": "/learn/fine_tuning_results/filtering",
+			"destination": "/learn/filtering_and_sorting/filter_search_results"
 		},
 		{
-			"source": "/docs/learn/fine_tuning_results/working_with_dates",
-			"destination": "/docs/learn/filtering_and_sorting/working_with_dates"
+			"source": "/learn/fine_tuning_results/working_with_dates",
+			"destination": "/learn/filtering_and_sorting/working_with_dates"
 		},
 		{
-			"source": "/docs/learn/fine_tuning_results/geosearch",
-			"destination": "/docs/learn/filtering_and_sorting/geosearch"
+			"source": "/learn/fine_tuning_results/geosearch",
+			"destination": "/learn/filtering_and_sorting/geosearch"
 		},
 		{
-			"source": "/docs/learn/fine_tuning_results/sorting",
-			"destination": "/docs/learn/filtering_and_sorting/sort_search_results"
+			"source": "/learn/fine_tuning_results/sorting",
+			"destination": "/learn/filtering_and_sorting/sort_search_results"
 		},
 		{
-			"source": "/docs/learn/configuration/instance_options",
-			"destination": "/docs/learn/self_hosted/configure_meilisearch_at_launch"
+			"source": "/learn/configuration/instance_options",
+			"destination": "/learn/self_hosted/configure_meilisearch_at_launch"
 		},
 		{
-			"source": "/docs/learn/getting_started/installation",
-			"destination": "/docs/learn/self_hosted/install_meilisearch_locally"
+			"source": "/learn/getting_started/installation",
+			"destination": "/learn/self_hosted/install_meilisearch_locally"
 		},
 		{
-			"source": "/docs/learn/getting_started/quick_start",
-			"destination": "/docs/learn/self_hosted/getting_started_with_self_hosted_meilisearch"
+			"source": "/learn/getting_started/quick_start",
+			"destination": "/learn/self_hosted/getting_started_with_self_hosted_meilisearch"
 		},
 		{
-			"source": "/docs/learn/getting_started/supported_os",
-			"destination": "/docs/learn/self_hosted/supported_os"
+			"source": "/learn/getting_started/supported_os",
+			"destination": "/learn/self_hosted/supported_os"
 		},
 		{
-			"source": "/docs/learn/advanced/indexing",
-			"destination": "/docs/learn/indexing/indexing_best_practices"
+			"source": "/learn/advanced/indexing",
+			"destination": "/learn/indexing/indexing_best_practices"
 		},
 		{
-			"source": "/docs/guides/performance/indexing_best_practices",
-			"destination": "/docs/learn/indexing/indexing_best_practices"
+			"source": "/guides/performance/indexing_best_practices",
+			"destination": "/learn/indexing/indexing_best_practices"
 		},
 		{
-			"source": "/docs/learn/advanced/tokenization",
-			"destination": "/docs/learn/indexing/tokenization"
+			"source": "/learn/advanced/tokenization",
+			"destination": "/learn/indexing/tokenization"
 		},
 		{
-			"source": "/docs/learn/advanced/known_limitations",
-			"destination": "/docs/learn/resources/known_limitations"
+			"source": "/learn/advanced/known_limitations",
+			"destination": "/learn/resources/known_limitations"
 		},
 		{
-			"source": "/docs/faq",
-			"destination": "/docs/learn/resources/faq"
+			"source": "/faq",
+			"destination": "/learn/resources/faq"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/overview",
-			"destination": "/docs/learn/getting_started/what_is_meilisearch"
+			"source": "/learn/what_is_meilisearch/overview",
+			"destination": "/learn/getting_started/what_is_meilisearch"
 		},
 		{
-			"source": "/docs/learn/core_concepts/documents",
-			"destination": "/docs/learn/getting_started/documents"
+			"source": "/learn/core_concepts/documents",
+			"destination": "/learn/getting_started/documents"
 		},
 		{
-			"source": "/docs/learn/core_concepts/indexes",
-			"destination": "/docs/learn/getting_started/indexes"
+			"source": "/learn/core_concepts/indexes",
+			"destination": "/learn/getting_started/indexes"
 		},
 		{
-			"source": "/docs/learn/core_concepts/primary_key",
-			"destination": "/docs/learn/getting_started/primary_key"
+			"source": "/learn/core_concepts/primary_key",
+			"destination": "/learn/getting_started/primary_key"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/comparison_to_alternatives",
-			"destination": "/docs/learn/resources/comparison_to_alternatives"
+			"source": "/learn/what_is_meilisearch/comparison_to_alternatives",
+			"destination": "/learn/resources/comparison_to_alternatives"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/telemetry",
-			"destination": "/docs/learn/resources/telemetry"
+			"source": "/learn/what_is_meilisearch/telemetry",
+			"destination": "/learn/resources/telemetry"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/language",
-			"destination": "/docs/learn/resources/language"
+			"source": "/learn/what_is_meilisearch/language",
+			"destination": "/learn/resources/language"
 		},
 		{
-			"source": "/docs/learn/update_and_migration/versioning",
-			"destination": "/docs/learn/resources/versioning"
+			"source": "/learn/update_and_migration/versioning",
+			"destination": "/learn/resources/versioning"
 		},
 		{
-			"source": "/docs/learn/contributing/contributing_docs",
-			"destination": "/docs/learn/resources/contributing_docs"
+			"source": "/learn/contributing/contributing_docs",
+			"destination": "/learn/resources/contributing_docs"
 		},
 		{
-			"source": "/docs/learn/experimental/overview",
-			"destination": "/docs/learn/resources/experimental_features_overview"
+			"source": "/learn/experimental/overview",
+			"destination": "/learn/resources/experimental_features_overview"
 		},
 		{
-			"source": "/docs/learn/experimental/max_number_of_batched_tasks",
-			"destination": "/docs/learn/self_hosted/configure_meilisearch_at_launch"
+			"source": "/learn/experimental/max_number_of_batched_tasks",
+			"destination": "/learn/self_hosted/configure_meilisearch_at_launch"
 		},
 		{
-			"source": "/docs/learn/experimental/metrics",
-			"destination": "/docs/reference/api/metrics"
+			"source": "/learn/experimental/metrics",
+			"destination": "/reference/api/metrics"
 		},
 		{
-			"source": "/docs/learn/experimental/reduce-indexing-memory-usage",
-			"destination": "/docs/learn/self_hosted/configure_meilisearch_at_launch"
+			"source": "/learn/experimental/reduce-indexing-memory-usage",
+			"destination": "/learn/self_hosted/configure_meilisearch_at_launch"
 		},
 		{
-			"source": "/docs/learn/experimental/log_customization",
-			"destination": "/docs/reference/api/logs"
+			"source": "/learn/experimental/log_customization",
+			"destination": "/reference/api/logs"
 		},
 		{
-			"source": "/docs/learn/experimental/vector_search",
-			"destination": "/docs/learn/ai_powered_search/getting_started_with_ai_search"
+			"source": "/learn/experimental/vector_search",
+			"destination": "/learn/ai_powered_search/getting_started_with_ai_search"
 		},
 		{
-			"source": "/docs/learn/experimental/search_queue_size",
-			"destination": "/docs/learn/self_hosted/configure_meilisearch_at_launch"
+			"source": "/learn/experimental/search_queue_size",
+			"destination": "/learn/self_hosted/configure_meilisearch_at_launch"
 		},
 		{
-			"source": "/docs/learn/experimental/replication_parameter",
-			"destination": "/docs/learn/self_hosted/configure_meilisearch_at_launch"
+			"source": "/learn/experimental/replication_parameter",
+			"destination": "/learn/self_hosted/configure_meilisearch_at_launch"
 		},
 		{
-			"source": "/docs/guides/database/meilisync_mysql",
+			"source": "/guides/database/meilisync_mysql",
 			"destination": "https://github.com/long2ice/meilisync"
 		},
 		{
-			"source": "/docs/guides/database/meilisync_postgresql",
+			"source": "/guides/database/meilisync_postgresql",
 			"destination": "https://github.com/long2ice/meilisync"
 		},
 		{
-			"source": "/docs/learn/ai-powered-search/search_with_user_provided_embeddings",
-			"destination": "/docs/learn/ai_powered_search/search_with_user_provided_embeddings"
+			"source": "/learn/ai-powered-search/search_with_user_provided_embeddings",
+			"destination": "/learn/ai_powered_search/search_with_user_provided_embeddings"
 		},
 		{
-			"source": "/docs/learn/ai-powered-search/getting_started_with_ai_search",
-			"destination": "/docs/learn/ai_powered_search/getting_started_with_ai_search"
+			"source": "/learn/ai-powered-search/getting_started_with_ai_search",
+			"destination": "/learn/ai_powered_search/getting_started_with_ai_search"
 		},
 		{
-			"source": "/docs/learn/ai-powered-search/deactivate_ai_powered_search",
-			"destination": "/docs/learn/ai_powered_search/deactivate_ai_powered_search"
+			"source": "/learn/ai-powered-search/deactivate_ai_powered_search",
+			"destination": "/learn/ai_powered_search/deactivate_ai_powered_search"
 		},
 		{
-			"source": "/docs/learn/ai-powered-search/difference_full_text_ai_search",
-			"destination": "/docs/learn/ai_powered_search/difference_full_text_ai_search"
+			"source": "/learn/ai-powered-search/difference_full_text_ai_search",
+			"destination": "/learn/ai_powered_search/difference_full_text_ai_search"
 		},
 		{
-			"source": "/docs/reference/features/installation#download-and-launch",
+			"source": "/reference/features/installation#download-and-launch",
 			"destination": "docs/learn/self_hosted/install_meilisearch_locally"
 		},
 		{
-			"source": "/docs/reference/features/installation.html#download-and-launch",
+			"source": "/reference/features/installation.html#download-and-launch",
 			"destination": "docs/learn/self_hosted/install_meilisearch_locally"
 		},
 		{
-			"source": "/docs/learn/advanced/filtering",
+			"source": "/learn/advanced/filtering",
 			"destination": "docs/learn/filtering_and_sorting/filter_search_results"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/contact.html",
+			"source": "/learn/what_is_meilisearch/contact.html",
 			"destination": "https://www.meilisearch.com/#homepage-community"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/contact",
+			"source": "/learn/what_is_meilisearch/contact",
 			"destination": "https://www.meilisearch.com/#homepage-community"
 		},
 		{
-			"source": "/docs/learn/security/tenant_tokens",
-			"destination": "/docs/learn/security/generate_tenant_token_sdk"
+			"source": "/learn/security/tenant_tokens",
+			"destination": "/learn/security/generate_tenant_token_sdk"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/sdks.html",
-			"destination": "/docs/learn/resources/sdks"
+			"source": "/learn/what_is_meilisearch/sdks.html",
+			"destination": "/learn/resources/sdks"
 		},
 		{
-			"source": "/docs/learn/what_is_meilisearch/sdks",
-			"destination": "/docs/learn/resources/sdks"
+			"source": "/learn/what_is_meilisearch/sdks",
+			"destination": "/learn/resources/sdks"
 		},
 		{
-			"source": "/docs/learn/getting_started/a",
-			"destination": "/docs/learn/getting_started/cloud_quick_start"
+			"source": "/learn/getting_started/a",
+			"destination": "/learn/getting_started/cloud_quick_start"
 		},
 		{
-			"source": "/docs/reference/api/tasks.html#delete-task",
-			"destination": "/docs/reference/api/tasks#delete-tasks"
+			"source": "/reference/api/tasks.html#delete-task",
+			"destination": "/reference/api/tasks#delete-tasks"
 		},
 		{
-			"source": "/docs/reference/api/tasks#delete-task",
-			"destination": "/docs/reference/api/tasks#delete-tasks"
+			"source": "/reference/api/tasks#delete-task",
+			"destination": "/reference/api/tasks#delete-tasks"
 		},
 		{
-			"source": "/docs/reference",
-			"destination": "/docs/reference/api/overview"
+			"source": "/reference",
+			"destination": "/reference/api/overview"
 		},
 		{
-			"source": "/docs/guides/deployment/gcp",
-			"destination": "/guides/deployment/running_production"
+			"source": "/guides/deployment/gcp",
+			"destination": "/guides/running_production"
 		}
-  	]
+  ]
 }

--- a/docs.json
+++ b/docs.json
@@ -77,7 +77,7 @@
 					},
 					{
 						"label": "Comparisons",
-						"href": "https://www.meilisearch.com/learn/what_is_meilisearch/comparison_to_alternatives"
+						"href": "https://www.meilisearch.com/docs/learn/what_is_meilisearch/comparison_to_alternatives"
 					},
 					{
 						"label": "Trust center",

--- a/snippets/samples/code_samples_add_movies_json_1.mdx
+++ b/snippets/samples/code_samples_add_movies_json_1.mdx
@@ -27,19 +27,6 @@ $movies = json_decode($moviesJson);
 $client->index('movies')->addDocuments($movies);
 ```
 
-```java Java
-import com.meilisearch.sdk;
-import org.json.JSONArray;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-Path fileName = Path.of("movies.json");
-String moviesJson = Files.readString(fileName);
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-Index index = client.index("movies");
-index.addDocuments(moviesJson);
-```
-
 ```ruby Ruby
 require 'json'
 

--- a/snippets/samples/code_samples_add_or_replace_documents_1.mdx
+++ b/snippets/samples/code_samples_add_or_replace_documents_1.mdx
@@ -47,17 +47,6 @@ $client->index('movies')->addDocuments([
 ]);
 ```
 
-```java Java
-client.index("movies").addDocuments("[{"
-  + "\"id\": 287947,"
-  + "\"title\": \"Shazam\","
-  + "\"poster\": \"https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg\","
-  + "\"overview\": \"A boy is given the ability to become an adult superhero in times of need with a single magic word.\","
-  + "\"release_date\": \"2019-03-23\""
-  + "}]"
-);
-```
-
 ```ruby Ruby
 client.index('movies').add_documents([
   {

--- a/snippets/samples/code_samples_add_or_update_documents_1.mdx
+++ b/snippets/samples/code_samples_add_or_update_documents_1.mdx
@@ -39,15 +39,6 @@ $client->index('movies')->updateDocuments([
 ]);
 ```
 
-```java Java
-client.index("movies").updateDocuments("[{
-  + "\"id\": 287947,"
-  + "\"title\": \"Shazam ⚡️\","
-  + "\"genres\": \"comedy\""
-  + "}]"
-);
-```
-
 ```ruby Ruby
 client.index('movies').update_documents([
   {

--- a/snippets/samples/code_samples_async_guide_canceled_by_1.mdx
+++ b/snippets/samples/code_samples_async_guide_canceled_by_1.mdx
@@ -12,11 +12,6 @@ client.get_tasks({'canceledBy': ['9', '15']})
 $client->getTasks((new TasksQuery())->setCanceledBy([9, 15]));
 ```
 
-```java Java
-TasksQuery query = new TasksQuery().setCanceledBy(new int[] {9, 15});
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(canceled_by: [9, 15])
 ```

--- a/snippets/samples/code_samples_async_guide_filter_by_date_1.mdx
+++ b/snippets/samples/code_samples_async_guide_filter_by_date_1.mdx
@@ -12,14 +12,6 @@ client.get_tasks({'afterEnqueuedAt': '2020-10-11T11:49:53.000Z'})
 $client->getTasks((new TasksQuery())->setAfterEnqueuedAt(new \DateTime('2020-10-11T11:49:53.000Z'));
 ```
 
-```java Java
-SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-Date date = format.parse("2020-10-11T11:49:53.000Z");
-TasksQuery query = new TasksQuery().setBeforeEnqueuedAt(date);
-
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(after_enqueued_at: DateTime.new(2020, 10, 11, 11, 49, 53))
 ```

--- a/snippets/samples/code_samples_async_guide_filter_by_ids_1.mdx
+++ b/snippets/samples/code_samples_async_guide_filter_by_ids_1.mdx
@@ -12,11 +12,6 @@ client.get_tasks({'uids': ['5', '10', '13']})
 $client->getTasks((new TasksQuery())->setUids([5, 10, 13]));
 ```
 
-```java Java
-TasksQuery query = new TasksQuery().setUids(new int[] {5, 10, 13});
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(uids: [5, 10, 13])
 ```

--- a/snippets/samples/code_samples_async_guide_filter_by_index_uids_1.mdx
+++ b/snippets/samples/code_samples_async_guide_filter_by_index_uids_1.mdx
@@ -12,11 +12,6 @@ client.get_tasks({'indexUids': ['movies']})
 $client->getTasks((new TasksQuery())->setIndexUids(['movies']));
 ```
 
-```java Java
-TasksQuery query = new TasksQuery().setIndexUids(new String[] {"movies"});
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(index_uids: ['movies'])
 ```

--- a/snippets/samples/code_samples_async_guide_filter_by_statuses_1.mdx
+++ b/snippets/samples/code_samples_async_guide_filter_by_statuses_1.mdx
@@ -17,11 +17,6 @@ client.get_tasks({'statuses': ['failed', 'canceled']})
 $client->getTasks((new TasksQuery())->setStatuses(['failed', 'canceled']));
 ```
 
-```java Java
-TasksQuery query = new TasksQuery().setStatuses(new String[] {"failed", "canceled"});
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(statuses: ['failed', 'canceled'])
 ```

--- a/snippets/samples/code_samples_async_guide_filter_by_types_1.mdx
+++ b/snippets/samples/code_samples_async_guide_filter_by_types_1.mdx
@@ -12,11 +12,6 @@ client.get_tasks({'types': ['dumpCreation', 'indexSwap']})
 $client->getTasks((new TasksQuery())->setTypes(['dumpCreation', 'indexSwap']));
 ```
 
-```java Java
-TasksQuery query = new TasksQuery().setTypes(new String[] {"dumpCreation", "indexSwap"});
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(types: ['dumpCreation', 'indexSwap'])
 ```

--- a/snippets/samples/code_samples_async_guide_multiple_filters_1.mdx
+++ b/snippets/samples/code_samples_async_guide_multiple_filters_1.mdx
@@ -32,16 +32,6 @@ $client->getTasks(
 );
 ```
 
-```java Java
-TasksQuery query =
-        new TasksQuery()
-                .setStatuses(new String[] {"processing"})
-                .setTypes(new String[] {"documentAdditionOrUpdate", "documentDeletion"})
-                .setIndexUids(new String[] {"movies"});
-
-client.getTasks(query);
-```
-
 ```ruby Ruby
 client.get_tasks(index_uids: ['movies'], types: ['documentAdditionOrUpdate', 'documentDeletion'], statuses: ['processing'])
 ```

--- a/snippets/samples/code_samples_authorization_header_1.mdx
+++ b/snippets/samples/code_samples_authorization_header_1.mdx
@@ -22,11 +22,6 @@ $client = new Client('http://localhost:7700', 'masterKey');
 $client->getKeys();
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-client.getKeys();
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'masterKey')
 client.keys

--- a/snippets/samples/code_samples_cancel_tasks_1.mdx
+++ b/snippets/samples/code_samples_cancel_tasks_1.mdx
@@ -17,11 +17,6 @@ client.cancel_tasks({'uids': ['1', '2']})
 $client->cancelTasks((new CancelTasksQuery())->setUids([1, 2]));
 ```
 
-```java Java
-CancelTasksQuery query = new CancelTasksQuery().setUids(new int[] {1, 2})
-client.cancelTasks(query);
-```
-
 ```ruby Ruby
 client.cancel_tasks(uids: [1, 2])
 ```

--- a/snippets/samples/code_samples_create_a_key_1.mdx
+++ b/snippets/samples/code_samples_create_a_key_1.mdx
@@ -40,20 +40,6 @@ $client->createKey([
 ]);
 ```
 
-```java Java
-SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-Date dateParsed = format.parse("2042-04-02T00:42:42Z");
-
-Key keyInfo = new Key();
-
-keyInfo.setDescription("Add documents: Products API key");
-keyInfo.setActions(new String[] {"documents.add"});
-keyInfo.setIndexes(new String[] {"products"});
-keyInfo.setExpiresAt(dateParsed);
-
-client.createKey(keyInfo);
-```
-
 ```ruby Ruby
 client.create_key(
   description: 'Add documents: Products API key',

--- a/snippets/samples/code_samples_create_an_index_1.mdx
+++ b/snippets/samples/code_samples_create_an_index_1.mdx
@@ -22,10 +22,6 @@ client.create_index('movies', {'primaryKey': 'id'})
 $client->createIndex('movies', ['primaryKey' => 'id']);
 ```
 
-```java Java
-client.createIndex("movies", "id");
-```
-
 ```ruby Ruby
 client.create_index('movies', primary_key: 'id')
 ```

--- a/snippets/samples/code_samples_create_snapshot_1.mdx
+++ b/snippets/samples/code_samples_create_snapshot_1.mdx
@@ -17,10 +17,6 @@ client.create_snapshot()
 $client->createSnapshot();
 ```
 
-```java Java
-client.createSnapshot();
-```
-
 ```ruby Ruby
 client.create_snapshot
 ```

--- a/snippets/samples/code_samples_date_guide_filter_1.mdx
+++ b/snippets/samples/code_samples_date_guide_filter_1.mdx
@@ -28,11 +28,6 @@ $client->index('games')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").filter(new String[] {"release_timestamp >= 1514761200 AND release_timestamp < 1672527600"}).build();
-client.index("games").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('games').search('', {
   filter: 'release_timestamp >= 1514761200 AND release_timestamp < 1672527600'

--- a/snippets/samples/code_samples_date_guide_filterable_attributes_1.mdx
+++ b/snippets/samples/code_samples_date_guide_filterable_attributes_1.mdx
@@ -21,10 +21,6 @@ client.index('games').update_filterable_attributes(['release_timestamp'])
 $client->index('games')->updateFilterableAttributes(['release_timestamp']);
 ```
 
-```java Java
-client.index("movies").updateFilterableAttributesSettings(new String[] { "release_timestamp" });
-```
-
 ```ruby Ruby
 client.index('games').update_filterable_attributes(['release_timestamp'])
 ```

--- a/snippets/samples/code_samples_date_guide_index_1.mdx
+++ b/snippets/samples/code_samples_date_guide_index_1.mdx
@@ -27,18 +27,6 @@ $games = json_decode($gamesJson);
 $client->index('games')->addDocuments($games);
 ```
 
-```java Java
-import com.meilisearch.sdk;
-import org.json.JSONArray;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-Path fileName = Path.of("games.json");
-String gamesJson = Files.readString(fileName);
-Index index = client.index("games");
-index.addDocuments(gamesJson);
-```
-
 ```ruby Ruby
 require 'json'
 

--- a/snippets/samples/code_samples_date_guide_sort_1.mdx
+++ b/snippets/samples/code_samples_date_guide_sort_1.mdx
@@ -26,11 +26,6 @@ client.index('games').search('', {
 $client->index('games')->search('', ['sort' => ['release_timestamp:desc']]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").sort(new String[] {"release_timestamp:desc"}).build();
-client.index("games").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('games').search('', sort: ['release_timestamp:desc'])
 ```

--- a/snippets/samples/code_samples_date_guide_sortable_attributes_1.mdx
+++ b/snippets/samples/code_samples_date_guide_sortable_attributes_1.mdx
@@ -21,12 +21,6 @@ client.index('games').update_sortable_attributes(['release_timestamp'])
 $client->index('games')->updateSortableAttributes(['release_timestamp']);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setSortableAttributes(new String[] {"release_timestamp"});
-client.index("games").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('games').update_sortable_attributes(['release_timestamp'])
 ```

--- a/snippets/samples/code_samples_delete_a_key_1.mdx
+++ b/snippets/samples/code_samples_delete_a_key_1.mdx
@@ -18,10 +18,6 @@ client.delete_key('6062abda-a5aa-4414-ac91-ecd7944c0f8d')
 $client->deleteKey('6062abda-a5aa-4414-ac91-ecd7944c0f8d');
 ```
 
-```java Java
-client.deleteKey("6062abda-a5aa-4414-ac91-ecd7944c0f8d")
-```
-
 ```ruby Ruby
 client.delete_key('6062abda-a5aa-4414-ac91-ecd7944c0f8d')
 ```

--- a/snippets/samples/code_samples_delete_all_documents_1.mdx
+++ b/snippets/samples/code_samples_delete_all_documents_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').delete_all_documents()
 $client->index('movies')->deleteAllDocuments();
 ```
 
-```java Java
-client.index("movies").deleteAllDocuments();
-```
-
 ```ruby Ruby
 client.index('movies').delete_all_documents
 ```

--- a/snippets/samples/code_samples_delete_an_index_1.mdx
+++ b/snippets/samples/code_samples_delete_an_index_1.mdx
@@ -19,10 +19,6 @@ client.index('movies').delete()
 $client->deleteIndex('movies');
 ```
 
-```java Java
-client.deleteIndex("movies");
-```
-
 ```ruby Ruby
 client.delete_index('movies')
 ```

--- a/snippets/samples/code_samples_delete_documents_by_batch_1.mdx
+++ b/snippets/samples/code_samples_delete_documents_by_batch_1.mdx
@@ -24,16 +24,6 @@ client.index('movies').delete_documents([23488, 153738, 437035, 363869])
 $client->index('movies')->deleteDocuments([23488, 153738, 437035, 363869]);
 ```
 
-```java Java
-client.index("movies").deleteDocuments(Arrays.asList(new String[]
-{
-  "23488",
-  "153738",
-  "437035",
-  "363869"
-}));
-```
-
 ```ruby Ruby
 client.index('movies').delete_documents([23488, 153738, 437035, 363869])
 ```

--- a/snippets/samples/code_samples_delete_documents_by_filter_1.mdx
+++ b/snippets/samples/code_samples_delete_documents_by_filter_1.mdx
@@ -23,11 +23,6 @@ client.index('movies').delete_documents(filter='genres=action OR genres=adventur
 $client->index('movies')->deleteDocuments(['filter' => 'genres = action OR genres = adventure']);
 ```
 
-```java Java
-String filter = "genres = action OR genres = adventure";
-client.index("movies").deleteDocumentsByFilter(filter);
-```
-
 ```ruby Ruby
 client.index('movies').delete_documents(filter: 'genres = action OR genres = adventure')
 ```

--- a/snippets/samples/code_samples_delete_one_document_1.mdx
+++ b/snippets/samples/code_samples_delete_one_document_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').delete_document(25684)
 $client->index('movies')->deleteDocument(25684);
 ```
 
-```java Java
-client.index("movies").deleteDocument("25684");
-```
-
 ```ruby Ruby
 client.index('movies').delete_document(25684)
 ```

--- a/snippets/samples/code_samples_delete_tasks_1.mdx
+++ b/snippets/samples/code_samples_delete_tasks_1.mdx
@@ -17,11 +17,6 @@ client.delete_tasks({'uids': ['1', '2']})
 $client->deleteTasks((new DeleteTasksQuery())->setUids([1, 2]));
 ```
 
-```java Java
-DeleteTasksQuery query = new DeleteTasksQuery().setUids(new int[] {1, 2})
-client.deleteTasks(query);
-```
-
 ```ruby Ruby
 client.delete_tasks(uids: [1, 2])
 ```

--- a/snippets/samples/code_samples_distinct_attribute_guide_1.mdx
+++ b/snippets/samples/code_samples_distinct_attribute_guide_1.mdx
@@ -19,10 +19,6 @@ client.index('jackets').update_distinct_attribute('product_id')
 $client->index('jackets')->updateDistinctAttribute('product_id');
 ```
 
-```java Java
-client.index("jackets").updateDistinctAttributeSettings("product_id");
-```
-
 ```ruby Ruby
 client.index('jackets').update_distinct_attribute('product_id')
 ```

--- a/snippets/samples/code_samples_distinct_attribute_guide_distinct_parameter_1.mdx
+++ b/snippets/samples/code_samples_distinct_attribute_guide_distinct_parameter_1.mdx
@@ -24,11 +24,6 @@ $client->index('products')->search('white shirt', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("white shirt").distinct("sku").build();
-client.index("products").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('products').search('white shirt', {
   distinct: 'sku'

--- a/snippets/samples/code_samples_distinct_attribute_guide_filterable_1.mdx
+++ b/snippets/samples/code_samples_distinct_attribute_guide_filterable_1.mdx
@@ -23,12 +23,6 @@ client.index('products').update_filterable_attributes(['product_id', 'sku', 'url
 $client->index('products')->updateFilterableAttributes(['product_id', 'sku', 'url']);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setFilterableAttributes(new String[] {"product_id", "SKU", "url"});
-client.index("products").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('products').update_filterable_attributes([
   'product_id',

--- a/snippets/samples/code_samples_facet_search_1.mdx
+++ b/snippets/samples/code_samples_facet_search_1.mdx
@@ -34,11 +34,6 @@ $client->index('books')->facetSearch(
 );
 ```
 
-```java Java
-FacetSearchRequest fsr = FacetSearchRequest.builder().facetName("genres").facetQuery("fiction").filter(new String[]{"rating > 3"}).build();
-client.index("books").facetSearch(fsr);
-```
-
 ```ruby Ruby
 client.index('books').facet_search('genres', 'fiction', filter: 'rating > 3')
 ```

--- a/snippets/samples/code_samples_facet_search_2.mdx
+++ b/snippets/samples/code_samples_facet_search_2.mdx
@@ -27,14 +27,6 @@ client.index('books').update_faceting_settings({ 'sortFacetValuesBy': { 'genres'
 $client->index('books')->updateFaceting(['sortFacetValuesBy' => ['genres' => 'count']]);
 ```
 
-```java Java
-Faceting newFaceting = new Faceting();
-HashMap<String, FacetSortValue> facetSortValues = new HashMap<>();
-facetSortValues.put("genres", FacetSortValue.COUNT);
-newFaceting.setSortFacetValuesBy(facetSortValues);
-client.index("books").updateFacetingSettings(newFaceting);
-```
-
 ```ruby Ruby
 client.index('books').update_faceting(
   sort_facet_values_by: {

--- a/snippets/samples/code_samples_facet_search_3.mdx
+++ b/snippets/samples/code_samples_facet_search_3.mdx
@@ -29,11 +29,6 @@ $client->index('books')->facetSearch(
 );
 ```
 
-```java Java
-FacetSearchRequest fsr = FacetSearchRequest.builder().facetName("genres").facetQuery("c").build();
-client.index("books").facetSearch(fsr);
-```
-
 ```ruby Ruby
 client.index('books').facet_search('genres', 'c')
 ```

--- a/snippets/samples/code_samples_faceted_search_1.mdx
+++ b/snippets/samples/code_samples_faceted_search_1.mdx
@@ -28,16 +28,6 @@ $client->index('books')->search('classic', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("classic").facets(new String[]
-{
-  "genres",
-  "rating",
-  "language"
-}).build();
-client.index("books").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('books').search('classic', {
   facets: ['genres', 'rating', 'language']

--- a/snippets/samples/code_samples_faceted_search_update_settings_1.mdx
+++ b/snippets/samples/code_samples_faceted_search_update_settings_1.mdx
@@ -25,10 +25,6 @@ client.index('movie_ratings').update_filterable_attributes([
 $client->index('movie_ratings')->updateFilterableAttributes(['genres', 'rating', 'language']);
 ```
 
-```java Java
-client.index("movie_ratings").updateFilterableAttributesSettings(new String[] { "genres", "director", "language" });
-```
-
 ```ruby Ruby
 client.index('movie_ratings').update_filterable_attributes(['genres', 'rating', 'language'])
 ```

--- a/snippets/samples/code_samples_faceted_search_walkthrough_filter_1.mdx
+++ b/snippets/samples/code_samples_faceted_search_walkthrough_filter_1.mdx
@@ -35,14 +35,6 @@ $client->index('movies')->search('thriller', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest =
-  SearchRequest.builder().q("thriller").filterArray(new String[][] {
-    new String[] {"genres = Horror", "genres = Mystery"},
-    new String[] {"director = \"Jordan Peele\""}}).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('thriller', {
   filter: [['genres = Horror', 'genres = Mystery'], 'director = "Jordan Peele"']

--- a/snippets/samples/code_samples_field_properties_guide_displayed_1.mdx
+++ b/snippets/samples/code_samples_field_properties_guide_displayed_1.mdx
@@ -40,11 +40,6 @@ $client->index('movies')->updateDisplayedAttributes([
 ]);
 ```
 
-```java Java
-String[] attributes = {"title", "overview", "genres", "release_date"}
-client.index("movies").updateDisplayedAttributesSettings(attributes);
-```
-
 ```ruby Ruby
 client.index('movies').update_settings({
   displayed_attributes: [

--- a/snippets/samples/code_samples_field_properties_guide_searchable_1.mdx
+++ b/snippets/samples/code_samples_field_properties_guide_searchable_1.mdx
@@ -36,11 +36,6 @@ $client->index('movies')->updateSearchableAttributes([
 ]);
 ```
 
-```java Java
-String[] attributes = {"title", "overview", "genres"}
-client.index("movies").updateSearchableAttributesSettings(attributes);
-```
-
 ```ruby Ruby
 client.index('movies').update_searchable_attributes([
   'title',

--- a/snippets/samples/code_samples_filtering_guide_1.mdx
+++ b/snippets/samples/code_samples_filtering_guide_1.mdx
@@ -28,11 +28,6 @@ $client->index('movie_ratings')->search('Avengers', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("Avengers").filter(new String[] {"release_date > \"795484800\""}).build();
-client.index("movie_ratings").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movie_ratings').search('Avengers', { filter: 'release_date > 795484800' })
 ```

--- a/snippets/samples/code_samples_filtering_guide_2.mdx
+++ b/snippets/samples/code_samples_filtering_guide_2.mdx
@@ -28,11 +28,6 @@ $client->index('movie_ratings')->search('Batman', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("Batman").filter(new String[] {"release_date > 795484800 AND (director = \"Tim Burton\" OR director = \"Christopher Nolan\")"}).build();
-client.index("movie_ratings").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movie_ratings').search('Batman', {
   filter: 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'

--- a/snippets/samples/code_samples_filtering_guide_3.mdx
+++ b/snippets/samples/code_samples_filtering_guide_3.mdx
@@ -28,11 +28,6 @@ $client->index('movie_ratings')->search('Planet of the Apes', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("Planet of the Apes").filter(new String[] {"release_date > 1577884550 AND (NOT director = \"Tim Burton\")"}).build();
-client.index("movie_ratings").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movie_ratings').search('Planet of the Apes', {
   filter: "release_date > 1577884550 AND (NOT director = \"Tim Burton\")"

--- a/snippets/samples/code_samples_filtering_guide_nested_1.mdx
+++ b/snippets/samples/code_samples_filtering_guide_nested_1.mdx
@@ -28,11 +28,6 @@ $client->index('movie_ratings')->search('thriller', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("thriller").filter(new String[] {"rating.users >= 90"}).build();
-client.index("movie_ratings").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies_ratings').search('thriller', {
   filter: 'rating.users >= 90'

--- a/snippets/samples/code_samples_filtering_update_settings_1.mdx
+++ b/snippets/samples/code_samples_filtering_update_settings_1.mdx
@@ -31,14 +31,6 @@ client.index('movies').update_filterable_attributes([
 $client->index('movies')->updateFilterableAttributes(['director', 'genres']);
 ```
 
-```java Java
-client.index("movies").updateFilterableAttributesSettings(new String[]
-{
-  "genres",
-  "director"
-});
-```
-
 ```ruby Ruby
 client.index('movies').update_filterable_attributes([
   'director',

--- a/snippets/samples/code_samples_geosearch_guide_filter_settings_1.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_filter_settings_1.mdx
@@ -26,12 +26,6 @@ $client->index('restaurants')->updateFilterableAttributes([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setFilterableAttributes(new String[] {"_geo"});
-client.index("restaurants").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('restaurants').update_filterable_attributes(['_geo'])
 ```

--- a/snippets/samples/code_samples_geosearch_guide_filter_usage_1.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_filter_usage_1.mdx
@@ -25,11 +25,6 @@ $client->index('restaurants')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").filter(new String[] {"_geoRadius(45.472735, 9.184019, 2000)"}).build();
-client.index("restaurants").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('restaurants').search('', { filter: '_geoRadius(45.472735, 9.184019, 2000)' })
 ```

--- a/snippets/samples/code_samples_geosearch_guide_filter_usage_2.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_filter_usage_2.mdx
@@ -25,11 +25,6 @@ $client->index('restaurants')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").filter(new String[] {"_geoRadius(45.472735, 9.184019, 2000) AND type = pizza"}).build();
-client.index("restaurants").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('restaurants').search('', { filter: '_geoRadius(45.472735, 9.184019, 2000) AND type = pizza' })
 ```

--- a/snippets/samples/code_samples_geosearch_guide_filter_usage_3.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_filter_usage_3.mdx
@@ -25,13 +25,6 @@ $client->index('restaurants')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q()("").filter(new String[] {
-    "_geoBoundingBox([45.494181, 9.214024], [45.449484, 9.179175])"
-  }).build();
-client.index("restaurants").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('restaurants').search('', { filter: ['_geoBoundingBox([45.494181, 9.214024], [45.449484, 9.179175])'] })
 ```

--- a/snippets/samples/code_samples_geosearch_guide_sort_settings_1.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_sort_settings_1.mdx
@@ -25,10 +25,6 @@ $client->index('restaurants')->updateSortableAttributes([
 ]);
 ```
 
-```java Java
-client.index("restaurants").updateSortableAttributesSettings(new String[] {"_geo"});
-```
-
 ```ruby Ruby
 client.index('restaurants').update_sortable_attributes(['_geo'])
 ```

--- a/snippets/samples/code_samples_geosearch_guide_sort_usage_1.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_sort_usage_1.mdx
@@ -25,11 +25,6 @@ $client->index('restaurants')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").sort(new String[] {"_geoPoint(48.8561446,2.2978204):asc"}).build();
-client.index("restaurants").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('restaurants').search('', { sort: ['_geoPoint(48.8561446, 2.2978204):asc'] })
 ```

--- a/snippets/samples/code_samples_geosearch_guide_sort_usage_2.mdx
+++ b/snippets/samples/code_samples_geosearch_guide_sort_usage_2.mdx
@@ -30,14 +30,6 @@ $client->index('restaurants')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q()("").sort(new String[] {
-    "_geoPoint(48.8561446,2.2978204):asc",
-    "rating:desc",
-  }).build();
-client.index("restaurants").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('restaurants').search('', { sort: ['_geoPoint(48.8561446, 2.2978204):asc', 'rating:desc'] })
 ```

--- a/snippets/samples/code_samples_get_all_keys_1.mdx
+++ b/snippets/samples/code_samples_get_all_keys_1.mdx
@@ -18,11 +18,6 @@ client.get_keys({'limit': 3})
 $client->getKeys((new KeysQuery())->setLimit(3));
 ```
 
-```java Java
-KeysQuery query = new KeysQuery().setLimit(3);
-client.getKeys(query);
-```
-
 ```ruby Ruby
 client.keys(limit: 3)
 ```

--- a/snippets/samples/code_samples_get_all_tasks_1.mdx
+++ b/snippets/samples/code_samples_get_all_tasks_1.mdx
@@ -17,10 +17,6 @@ client.get_tasks()
 $client->getTasks();
 ```
 
-```java Java
-client.getTasks();
-```
-
 ```ruby Ruby
 client.tasks
 ```

--- a/snippets/samples/code_samples_get_all_tasks_paginating_1.mdx
+++ b/snippets/samples/code_samples_get_all_tasks_paginating_1.mdx
@@ -21,14 +21,6 @@ $taskQuery = (new TasksQuery())->setLimit(2)->setFrom(10));
 $client->getTasks($taskQuery);
 ```
 
-```java Java
-TasksQuery query = new TasksQuery()
-      .setLimit(2)
-      .setFrom(10);
-
-client.index("movies").getTasks(query);
-```
-
 ```ruby Ruby
 client.tasks(limit: 2, from: 10)
 ```

--- a/snippets/samples/code_samples_get_all_tasks_paginating_2.mdx
+++ b/snippets/samples/code_samples_get_all_tasks_paginating_2.mdx
@@ -21,14 +21,6 @@ $taskQuery = (new TasksQuery())->setLimit(2)->setFrom(8));
 $client->getTasks($taskQuery);
 ```
 
-```java Java
-TasksQuery query = new TasksQuery()
-      .setLimit(2)
-      .setFrom(8);
-
-client.index("movies").getTasks(query);
-```
-
 ```ruby Ruby
 client.tasks(limit: 2, from: 8)
 ```

--- a/snippets/samples/code_samples_get_dictionary_1.mdx
+++ b/snippets/samples/code_samples_get_dictionary_1.mdx
@@ -17,10 +17,6 @@ client.index('books').get_dictionary()
 $client->index('books')->getDictionary();
 ```
 
-```java Java
-client.index("books").getDictionarySettings();
-```
-
 ```ruby Ruby
 client.index('books').dictionary
 ```

--- a/snippets/samples/code_samples_get_displayed_attributes_1.mdx
+++ b/snippets/samples/code_samples_get_displayed_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_displayed_attributes()
 $client->index('movies')->getDisplayedAttributes();
 ```
 
-```java Java
-client.index("movies").getDisplayedAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').get_displayed_attributes
 ```

--- a/snippets/samples/code_samples_get_distinct_attribute_1.mdx
+++ b/snippets/samples/code_samples_get_distinct_attribute_1.mdx
@@ -17,10 +17,6 @@ client.index('shoes').get_distinct_attribute()
 $client->index('shoes')->getDistinctAttribute();
 ```
 
-```java Java
-client.index("shoes").getDistinctAttributeSettings();
-```
-
 ```ruby Ruby
 client.index('shoes').distinct_attribute
 ```

--- a/snippets/samples/code_samples_get_documents_1.mdx
+++ b/snippets/samples/code_samples_get_documents_1.mdx
@@ -20,11 +20,6 @@ client.index('movies').get_documents({'limit':2, 'filter': 'genres=action'})
 $client->index('movies')->getDocuments((new DocumentsQuery())->setFilter('genres = action')->setLimit(2));
 ```
 
-```java Java
-DocumentsQuery query = new DocumentsQuery().setLimit(2).setFilter(new String[] {"genres = action"});
-client.index("movies").getDocuments(query, TargetClassName.class);
-```
-
 ```ruby Ruby
 client.index('movies').get_documents(limit: 2, filter: 'genres = action')
 ```

--- a/snippets/samples/code_samples_get_documents_post_1.mdx
+++ b/snippets/samples/code_samples_get_documents_post_1.mdx
@@ -36,14 +36,6 @@ $client->index('books')->getDocuments(
 );
 ```
 
-```java Java
-DocumentsQuery query = new DocumentsQuery()
-  .setFilter(new String[] {"(rating > 3 AND (genres = Adventure OR genres = Fiction)) AND language = English"})
-  .setFields(new String[] {"title", "genres", "rating", "language"})
-  .setLimit(3);
-client.index("books").getDocuments(query, TargetClassName.class);
-```
-
 ```ruby Ruby
 client.index('books').get_documents(
   filter: '(rating > 3 AND (genres = Adventure OR genres = Fiction)) AND language = English',

--- a/snippets/samples/code_samples_get_faceting_settings_1.mdx
+++ b/snippets/samples/code_samples_get_faceting_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('books').get_faceting_settings()
 $client->index('books')->getFaceting();
 ```
 
-```java Java
-client.index("books").getFacetingSettings();
-```
-
 ```ruby Ruby
 client.index('books').faceting
 ```

--- a/snippets/samples/code_samples_get_filterable_attributes_1.mdx
+++ b/snippets/samples/code_samples_get_filterable_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_filterable_attributes()
 $client->index('movies')->getFilterableAttributes();
 ```
 
-```java Java
-client.index("movies").getFilterableAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').filterable_attributes
 ```

--- a/snippets/samples/code_samples_get_health_1.mdx
+++ b/snippets/samples/code_samples_get_health_1.mdx
@@ -17,10 +17,6 @@ client.health()
 $client->health();
 ```
 
-```java Java
-client.health();
-```
-
 ```ruby Ruby
 client.health
 ```

--- a/snippets/samples/code_samples_get_index_stats_1.mdx
+++ b/snippets/samples/code_samples_get_index_stats_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_stats()
 $client->index('movies')->stats();
 ```
 
-```java Java
-client.index("movies").getStats();
-```
-
 ```ruby Ruby
 client.index('movies').stats
 ```

--- a/snippets/samples/code_samples_get_indexes_stats_1.mdx
+++ b/snippets/samples/code_samples_get_indexes_stats_1.mdx
@@ -17,10 +17,6 @@ client.get_all_stats()
 $client->stats();
 ```
 
-```java Java
-client.getStats();
-```
-
 ```ruby Ruby
 client.stats
 ```

--- a/snippets/samples/code_samples_get_localized_attribute_settings_1.mdx
+++ b/snippets/samples/code_samples_get_localized_attribute_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('INDEX_NAME').get_localized_attributes()
 $client->index('INDEX_NAME')->getLocalizedAttributes();
 ```
 
-```java Java
-client.index("INDEX_NAME").getLocalizedAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').localized_attributes
 ```

--- a/snippets/samples/code_samples_get_non_separator_tokens_1.mdx
+++ b/snippets/samples/code_samples_get_non_separator_tokens_1.mdx
@@ -17,10 +17,6 @@ client.index('articles').get_non_separator_tokens()
 $client->index('articles')->getNonSeparatorTokens();
 ```
 
-```java Java
-client.index("articles").getNonSeparatorTokensSettings();
-```
-
 ```ruby Ruby
 client.index('articles').non_separator_tokens
 ```

--- a/snippets/samples/code_samples_get_one_document_1.mdx
+++ b/snippets/samples/code_samples_get_one_document_1.mdx
@@ -21,11 +21,6 @@ client.index('movies').get_document(25684, {
 $client->index('movies')->getDocument(25684, ['id', 'title', 'poster', 'release_date']);
 ```
 
-```java Java
-DocumentQuery query = new DocumentQuery().setFields(new String[] {"id", "title", "poster", "release_date"});
-client.index("movies").getDocument("25684", query);
-```
-
 ```ruby Ruby
 client.index('movies').document(25684, fields: ['id', 'title', 'poster', 'release_date'])
 ```

--- a/snippets/samples/code_samples_get_one_index_1.mdx
+++ b/snippets/samples/code_samples_get_one_index_1.mdx
@@ -17,10 +17,6 @@ client.get_index('movies')
 $client->index('movies')->fetchRawInfo();
 ```
 
-```java Java
-client.getIndex("movies");
-```
-
 ```ruby Ruby
 client.fetch_index('movies')
 ```

--- a/snippets/samples/code_samples_get_one_key_1.mdx
+++ b/snippets/samples/code_samples_get_one_key_1.mdx
@@ -18,10 +18,6 @@ client.get_key('6062abda-a5aa-4414-ac91-ecd7944c0f8d')
 $client->getKey('6062abda-a5aa-4414-ac91-ecd7944c0f8d');
 ```
 
-```java Java
-client.getKey("6062abda-a5aa-4414-ac91-ecd7944c0f8d");
-```
-
 ```ruby Ruby
 client.key('6062abda-a5aa-4414-ac91-ecd7944c0f8d')
 ```

--- a/snippets/samples/code_samples_get_pagination_settings_1.mdx
+++ b/snippets/samples/code_samples_get_pagination_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('books').get_pagination_settings()
 $client->index('books')->getPagination();
 ```
 
-```java Java
-client.index("books").getPaginationSettings();
-```
-
 ```ruby Ruby
 index('books').pagination
 ```

--- a/snippets/samples/code_samples_get_proximity_precision_settings_1.mdx
+++ b/snippets/samples/code_samples_get_proximity_precision_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('books').get_proximity_precision()
 $client->index('books')->getProximityPrecision();
 ```
 
-```java Java
-client.index("books").getProximityPrecisionSettings();
-```
-
 ```ruby Ruby
 client.index('books').proximity_precision
 ```

--- a/snippets/samples/code_samples_get_ranking_rules_1.mdx
+++ b/snippets/samples/code_samples_get_ranking_rules_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_ranking_rules()
 $client->index('movies')->getRankingRules();
 ```
 
-```java Java
-client.index("movies").getRankingRulesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').ranking_rules
 ```

--- a/snippets/samples/code_samples_get_search_cutoff_1.mdx
+++ b/snippets/samples/code_samples_get_search_cutoff_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_search_cutoff_ms()
 $client->index('movies')->getSearchCutoffMs();
 ```
 
-```java Java
-client.index("movies").getSearchCutoffMsSettings();
-```
-
 ```ruby Ruby
 client.index('movies').search_cutoff_ms
 ```

--- a/snippets/samples/code_samples_get_searchable_attributes_1.mdx
+++ b/snippets/samples/code_samples_get_searchable_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_searchable_attributes()
 $client->index('movies')->getSearchableAttributes();
 ```
 
-```java Java
-client.index("movies").getSearchableAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').searchable_attributes
 ```

--- a/snippets/samples/code_samples_get_separator_tokens_1.mdx
+++ b/snippets/samples/code_samples_get_separator_tokens_1.mdx
@@ -17,10 +17,6 @@ client.index('articles').get_separator_tokens()
 $client->index('articles')->getSeparatorTokens();
 ```
 
-```java Java
-client.index("articles").getSeparatorTokensSettings();
-```
-
 ```ruby Ruby
 client.index('articles').separator_tokens
 ```

--- a/snippets/samples/code_samples_get_settings_1.mdx
+++ b/snippets/samples/code_samples_get_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_settings()
 $client->index('movies')->getSettings();
 ```
 
-```java Java
-client.index("movies").getSettings();
-```
-
 ```ruby Ruby
 client.index('movies').settings
 ```

--- a/snippets/samples/code_samples_get_similar_post_1.mdx
+++ b/snippets/samples/code_samples_get_similar_post_1.mdx
@@ -24,10 +24,6 @@ $similarQuery = new SimilarDocumentsQuery('TARGET_DOCUMENT_ID', 'default');
 $client->index('INDEX_NAME')->searchSimilarDocuments($similarQuery);
 ```
 
-```java Java
-SimilarDocumentRequest query = new SimilarDocumentRequest() .setId("143") .setEmbedder("manual"); client.index("movies").searchSimilarDocuments(query)
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').search_similar_documents('TARGET_DOCUMENT_ID', embedder: 'default')
 ```

--- a/snippets/samples/code_samples_get_sortable_attributes_1.mdx
+++ b/snippets/samples/code_samples_get_sortable_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('books').get_sortable_attributes()
 $client->index('books')->getSortableAttributes();
 ```
 
-```java Java
-client.index("books").getSortableAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('books').sortable_attributes
 ```

--- a/snippets/samples/code_samples_get_stop_words_1.mdx
+++ b/snippets/samples/code_samples_get_stop_words_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_stop_words()
 $client->index('movies')->getStopWords();
 ```
 
-```java Java
-client.index("movies").getStopWordsSettings();
-```
-
 ```ruby Ruby
 client.index('movies').stop_words
 ```

--- a/snippets/samples/code_samples_get_synonyms_1.mdx
+++ b/snippets/samples/code_samples_get_synonyms_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').get_synonyms()
 $client->index('movies')->getSynonyms();
 ```
 
-```java Java
-client.index("movies").getSynonymsSettings();
-```
-
 ```ruby Ruby
 client.index('movies').synonyms
 ```

--- a/snippets/samples/code_samples_get_task_1.mdx
+++ b/snippets/samples/code_samples_get_task_1.mdx
@@ -17,10 +17,6 @@ client.get_task(1)
 $client->getTask(1);
 ```
 
-```java Java
-client.getTask(1);
-```
-
 ```ruby Ruby
 client.task(1)
 ```

--- a/snippets/samples/code_samples_get_typo_tolerance_1.mdx
+++ b/snippets/samples/code_samples_get_typo_tolerance_1.mdx
@@ -17,10 +17,6 @@ client.index('books').get_typo_tolerance()
 $client->index('books')->getTypoTolerance();
 ```
 
-```java Java
-client.index("books").getTypoToleranceSettings();
-```
-
 ```ruby Ruby
 index('books').typo_tolerance
 ```

--- a/snippets/samples/code_samples_get_version_1.mdx
+++ b/snippets/samples/code_samples_get_version_1.mdx
@@ -17,10 +17,6 @@ client.get_version()
 $client->version();
 ```
 
-```java Java
-client.getVersion();
-```
-
 ```ruby Ruby
 client.version
 ```

--- a/snippets/samples/code_samples_getting_started_add_documents.mdx
+++ b/snippets/samples/code_samples_getting_started_add_documents.mdx
@@ -71,34 +71,6 @@ $movies = json_decode($movies_json);
 $client->index('movies')->addDocuments($movies);
 ```
 
-```java Java
-// For Maven:
-// Add the following code to the `<dependencies>` section of your project:
-//
-// <dependency>
-//   <groupId>com.meilisearch.sdk</groupId>
-//   <artifactId>meilisearch-java</artifactId>
-//   <version>0.14.3</version>
-//   <type>pom</type>
-// </dependency>
-
-// For Gradle
-// Add the following line to the `dependencies` section of your `build.gradle`:
-//
-// implementation 'com.meilisearch.sdk:meilisearch-java:0.14.3'
-
-// In your .java file:
-import com.meilisearch.sdk;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-Path fileName = Path.of("movies.json");
-String moviesJson = Files.readString(fileName);
-Client client = new Client(new Config("http://localhost:7700", "aSampleMasterKey"));
-Index index = client.index("movies");
-index.addDocuments(moviesJson);
-```
-
 ```ruby Ruby
 # In the command line:
 # bundle add meilisearch

--- a/snippets/samples/code_samples_getting_started_add_meteorites.mdx
+++ b/snippets/samples/code_samples_getting_started_add_meteorites.mdx
@@ -30,19 +30,6 @@ $meteorites = json_decode($meteorites_json);
 $client->index('meteorites')->addDocuments($meteorites);
 ```
 
-```java Java
-import com.meilisearch.sdk;
-import org.json.JSONArray;
-import java.nio.file.Files;
-import java.nio.file.Path;
-
-Path fileName = Path.of("meteorites.json");
-String meteoritesJson = Files.readString(fileName);
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-
-client.index("meteorites").addDocuments(meteoritesJson);
-```
-
 ```ruby Ruby
 file = File.read('meteorites.json')
 json = JSON.parse(file)

--- a/snippets/samples/code_samples_getting_started_check_task_status.mdx
+++ b/snippets/samples/code_samples_getting_started_check_task_status.mdx
@@ -18,10 +18,6 @@ client.get_task(0)
 $client->getTask(0);
 ```
 
-```java Java
-client.getTask(0);
-```
-
 ```ruby Ruby
 client.task(0)
 ```

--- a/snippets/samples/code_samples_getting_started_configure_settings.mdx
+++ b/snippets/samples/code_samples_getting_started_configure_settings.mdx
@@ -49,13 +49,6 @@ $client->index('meteorites')->updateSettings([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setFilterableAttributes(new String[] {"mass", "_geo"});
-settings.setSortableAttributes(new String[] {"mass", "_geo"});
-client.index("meteorites").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('meteorites').update_settings({
   filterable_attributes: ['mass', '_geo'],

--- a/snippets/samples/code_samples_getting_started_faceting.mdx
+++ b/snippets/samples/code_samples_getting_started_faceting.mdx
@@ -38,15 +38,6 @@ $client->index('movies')
   ]);
 ```
 
-```java Java
-Faceting newFaceting = new Faceting();
-newFaceting.setMaxValuesPerFacet(2);
-HashMap<String, FacetSortValue> facetSortValues = new HashMap<>();
-facetSortValues.put("*", FacetSortValue.COUNT);
-newFaceting.setSortFacetValuesBy(facetSortValues);
-client.index("movies").updateFacetingSettings(newFaceting);
-```
-
 ```ruby Ruby
 client.index('movies').update_faceting({
   max_values_per_facet: 2,

--- a/snippets/samples/code_samples_getting_started_filtering.mdx
+++ b/snippets/samples/code_samples_getting_started_filtering.mdx
@@ -23,11 +23,6 @@ $client->index('meteorites')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").filter(new String[] {"mass < 200"}).build();
-client.index("meteorites").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('meteorites').search('', { filter: 'mass < 200' })
 ```

--- a/snippets/samples/code_samples_getting_started_geo_point.mdx
+++ b/snippets/samples/code_samples_getting_started_geo_point.mdx
@@ -23,11 +23,6 @@ $client->index('meteorites')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").sort(new String[] {"_geoPoint(48.8583701,2.2922926):asc"}).build();
-client.index("meteorites").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('meteorites').search('', { sort: ['_geoPoint(48.8583701, 2.2922926):asc'] })
 ```

--- a/snippets/samples/code_samples_getting_started_geo_radius.mdx
+++ b/snippets/samples/code_samples_getting_started_geo_radius.mdx
@@ -23,11 +23,6 @@ $client->index('meteorites')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").filter(new String[] {"_geoRadius(46.9480, 7.4474, 210000)"}).build();
-client.index("meteorites").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('meteorites').search('', { filter: '_geoRadius(46.9480, 7.4474, 210000)' })
 ```

--- a/snippets/samples/code_samples_getting_started_pagination.mdx
+++ b/snippets/samples/code_samples_getting_started_pagination.mdx
@@ -21,12 +21,6 @@ client.index('movies').update_pagination_settings({'maxTotalHits': 500})
 $client->index('movies')->updatePagination(['maxTotalHits' => 500]);
 ```
 
-```java Java
-Pagination newPagination = new Pagination();
-newPagination.setMaxTotalHits(500);
-client.index("movies").updatePaginationSettings(newPagination);
-```
-
 ```ruby Ruby
 client.index('movies').update_pagination(max_total_hits: 500)
 ```

--- a/snippets/samples/code_samples_getting_started_search.mdx
+++ b/snippets/samples/code_samples_getting_started_search.mdx
@@ -20,10 +20,6 @@ client.index('movies').search('botman')
 $client->index('movies')->search('botman');
 ```
 
-```java Java
-client.index("movies").search("botman");
-```
-
 ```ruby Ruby
 client.index('movies').search('botman')
 ```

--- a/snippets/samples/code_samples_getting_started_sorting.mdx
+++ b/snippets/samples/code_samples_getting_started_sorting.mdx
@@ -31,11 +31,6 @@ $client->index('meteorites')->search('', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").filter(new String[] {"mass < 200"}).sort(new String[] {"mass:asc"}).build();
-client.index("meteorites").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('meteorites').search('', {
   sort: ['mass:asc'],

--- a/snippets/samples/code_samples_getting_started_synonyms.mdx
+++ b/snippets/samples/code_samples_getting_started_synonyms.mdx
@@ -31,15 +31,6 @@ $client->index('movies')->updateSynonyms([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-HashMap<String, String[]> synonyms = new HashMap<String, String[]>();
-synonyms.put("winnie", new String[] {"piglet"});
-synonyms.put("piglet", new String[] {"winnie"});
-settings.setSynonyms(synonyms);
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_synonyms({
   winnie: ['piglet'],

--- a/snippets/samples/code_samples_getting_started_typo_tolerance.mdx
+++ b/snippets/samples/code_samples_getting_started_typo_tolerance.mdx
@@ -33,20 +33,6 @@ $client->index('books')->updateTypoTolerance([
 ]);
 ```
 
-```java Java
-HashMap<String, Integer> minWordSizeTypos =
-new HashMap<String, Integer>() {
-  {
-    put("oneTypo", 4);
-  }
-};
-
-TypoTolerance typoTolerance = new TypoTolerance();
-typoTolerance.setMinWordSizeForTypos(minWordSizeTypos);
-
-client.index("movies").updateTypoToleranceSettings(typoTolerance);
-```
-
 ```ruby Ruby
 client.index('movies').update_typo_tolerance({ min_word_size_for_typos: { one_typo: 4 } })
 ```

--- a/snippets/samples/code_samples_getting_started_update_displayed_attributes.mdx
+++ b/snippets/samples/code_samples_getting_started_update_displayed_attributes.mdx
@@ -35,17 +35,6 @@ $client->index('movies')->updateDisplayedAttributes([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setDisplayedAttributes(new String[]
-{
-      "title",
-      "overview",
-      "poster"
-});
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_displayed_attributes([
   'title',

--- a/snippets/samples/code_samples_getting_started_update_ranking_rules.mdx
+++ b/snippets/samples/code_samples_getting_started_update_ranking_rules.mdx
@@ -55,22 +55,6 @@ $client->index('movies')->updateRankingRules([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setRankingRules(new String[]
-{
-  "exactness",
-  "words",
-  "typo",
-  "proximity",
-  "attribute",
-  "sort",
-  "release_date:asc",
-  "rank:desc"
-});
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_ranking_rules([
   'exactness',

--- a/snippets/samples/code_samples_getting_started_update_searchable_attributes.mdx
+++ b/snippets/samples/code_samples_getting_started_update_searchable_attributes.mdx
@@ -23,14 +23,6 @@ client.index('movies').update_searchable_attributes([
 $client->index('movies')->updateSearchableAttributes(['title']);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setSearchableAttributes(new String[]
-{
-  "title"
-});
-```
-
 ```ruby Ruby
 client.index('movies').update_searchable_attributes([
   'title'

--- a/snippets/samples/code_samples_getting_started_update_stop_words.mdx
+++ b/snippets/samples/code_samples_getting_started_update_stop_words.mdx
@@ -19,15 +19,6 @@ client.index('movies').update_stop_words(['the'])
 $client->index('movies')->updateStopWords(['the']);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setStopWords(new String[]
-{
-  "the"
-});
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_stop_words(['the'])
 ```

--- a/snippets/samples/code_samples_landing_getting_started_1.mdx
+++ b/snippets/samples/code_samples_landing_getting_started_1.mdx
@@ -43,20 +43,6 @@ $client->index('movies')->addDocuments([
 ]);
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-
-client.index("movies").addDocuments("["
-  + "{\"id\": 1, \"title\": \"Carol\"},"
-  + "{\"id\": 2, \"title\": \"Wonder Woman\"},"
-  + "{\"id\": 3, \"title\": \"Life of Pi\"},"
-  + "{\"id\": 4, \"title\": \"Mad Max: Fury Road\"},"
-  + "{\"id\": 5, \"title\": \"Moana\"},"
-  + "{\"id\": 6, \"title\": \"Philadelphia\"}"
-  + "]"
-);
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'masterKey')
 

--- a/snippets/samples/code_samples_list_all_indexes_1.mdx
+++ b/snippets/samples/code_samples_list_all_indexes_1.mdx
@@ -17,11 +17,6 @@ client.get_indexes({'limit': 3})
 $client->getIndexes((new IndexesQuery())->setLimit(3));
 ```
 
-```java Java
-IndexesQuery query = new IndexesQuery().setLimit(3);
-client.getIndexes(query);
-```
-
 ```ruby Ruby
 client.indexes(limit: 3)
 ```

--- a/snippets/samples/code_samples_multi_search_1.mdx
+++ b/snippets/samples/code_samples_multi_search_1.mdx
@@ -69,15 +69,6 @@ $client->multiSearch([
   ]);
 ```
 
-```java Java
-MultiSearchRequest multiSearchRequest = new MultiSearchRequest();
-multiIndexSearch.addQuery(new IndexSearchRequest("movies").setQuery("pooh").setLimit(5));
-multiIndexSearch.addQuery(new IndexSearchRequest("movies").setQuery("nemo").setLimit(5));
-multiIndexSearch.addQuery(new IndexSearchRequest("movie_ratings").setQuery("us"));
-
-client.multiSearch(multiSearchRequest);
-```
-
 ```ruby Ruby
 client.multi_search([
   { index_uid: 'books', q: 'prince' },

--- a/snippets/samples/code_samples_phrase_search_1.mdx
+++ b/snippets/samples/code_samples_phrase_search_1.mdx
@@ -20,10 +20,6 @@ client.index('movies').search('"african american" horror')
 $client->index('movies')->search('"african american" horror');
 ```
 
-```java Java
-client.index("movies").search("\"african american\" horror");
-```
-
 ```ruby Ruby
 client.index('movies').search('"african american" horror')
 ```

--- a/snippets/samples/code_samples_post_dump_1.mdx
+++ b/snippets/samples/code_samples_post_dump_1.mdx
@@ -17,10 +17,6 @@ client.create_dump()
 $client->createDump();
 ```
 
-```java Java
-client.createDump();
-```
-
 ```ruby Ruby
 client.create_dump
 ```

--- a/snippets/samples/code_samples_primary_field_guide_add_document_primary_key.mdx
+++ b/snippets/samples/code_samples_primary_field_guide_add_document_primary_key.mdx
@@ -52,17 +52,6 @@ $client->index('books')->addDocuments([
 ], 'reference_number');
 ```
 
-```java Java
-client.index("books").addDocuments("[{"
-  + "\"reference_number\": 2879,"
-  + "\"title\": \"Diary of a Wimpy Kid\","
-  + "\"author\": \"Jeff Kinney\","
-  + "\"genres\": [\"comedy\", \"humor\"],"
-  + "\"price\": 5.00"
-  + "}]"
-, "reference_number");
-```
-
 ```ruby Ruby
 client.index('books').add_documents([
   {

--- a/snippets/samples/code_samples_primary_field_guide_create_index_primary_key.mdx
+++ b/snippets/samples/code_samples_primary_field_guide_create_index_primary_key.mdx
@@ -22,10 +22,6 @@ client.create_index('books', {'primaryKey': 'reference_number'})
 $client->createIndex('books', ['primaryKey' => 'reference_number']);
 ```
 
-```java Java
-client.createIndex("books", "reference_number");
-```
-
 ```ruby Ruby
 client.create_index('books', primary_key: 'reference_number')
 ```

--- a/snippets/samples/code_samples_primary_field_guide_update_document_primary_key.mdx
+++ b/snippets/samples/code_samples_primary_field_guide_update_document_primary_key.mdx
@@ -21,10 +21,6 @@ client.index('books').update(primary_key='title')
 $client->updateIndex('books', ['primaryKey' => 'title']);
 ```
 
-```java Java
-client.updateIndex("books", "title");
-```
-
 ```ruby Ruby
 client.index('books').update(primary_key: 'title')
 ```

--- a/snippets/samples/code_samples_reset_dictionary_1.mdx
+++ b/snippets/samples/code_samples_reset_dictionary_1.mdx
@@ -17,10 +17,6 @@ client.index('books').reset_dictionary()
 $client->index('books')->resetDictionary();
 ```
 
-```java Java
-client.index("books").resetDictionarySettings();
-```
-
 ```ruby Ruby
 client.index('books').reset_dictionary
 ```

--- a/snippets/samples/code_samples_reset_displayed_attributes_1.mdx
+++ b/snippets/samples/code_samples_reset_displayed_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_displayed_attributes()
 $client->index('movies')->resetDisplayedAttributes();
 ```
 
-```java Java
-client.index("movies").resetDisplayedAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_displayed_attributes
 ```

--- a/snippets/samples/code_samples_reset_distinct_attribute_1.mdx
+++ b/snippets/samples/code_samples_reset_distinct_attribute_1.mdx
@@ -17,10 +17,6 @@ client.index('shoes').reset_distinct_attribute()
 $client->index('shoes')->resetDistinctAttribute();
 ```
 
-```java Java
-client.index("shoes").resetDistinctAttributeSettings();
-```
-
 ```ruby Ruby
 client.index('shoes').reset_distinct_attribute
 ```

--- a/snippets/samples/code_samples_reset_faceting_settings_1.mdx
+++ b/snippets/samples/code_samples_reset_faceting_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('books').reset_faceting_settings()
 $client->index('books')->resetFaceting();
 ```
 
-```java Java
-client.index("books").resetFacetingSettings();
-```
-
 ```ruby Ruby
 index('books').reset_faceting
 ```

--- a/snippets/samples/code_samples_reset_filterable_attributes_1.mdx
+++ b/snippets/samples/code_samples_reset_filterable_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_filterable_attributes()
 $client->index('movies')->resetFilterableAttributes();
 ```
 
-```java Java
-client.index("movies").resetFilterableAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_filterable_attributes
 ```

--- a/snippets/samples/code_samples_reset_localized_attribute_settings_1.mdx
+++ b/snippets/samples/code_samples_reset_localized_attribute_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('INDEX_NAME').reset_localized_attributes()
 $client->index('INDEX_NAME')->resetLocalizedAttributes();
 ```
 
-```java Java
-client.index("INDEX_NAME").resetLocalizedAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').reset_localized_attributes
 ```

--- a/snippets/samples/code_samples_reset_non_separator_tokens_1.mdx
+++ b/snippets/samples/code_samples_reset_non_separator_tokens_1.mdx
@@ -17,10 +17,6 @@ client.index('articles').reset_non_separator_tokens()
 $client->index('articles')->resetNonSeparatorTokens();
 ```
 
-```java Java
-client.index("articles").resetNonSeparatorTokensSettings();
-```
-
 ```ruby Ruby
 client.index('articles').reset_non_separator_tokens
 ```

--- a/snippets/samples/code_samples_reset_pagination_settings_1.mdx
+++ b/snippets/samples/code_samples_reset_pagination_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('books').reset_pagination_settings()
 $client->index('books')->resetPagination();
 ```
 
-```java Java
-client.index("books").resetPaginationSettings();
-```
-
 ```ruby Ruby
 index('books').reset_pagination
 ```

--- a/snippets/samples/code_samples_reset_proximity_precision_settings_1.mdx
+++ b/snippets/samples/code_samples_reset_proximity_precision_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('books').reset_proximity_precision()
 $client->index('books')->resetProximityPrecision();
 ```
 
-```java Java
-client.index("books").resetProximityPrecisionSettings();
-```
-
 ```ruby Ruby
 client.index('books').reset_proximity_precision
 ```

--- a/snippets/samples/code_samples_reset_ranking_rules_1.mdx
+++ b/snippets/samples/code_samples_reset_ranking_rules_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_ranking_rules()
 $client->index('movies')->resetRankingRules();
 ```
 
-```java Java
-client.index("movies").resetRankingRulesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_ranking_rules
 ```

--- a/snippets/samples/code_samples_reset_search_cutoff_1.mdx
+++ b/snippets/samples/code_samples_reset_search_cutoff_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_search_cutoff_ms()
 $client->index('movies')->resetSearchCutoffMs();
 ```
 
-```java Java
-client.index("movies").resetSearchCutoffMsSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_search_cutoff_ms
 ```

--- a/snippets/samples/code_samples_reset_searchable_attributes_1.mdx
+++ b/snippets/samples/code_samples_reset_searchable_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_searchable_attributes()
 $client->index('movies')->resetSearchableAttributes();
 ```
 
-```java Java
-client.index("movies").resetSearchableAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_searchable_attributes
 ```

--- a/snippets/samples/code_samples_reset_separator_tokens_1.mdx
+++ b/snippets/samples/code_samples_reset_separator_tokens_1.mdx
@@ -17,10 +17,6 @@ client.index('articles').reset_separator_tokens()
 $client->index('articles')->resetSeparatorTokens();
 ```
 
-```java Java
-client.index("articles").resetSeparatorTokensSettings();
-```
-
 ```ruby Ruby
 client.index('articles').reset_separator_tokens
 ```

--- a/snippets/samples/code_samples_reset_settings_1.mdx
+++ b/snippets/samples/code_samples_reset_settings_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_settings()
 $client->index('movies')->resetSettings();
 ```
 
-```java Java
-client.index("movies").resetSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_settings
 ```

--- a/snippets/samples/code_samples_reset_sortable_attributes_1.mdx
+++ b/snippets/samples/code_samples_reset_sortable_attributes_1.mdx
@@ -17,10 +17,6 @@ client.index('books').reset_sortable_attributes()
 $client->index('books')->resetSortableAttributes();
 ```
 
-```java Java
-client.index("books").resetSortableAttributesSettings();
-```
-
 ```ruby Ruby
 client.index('books').reset_sortable_attributes
 ```

--- a/snippets/samples/code_samples_reset_stop_words_1.mdx
+++ b/snippets/samples/code_samples_reset_stop_words_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_stop_words()
 $client->index('movies')->resetStopWords();
 ```
 
-```java Java
-client.index("movies").resetStopWordsSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_stop_words
 ```

--- a/snippets/samples/code_samples_reset_synonyms_1.mdx
+++ b/snippets/samples/code_samples_reset_synonyms_1.mdx
@@ -17,10 +17,6 @@ client.index('movies').reset_synonyms()
 $client->index('movies')->resetSynonyms();
 ```
 
-```java Java
-client.index("movies").resetSynonymsSettings();
-```
-
 ```ruby Ruby
 client.index('movies').reset_synonyms
 ```

--- a/snippets/samples/code_samples_reset_typo_tolerance_1.mdx
+++ b/snippets/samples/code_samples_reset_typo_tolerance_1.mdx
@@ -17,10 +17,6 @@ client.index('books').reset_typo_tolerance()
 $client->index('books')->resetTypoTolerance();
 ```
 
-```java Java
-client.index("books").resetTypoToleranceSettings();
-```
-
 ```ruby Ruby
 index('books').reset_typo_tolerance
 ```

--- a/snippets/samples/code_samples_search_parameter_guide_attributes_to_search_on_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_attributes_to_search_on_1.mdx
@@ -28,11 +28,6 @@ $client->index('movies')->search('adventure', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("adventure").attributesToSearchOn(new String[] {"overview"});
-client.index("movies").searchRequest(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('adventure', {
   attributes_to_search_on: ['overview']

--- a/snippets/samples/code_samples_search_parameter_guide_crop_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_crop_1.mdx
@@ -32,16 +32,6 @@ $client->index('movies')->search('shifu', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest =
-        SearchRequest.builder()
-                .q("shifu")
-                .attributesToCrop(new String[] {"overview"})
-                .cropLength(5)
-                .build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('shifu', {
   attributes_to_crop: ['overview'],

--- a/snippets/samples/code_samples_search_parameter_guide_crop_marker_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_crop_marker_1.mdx
@@ -32,16 +32,6 @@ $client->index('movies')->search('shifu', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest =
-        SearchRequest.builder()
-                .q("shifu")
-                .attributesToCrop(new String[] {"overview"})
-                .cropMarker("[…]")
-                .build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('shifu', {
   attributes_to_crop: ['overview'],

--- a/snippets/samples/code_samples_search_parameter_guide_facet_stats_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_facet_stats_1.mdx
@@ -26,15 +26,6 @@ $client->index('movie_ratings')->search('Batman', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("Batman").facets(new String[]
-{
-  "genres",
-  "rating"
-}).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movie_ratings').search('Batman', {
   facets: ['genres', 'rating']

--- a/snippets/samples/code_samples_search_parameter_guide_highlight_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_highlight_1.mdx
@@ -28,12 +28,6 @@ $client->index('movies')->search('winter feast', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest =
-  new SearchRequest("winter feast").setAttributesToHighlight(new String[] {"overview"});
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('winter feast', {
   attributes_to_highlight: ['overview']

--- a/snippets/samples/code_samples_search_parameter_guide_highlight_tag_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_highlight_tag_1.mdx
@@ -36,17 +36,6 @@ $client->index('movies')->search('winter feast', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest =
-        SearchRequest.builder()
-                .q("winter feast")
-                .attributesToHighlight(new String[] {"overview"})
-                .highlightPreTag("<span class=\"highlight\">")
-                .highlightPostTag("</span>")
-                .build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('winter feast', {
   attributes_to_highlight: ['overview'],

--- a/snippets/samples/code_samples_search_parameter_guide_hitsperpage_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_hitsperpage_1.mdx
@@ -24,11 +24,6 @@ client.index('movies').search('', {'hitsPerPage': 15})
 $client->index('movies')->search('', ['hitsPerPage' => 15]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").hitsPerPage(15).build();
-SearchResultPaginated searchResult = client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('', hits_per_page: 15)
 ```

--- a/snippets/samples/code_samples_search_parameter_guide_limit_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_limit_1.mdx
@@ -26,11 +26,6 @@ client.index('movies').search('shifu', {
 $client->index('movies')->search('shifu', ['limit' => 2]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("shifu").limit(2).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('shifu', {
   limit: 2

--- a/snippets/samples/code_samples_search_parameter_guide_matching_strategy_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_matching_strategy_1.mdx
@@ -26,11 +26,6 @@ client.index('movies').search('big fat liar', {
 $client->index('movies')->search('big fat liar', ['matchingStrategy' => 'last']);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("big fat liar").matchingStrategy(MatchingStrategy.LAST).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('big fat liar', {
   matching_strategy: 'last'

--- a/snippets/samples/code_samples_search_parameter_guide_matching_strategy_2.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_matching_strategy_2.mdx
@@ -26,11 +26,6 @@ client.index('movies').search('big fat liar', {
 $client->index('movies')->search('big fat liar', ['matchingStrategy' => 'all']);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("big fat liar").matchingStrategy(MatchingStrategy.ALL).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('big fat liar', {
   matching_strategy: 'all'

--- a/snippets/samples/code_samples_search_parameter_guide_matching_strategy_3.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_matching_strategy_3.mdx
@@ -26,11 +26,6 @@ client.index('movies').search('big fat liar', {
 $client->index('movies')->search('white shirt', ['matchingStrategy' => 'frequency']);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("white shirt").matchingStrategy(MatchingStrategy.FREQUENCY).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('white shirt', {
   matching_strategy: 'frequency'

--- a/snippets/samples/code_samples_search_parameter_guide_offset_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_offset_1.mdx
@@ -26,11 +26,6 @@ client.index('movies').search('shifu', {
 $client->index('movies')->search('shifu', ['offset' => 1]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("shifu").offset(1).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('shifu', {
   offset: 1

--- a/snippets/samples/code_samples_search_parameter_guide_page_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_page_1.mdx
@@ -24,11 +24,6 @@ client.index('movies').search('', {'page': 2})
 $client->index('movies')->search('', ['page' => 2]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("").page(15).build();
-SearchResultPaginated searchResult = client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('', page: 2)
 ```

--- a/snippets/samples/code_samples_search_parameter_guide_query_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_query_1.mdx
@@ -19,10 +19,6 @@ client.index('movies').search('shifu')
 $client->index('movies')->search('shifu');
 ```
 
-```java Java
-client.index("movies").search("shifu");
-```
-
 ```ruby Ruby
 client.index('movies').search('shifu')
 ```

--- a/snippets/samples/code_samples_search_parameter_guide_retrieve_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_retrieve_1.mdx
@@ -31,11 +31,6 @@ $client->index('movies')->search('shifu', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("a").attributesToRetrieve(new String[] {"overview", "title"}).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('shifu', {
   attributes_to_retrieve: ['overview', 'title']

--- a/snippets/samples/code_samples_search_parameter_guide_show_matches_position_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_show_matches_position_1.mdx
@@ -29,11 +29,6 @@ $client->index('movies')->search('winter feast', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("winter feast").showMatchesPosition(true).build();
-SearchResultPaginated searchResult = client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('winter feast', {
   show_matches_position: true

--- a/snippets/samples/code_samples_search_parameter_guide_show_ranking_score_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_show_ranking_score_1.mdx
@@ -28,11 +28,6 @@ $client->index('movies')->search('dragon', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("dragon").showRankingScore(true).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('dragon', {
   show_ranking_score: true

--- a/snippets/samples/code_samples_search_parameter_guide_show_ranking_score_details_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_show_ranking_score_details_1.mdx
@@ -26,11 +26,6 @@ $client->index('movies')->search('dragon', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("dragon").showRankingScoreDetails(true).build();
-client.index("movies").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('movies').search('dragon', {
   show_ranking_score_details: true

--- a/snippets/samples/code_samples_search_parameter_guide_sort_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_guide_sort_1.mdx
@@ -26,11 +26,6 @@ client.index('books').search('science fiction', {
 $client->index('books')->search('science fiction', ['sort' => ['price:asc']]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("science fiction").sort(new String[] {"price:asc"}).build();
-client.index("search_parameter_guide_sort_1").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('books').search('science fiction', { sort: ['price:asc'] })
 ```

--- a/snippets/samples/code_samples_search_parameter_reference_distinct_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_reference_distinct_1.mdx
@@ -24,11 +24,6 @@ $client->index('INDEX_NAME')->search('QUERY TERMS', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("QUERY TERMS").distinct("ATTRIBUTE_A").build();
-client.index("INDEX_NAME").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').search('QUERY TERMS', {
   distinct: 'ATTRIBUTE_A'

--- a/snippets/samples/code_samples_search_parameter_reference_locales_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_reference_locales_1.mdx
@@ -24,11 +24,6 @@ $client->index('INDEX_NAME')->search('QUERY TEXT IN JAPANESE', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("QUERY TEXT IN JAPANESE").locales(new String[]{"jpn"}).build();
-client.index("INDEX_NAME").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').search('進撃の巨人', { locales: ['jpn'] })
 ```

--- a/snippets/samples/code_samples_search_parameter_reference_ranking_score_threshold_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_reference_ranking_score_threshold_1.mdx
@@ -24,11 +24,6 @@ $client->index('INDEX_NAME')->search('badman', [
 ]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("badman").rankingScoreThreshold(0.2).build();
-client.index("INDEX_NAME").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').search('badman', {
   rankingScoreThreshold: 0.2

--- a/snippets/samples/code_samples_search_post_1.mdx
+++ b/snippets/samples/code_samples_search_post_1.mdx
@@ -19,10 +19,6 @@ client.index('movies').search('American ninja')
 $client->index('movies')->search('american ninja');
 ```
 
-```java Java
-client.index("movies").search("American ninja");
-```
-
 ```ruby Ruby
 client.index('movies').search('american ninja')
 ```

--- a/snippets/samples/code_samples_security_guide_create_key_1.mdx
+++ b/snippets/samples/code_samples_security_guide_create_key_1.mdx
@@ -43,22 +43,6 @@ $client->createKey([
 ]);
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-
-SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
-Date dateParsed = format.parse("2023-01-01T00:00:00Z");
-
-Key keyInfo = new Key();
-
-keyInfo.setDescription("Search patient records key");
-keyInfo.setActions(new String[] {"search"});
-keyInfo.setIndexes(new String[] {"patient_medical_records"});
-keyInfo.setExpiresAt(dateParsed);
-
-client.createKey(keyInfo);
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'masterKey')
 client.create_key(

--- a/snippets/samples/code_samples_security_guide_delete_key_1.mdx
+++ b/snippets/samples/code_samples_security_guide_delete_key_1.mdx
@@ -21,11 +21,6 @@ $client = new Client('http://localhost:7700', 'masterKey');
 $client->deleteKey('ac5cd97d-5a4b-4226-a868-2d0eb6d197ab');
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-client.deleteKey("c5cd97d-5a4b-4226-a868-2d0eb6d197ab");
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'masterKey')
 client.delete_key('ac5cd97d-5a4b-4226-a868-2d0eb6d197ab')

--- a/snippets/samples/code_samples_security_guide_list_keys_1.mdx
+++ b/snippets/samples/code_samples_security_guide_list_keys_1.mdx
@@ -21,11 +21,6 @@ $client = new Client('http://localhost:7700', 'masterKey');
 $client->getKeys();
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-client.getKeys();
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'masterKey')
 client.keys

--- a/snippets/samples/code_samples_security_guide_search_key_1.mdx
+++ b/snippets/samples/code_samples_security_guide_search_key_1.mdx
@@ -21,11 +21,6 @@ $client = new Client('http://localhost:7700', 'masterKey');
 $client->index('patient_medical_records')->search();
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "apiKey"));
-client.index("patient_medical_records").search();
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'apiKey')
 client.index('patient_medical_records').search

--- a/snippets/samples/code_samples_security_guide_update_key_1.mdx
+++ b/snippets/samples/code_samples_security_guide_update_key_1.mdx
@@ -29,11 +29,6 @@ $client->updateKey('74c9c733-3368-4738-bbe5-1d18a5fecb37',
 );
 ```
 
-```java Java
-Client client = new Client(new Config("http://localhost:7700", "masterKey"));
-client.updateKey("74c9c733-3368-4738-bbe5-1d18a5fecb37", new KeyUpdate().setDescription("Default Search API Key"));
-```
-
 ```ruby Ruby
 client = MeiliSearch::Client.new('http://localhost:7700', 'masterKey')
 client.update_key('74c9c733-3368-4738-bbe5-1d18a5fecb37', description: 'Default Search API Key')

--- a/snippets/samples/code_samples_sorting_guide_sort_nested_1.mdx
+++ b/snippets/samples/code_samples_sorting_guide_sort_nested_1.mdx
@@ -26,11 +26,6 @@ client.index('books').search('science fiction', {
 $client->index('books')->search('science fiction', ['sort' => ['rating.users:asc']]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("science fiction").sort(new String[] {"rating.users:asc"}).build();
-client.index("books").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('books').search('science fiction', { sort: ['rating.users:asc'] })
 ```

--- a/snippets/samples/code_samples_sorting_guide_sort_parameter_1.mdx
+++ b/snippets/samples/code_samples_sorting_guide_sort_parameter_1.mdx
@@ -26,11 +26,6 @@ client.index('books').search('science fiction', {
 $client->index('books')->search('science fiction', ['sort' => ['price:asc']]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("science fiction").sort(new String[] {"price:asc"}).build();
-client.index("books").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('books').search('science fiction', { sort: ['price:asc'] })
 ```

--- a/snippets/samples/code_samples_sorting_guide_sort_parameter_2.mdx
+++ b/snippets/samples/code_samples_sorting_guide_sort_parameter_2.mdx
@@ -26,11 +26,6 @@ client.index('books').search('butler', {
 $client->index('books')->search('butler', ['sort' => ['author:desc']]);
 ```
 
-```java Java
-SearchRequest searchRequest = SearchRequest.builder().q("butler").sort(new String[] {"author:desc"}).build();
-client.index("books").search(searchRequest);
-```
-
 ```ruby Ruby
 client.index('books').search('butler', { sort: ['author:desc'] })
 ```

--- a/snippets/samples/code_samples_sorting_guide_update_ranking_rules_1.mdx
+++ b/snippets/samples/code_samples_sorting_guide_update_ranking_rules_1.mdx
@@ -47,20 +47,6 @@ $client->index('books')->updateRankingRules([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setRankingRules(new String[]
-{
-  "words",
-  "sort",
-  "typo",
-  "proximity",
-  "attribute",
-  "exactness"
-});
-client.index("books").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('books').update_ranking_rules([
   'words',

--- a/snippets/samples/code_samples_sorting_guide_update_sortable_attributes_1.mdx
+++ b/snippets/samples/code_samples_sorting_guide_update_sortable_attributes_1.mdx
@@ -31,10 +31,6 @@ $client->index('books')->updateSortableAttributes([
 ]);
 ```
 
-```java Java
-client.index("books").updateSortableAttributesSettings(new String[] {"price", "author"});
-```
-
 ```ruby Ruby
 client.index('books').update_sortable_attributes(['author', 'price'])
 ```

--- a/snippets/samples/code_samples_swap_indexes_1.mdx
+++ b/snippets/samples/code_samples_swap_indexes_1.mdx
@@ -35,15 +35,6 @@ client.swap_indexes([{'indexes': ['indexA', 'indexB']}, {'indexes': ['indexX', '
 $client->swapIndexes([['indexA', 'indexB'], ['indexX', 'indexY']]);
 ```
 
-```java Java
-SwapIndexesParams[] params =
-        new SwapIndexesParams[] {
-            new SwapIndexesParams().setIndexes(new String[] {"indexA", "indexB"}),
-            new SwapIndexesParams().setIndexes(new String[] {"indexX", "indexY"})
-        };
-TaskInfo task = client.swapIndexes(params);
-```
-
 ```ruby Ruby
 client.swap_indexes(['indexA', 'indexB'], ['indexX', 'indexY'])
 ```

--- a/snippets/samples/code_samples_synonyms_guide_1.mdx
+++ b/snippets/samples/code_samples_synonyms_guide_1.mdx
@@ -30,14 +30,6 @@ $client->index('movies')->updateSynonyms([
 ]);
 ```
 
-```java Java
-HashMap<String, String[]> synonyms = new HashMap<String, String[]>();
-synonyms.put("great", new String[] {"fantastic"});
-synonyms.put("fantastic", new String[] {"great"});
-
-client.index("movies").updateSynonymsSettings(synonyms);
-```
-
 ```ruby Ruby
 client.index('movies').update_synonyms({
   great: ['fantastic'],

--- a/snippets/samples/code_samples_tenant_token_guide_generate_sdk_1.mdx
+++ b/snippets/samples/code_samples_tenant_token_guide_generate_sdk_1.mdx
@@ -42,21 +42,6 @@ $options = [
 $token = $client->generateTenantToken($apiKeyUid, $searchRules, $options);
 ```
 
-```java Java
-Map<String, Object> filters = new HashMap<String, Object>();
-filters.put("filter", "user_id = 1");
-Map<String, Object> searchRules = new HashMap<String, Object>();
-searchRules.put("patient_medical_records", filters);
-
-Date expiresAt = new SimpleDateFormat("yyyy-MM-dd").parse("2025-12-20");
-TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
-TenantTokenOptions options = new TenantTokenOptions();
-options.setApiKey("B5KdX2MY2jV6EXfUs6scSfmC...");
-options.setExpiresAt(expiresAt);
-
-String token = client.generateTenantToken("85c3c2f9-bdd6-41f1-abd8-11fcf80e0f76", searchRules, options);
-```
-
 ```ruby Ruby
 uid = '85c3c2f9-bdd6-41f1-abd8-11fcf80e0f76'
 api_key = 'B5KdX2MY2jV6EXfUs6scSfmC...'

--- a/snippets/samples/code_samples_tenant_token_guide_search_sdk_1.mdx
+++ b/snippets/samples/code_samples_tenant_token_guide_search_sdk_1.mdx
@@ -15,11 +15,6 @@ $frontEndClient = new Client('http://localhost:7700', $token);
 $frontEndClient->index('patient_medical_records')->search('blood test');
 ```
 
-```java Java
-Client frontEndClient = new Client(new Config("http://localhost:7700", token));
-frontEndClient.index("patient_medical_records").search("blood test");
-```
-
 ```ruby Ruby
 front_end_client = MeiliSearch::Client.new('http://localhost:7700', token)
 

--- a/snippets/samples/code_samples_typo_tolerance_guide_1.mdx
+++ b/snippets/samples/code_samples_typo_tolerance_guide_1.mdx
@@ -25,12 +25,6 @@ $client->index('movies')->updateTypoTolerance([
 ]);
 ```
 
-```java Java
-TypoTolerance typoTolerance = new TypoTolerance();
-typoTolerance.setEnabled(false);
-client.index("movies").updateTypoToleranceSettings(typoTolerance);
-```
-
 ```ruby Ruby
 index('books').update_typo_tolerance({ enabled: false })
 ```

--- a/snippets/samples/code_samples_typo_tolerance_guide_2.mdx
+++ b/snippets/samples/code_samples_typo_tolerance_guide_2.mdx
@@ -25,12 +25,6 @@ $client->index('movies')->updateTypoTolerance([
 ]);
 ```
 
-```java Java
-TypoTolerance typoTolerance = new TypoTolerance();
-typoTolerance.setDisableOnAttributes(new String[] {"title"});
-client.index("movies").updateTypoToleranceSettings(typoTolerance);
-```
-
 ```ruby Ruby
 index('books').update_typo_tolerance({ disable_on_attributes: ['title'] })
 ```

--- a/snippets/samples/code_samples_typo_tolerance_guide_3.mdx
+++ b/snippets/samples/code_samples_typo_tolerance_guide_3.mdx
@@ -29,12 +29,6 @@ $client->index('movies')->updateTypoTolerance([
 ]);
 ```
 
-```java Java
-TypoTolerance typoTolerance = new TypoTolerance();
-typoTolerance.setDisableOnWords(new String[] {"shrek"});
-client.index("movies").updateTypoToleranceSettings(typoTolerance);
-```
-
 ```ruby Ruby
 index('books').update_typo_tolerance({ disable_on_words: ['shrek'] })
 ```

--- a/snippets/samples/code_samples_typo_tolerance_guide_4.mdx
+++ b/snippets/samples/code_samples_typo_tolerance_guide_4.mdx
@@ -39,19 +39,6 @@ $client->index('movies')->updateTypoTolerance([
 ]);
 ```
 
-```java Java
-TypoTolerance typoTolerance = new TypoTolerance();
-  HashMap<String, Integer> minWordSizeTypos =
-        new HashMap<String, Integer>() {
-            {
-                put("oneTypo", 4);
-                put("twoTypos", 10);
-            }
-        };
-typoTolerance.setMinWordSizeForTypos(minWordSizeTypos);
-client.index("movies").updateTypoToleranceSettings(typoTolerance);
-```
-
 ```ruby Ruby
 index('books').update_typo_tolerance({
   min_word_size_for_typos: {

--- a/snippets/samples/code_samples_update_a_key_1.mdx
+++ b/snippets/samples/code_samples_update_a_key_1.mdx
@@ -34,14 +34,6 @@ $client->updateKey('6062abda-a5aa-4414-ac91-ecd7944c0f8d',
   ]);
 ```
 
-```java Java
-KeyUpdate keyChanges = new KeyUpdate();
-keyChanges.setName("Products/Reviews API key");
-keyChanges.setDescription("Manage documents: Products/Reviews API key");
-
-client.updateKey("6062abda-a5aa-4414-ac91-ecd7944c0f8d", keyChanges);
-```
-
 ```ruby Ruby
 client.update_key(
   '6062abda-a5aa-4414-ac91-ecd7944c0f8d',

--- a/snippets/samples/code_samples_update_an_index_1.mdx
+++ b/snippets/samples/code_samples_update_an_index_1.mdx
@@ -19,10 +19,6 @@ client.index('movies').update(primary_key='id')
 $client->updateIndex('movies', ['primaryKey' => 'id']);
 ```
 
-```java Java
-client.updateIndex("movies", "id");
-```
-
 ```ruby Ruby
 client.index('movies').update(primary_key: 'movie_id')
 ```

--- a/snippets/samples/code_samples_update_dictionary_1.mdx
+++ b/snippets/samples/code_samples_update_dictionary_1.mdx
@@ -22,10 +22,6 @@ client.index('books').update_dictionary(["J. R. R.", "W. E. B."])
 $client->index('books')->updateDictionary(['J. R. R.', 'W. E. B.']);
 ```
 
-```java Java
-client.index("books").updateDictionarySettings(new String[] {"J. R. R.", "W. E. B."});
-```
-
 ```ruby Ruby
 client.index('books').update_dictionary(['J. R. R.', 'W. E. B.'])
 ```

--- a/snippets/samples/code_samples_update_displayed_attributes_1.mdx
+++ b/snippets/samples/code_samples_update_displayed_attributes_1.mdx
@@ -39,16 +39,6 @@ $client->index('movies')->updateDisplayedAttributes([
 ]);
 ```
 
-```java Java
-client.index("movies").updateDisplayedAttributesSettings(new String[]
-{
-  "title",
-  "overview",
-  "genres",
-  "release_date"
-});
-```
-
 ```ruby Ruby
 client.index('movies').update_displayed_attributes([
   'title',

--- a/snippets/samples/code_samples_update_distinct_attribute_1.mdx
+++ b/snippets/samples/code_samples_update_distinct_attribute_1.mdx
@@ -19,10 +19,6 @@ client.index('shoes').update_distinct_attribute('skuid')
 $client->index('shoes')->updateDistinctAttribute('skuid');
 ```
 
-```java Java
-client.index("shoes").updateDistinctAttributeSettings("skuid");
-```
-
 ```ruby Ruby
 client.index('shoes').update_distinct_attribute('skuid')
 ```

--- a/snippets/samples/code_samples_update_faceting_settings_1.mdx
+++ b/snippets/samples/code_samples_update_faceting_settings_1.mdx
@@ -41,16 +41,6 @@ $client->index('books')->updateFaceting([
 ]);
 ```
 
-```java Java
-Faceting newFaceting = new Faceting();
-newFaceting.setMaxValuesPerFacet(2);
-HashMap<String, FacetSortValue> facetSortValues = new HashMap<>();
-facetSortValues.put("*", FacetSortValue.ALPHA);
-facetSortValues.put("genres", FacetSortValue.COUNT);
-newFaceting.setSortFacetValuesBy(facetSortValues);
-client.index("books").updateFacetingSettings(newFaceting);
-```
-
 ```ruby Ruby
 client.index('books').update_faceting({
   max_values_per_facet: 2,

--- a/snippets/samples/code_samples_update_filterable_attributes_1.mdx
+++ b/snippets/samples/code_samples_update_filterable_attributes_1.mdx
@@ -57,12 +57,6 @@ $client->index('movies')->updateFilterableAttributes([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setFilterableAttributes(new String[] {"genres", "director"});
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_filterable_attributes([
   'genres',

--- a/snippets/samples/code_samples_update_localized_attribute_settings_1.mdx
+++ b/snippets/samples/code_samples_update_localized_attribute_settings_1.mdx
@@ -28,16 +28,6 @@ $client->index('INDEX_NAME')->updateLocalizedAttributes([
 ]);
 ```
 
-```java Java
-LocalizedAttribute attribute = new LocalizedAttribute();
-attribute.setAttributePatterns(new String[] {"jpn"});
-attribute.setLocales(new String[] {"*_ja"});
-
-client.index("INDEX_NAME").updateLocalizedAttributesSettings(
-  new LocalizedAttributes[] {attribute}
-);
-```
-
 ```ruby Ruby
 client.index('INDEX_NAME').update_localized_attributes([
   { attribute_patterns: ['*_ja'], locales: ['jpn'] },

--- a/snippets/samples/code_samples_update_non_separator_tokens_1.mdx
+++ b/snippets/samples/code_samples_update_non_separator_tokens_1.mdx
@@ -19,11 +19,6 @@ client.index('articles').update_non_separator_tokens(["@", "#"])
 $client->index('articles')->updateNonSeparatorTokens(['@', '#']);
 ```
 
-```java Java
-String[] newSeparatorTokens = { "@", "#" };
-client.index("articles").updateNonSeparatorTokensSettings(newSeparatorTokens);
-```
-
 ```ruby Ruby
 client.index('articles').update_non_separator_tokens(['@', '#'])
 ```

--- a/snippets/samples/code_samples_update_pagination_settings_1.mdx
+++ b/snippets/samples/code_samples_update_pagination_settings_1.mdx
@@ -25,12 +25,6 @@ $client->index('books')->updateSettings([
 ]);
 ```
 
-```java Java
-Pagination newPagination = new Pagination();
-newPagination.setMaxTotalHits(100);
-client.index("books").updatePaginationSettings(newPagination);
-```
-
 ```ruby Ruby
 index('books').update_pagination({ max_total_hits: 100 })
 ```

--- a/snippets/samples/code_samples_update_proximity_precision_settings_1.mdx
+++ b/snippets/samples/code_samples_update_proximity_precision_settings_1.mdx
@@ -19,10 +19,6 @@ client.index('books').update_proximity_precision(ProximityPrecision.BY_ATTRIBUTE
 $client->index('books')->updateProximityPrecision('byAttribute');
 ```
 
-```java Java
-client.index("books").updateProximityPrecisionSettings("byAttribute");
-```
-
 ```ruby Ruby
 client.index('books').update_proximity_precision('byAttribute')
 ```

--- a/snippets/samples/code_samples_update_ranking_rules_1.mdx
+++ b/snippets/samples/code_samples_update_ranking_rules_1.mdx
@@ -55,22 +55,6 @@ $client->index('movies')->updateRankingRules([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setRankingRules(new String[]
-{
-  "words",
-  "typo",
-  "proximity",
-  "attribute",
-  "sort",
-  "exactness",
-  "release_date:asc",
-  "rank:desc"
-});
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_ranking_rules([
   'words',

--- a/snippets/samples/code_samples_update_search_cutoff_1.mdx
+++ b/snippets/samples/code_samples_update_search_cutoff_1.mdx
@@ -19,10 +19,6 @@ client.index('movies').update_search_cutoff_ms(150)
 $client->index('movies')->updateSearchCutoffMs(150);
 ```
 
-```java Java
-client.index("movies").updateSearchCutoffMsSettings(150);
-```
-
 ```ruby Ruby
 client.index('movies').update_search_cutoff_ms(150)
 ```

--- a/snippets/samples/code_samples_update_searchable_attributes_1.mdx
+++ b/snippets/samples/code_samples_update_searchable_attributes_1.mdx
@@ -35,15 +35,6 @@ $client->index('movies')->updateSearchableAttributes([
 ]);
 ```
 
-```java Java
-client.index("movies").updateSearchableAttributesSettings(new String[]
-{
-  "title",
-  "overview",
-  "genres"
-});
-```
-
 ```ruby Ruby
 client.index('movies').update_searchable_attributes([
   'title',

--- a/snippets/samples/code_samples_update_separator_tokens_1.mdx
+++ b/snippets/samples/code_samples_update_separator_tokens_1.mdx
@@ -19,11 +19,6 @@ client.index('articles').update_separator_tokens(["|", "&hellip;"])
 $client->index('articles')->updateSeparatorTokens(['|', '&hellip;']);
 ```
 
-```java Java
-String[] newSeparatorTokens = { "|", "&hellip;" };
-client.index("articles").updateSeparatorTokensSettings(newSeparatorTokens);
-```
-
 ```ruby Ruby
 client.index('articles').update_separator_tokens(['|', '&hellip;'])
 ```

--- a/snippets/samples/code_samples_update_settings_1.mdx
+++ b/snippets/samples/code_samples_update_settings_1.mdx
@@ -224,64 +224,6 @@ $client->index('movies')->updateSettings([
 ]);
 ```
 
-```java Java
-Settings settings = new Settings();
-settings.setRankingRules(
-  new String[] {
-      "words",
-      "typo",
-      "proximity",
-      "attribute",
-      "sort",
-      "exactness",
-      "release_date:desc",
-      "rank:desc"
-  });
-settings.setDistinctAttribute("movie_id");
-settings.setSearchableAttributes(
-  new String[] {
-    "title",
-    "overview",
-    "genres"
-  });
-settings.setDisplayedAttributes(
-  new String[] {
-    "title",
-    "overview",
-    "genres",
-    "release_date"
-  });
-settings.setStopWords(
-  new String[] {
-    "the",
-    "a",
-    "an"
-  });
-settings.setSortableAttributes(
-  new String[] {
-    "title",
-    "release_date"
-  });
-
-HashMap<String, String[]> synonyms = new HashMap<String, String[]>();
-synonyms.put("wolverine", new String[] {"xmen", "logan"});
-synonyms.put("logan", new String[] {"wolverine"});
-settings.setSynonyms(synonyms);
-
-HashMap<String, Integer> minWordSizeTypos =
-  new HashMap<String, Integer>() {
-    {
-      put("oneTypo", 8);
-      put("twoTypos", 10);
-    }
-  };
-TypoTolerance typoTolerance = new TypoTolerance();
-typoTolerance.setMinWordSizeForTypos(minWordSizeTypos);
-settings.setTypoTolerance(typoTolerance);
-settings.setSearchCutoffMs(150);
-client.index("movies").updateSettings(settings);
-```
-
 ```ruby Ruby
 client.index('movies').update_settings({
   ranking_rules: [

--- a/snippets/samples/code_samples_update_sortable_attributes_1.mdx
+++ b/snippets/samples/code_samples_update_sortable_attributes_1.mdx
@@ -32,10 +32,6 @@ $client->index('books')->updateSortableAttributes([
 ]);
 ```
 
-```java Java
-client.index("books").updateSortableAttributesSettings(new String[] {"price", "author"});
-```
-
 ```ruby Ruby
 client.index('books').update_sortable_attributes([
   'price',

--- a/snippets/samples/code_samples_update_stop_words_1.mdx
+++ b/snippets/samples/code_samples_update_stop_words_1.mdx
@@ -23,10 +23,6 @@ client.index('movies').update_stop_words(['of', 'the', 'to'])
 $client->index('movies')->updateStopWords(['the', 'of', 'to']);
 ```
 
-```java Java
-client.index("movies").updateStopWordsSettings(new String[] {"of", "the", "to"});
-```
-
 ```ruby Ruby
 client.index('movies').update_stop_words(['of', 'the', 'to'])
 ```

--- a/snippets/samples/code_samples_update_synonyms_1.mdx
+++ b/snippets/samples/code_samples_update_synonyms_1.mdx
@@ -41,13 +41,6 @@ $client->index('movies')->updateSynonyms([
 ]);
 ```
 
-```java Java
-HashMap<String, String[]> synonyms = new HashMap<String, String[]>();
-synonyms.put("wolverine", new String[] {"xmen", "logan"});
-synonyms.put("logan", new String[] {"wolverine"});
-client.index("movies").updateSynonymsSettings(synonyms);
-```
-
 ```ruby Ruby
 client.index('movies').update_synonyms({
   wolverine: ['xmen', 'logan'],

--- a/snippets/samples/code_samples_update_typo_tolerance_1.mdx
+++ b/snippets/samples/code_samples_update_typo_tolerance_1.mdx
@@ -49,22 +49,6 @@ $client->index('books')->updateTypoTolerance([
 ]);
 ```
 
-```java Java
-TypoTolerance typoTolerance = new TypoTolerance();
-HashMap<String, Integer> minWordSizeTypos =
-        new HashMap<String, Integer>() {
-            {
-                put("oneTypo", 4);
-                put("twoTypos", 10);
-            }
-        };
-
-typoTolerance.setMinWordSizeForTypos(minWordSizeTypos);
-typoTolerance.setDisableOnAttributes(new String[] {"title"});
-
-client.index("books").updateTypoToleranceSettings(typoTolerance);
-```
-
 ```ruby Ruby
 index('books').update_typo_tolerance({
   min_word_size_for_typos: {


### PR DESCRIPTION
Redirects currently include `/docs` in their `source`/`target`. This was necessary with the next.js docs, but prevents redirects from working with Mintlify.

This PR fixes this by replacing all `/docs/` in the redirects with `/`.