### PR TITLE
Remove misleading mention of `sortFacetValuesBy` from facet search reference

### DIFF
--- a/reference/api/facet_search.mdx
+++ b/reference/api/facet_search.mdx
@@ -8,7 +8,7 @@ import { RouteHighlighter } from '/snippets/route_highlighter.mdx'
 
 import CodeSamplesFacetSearch1 from '/snippets/samples/code_samples_facet_search_1.mdx';
 
-The `/facet-search` route allows you to search for facet values. Facet search supports [prefix search](/learn/engine/prefix) and [typo tolerance](/learn/relevancy/typo_tolerance_settings). The returned hits are sorted lexicographically in ascending order. You can configure how facets are sorted using the [`sortFacetValuesBy`](/reference/api/settings#faceting-object) property of the `faceting` index settings.
+The `/facet-search` route allows you to search for facet values. Facet search supports [prefix search](/learn/engine/prefix) and [typo tolerance](/learn/relevancy/typo_tolerance_settings). The returned hits are sorted lexicographically in ascending order.
 
 <Note>
 Meilisearch does not support facet search on numbers. Convert numeric facets to strings to make them searchable.


### PR DESCRIPTION
Fixes #2700