### PR TITLE
API CHATS workspace creation clarification

### DIFF
--- a/reference/api/chats.mdx
+++ b/reference/api/chats.mdx
@@ -37,6 +37,10 @@ curl \
 
 <RouteHighlighter method="PATCH" path="/chats/{workspace}/settings" />
 
+<Note>
+The first call to `PATCH /chats/{workspace}/settings` will create the workspace UID if it doesn’t already exist.
+</Note>
+
 Configure the LLM provider and settings for a chat workspace.
 
 ```json


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3289

## What does this PR do?
As there isn't a specific Workspace creation route for the Chats workspace , this note adds a small clarification that the first PATCH /chats/{workspace}/settings call will create the workspace UID if it doesn’t exist.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
