### PR TITLE
fix(docs): point stopwords link to GitHub repo instead of inactive website

### DIFF
--- a/reference/api/settings.mdx
+++ b/reference/api/settings.mdx
@@ -2127,7 +2127,7 @@ Updating stop words will re-index all documents in the index, which can take som
 <Tip>
 Stop words are strongly related to the language used in your dataset. For example, most datasets containing English documents will have countless occurrences of `the` and `of`. Italian datasets, instead, will benefit from ignoring words like `a`, `la`, or `il`.
 
-[This website maintained by a French developer](https://sites.google.com/site/kevinbouge/stopwords-lists) offers lists of possible stop words in different languages. Note that, depending on your dataset and use case, you will need to tweak these lists for optimal results.
+[This open-source project on GitHub](https://github.com/stopwords-iso/stopwords-iso) offers lists of possible stop words in different languages. Note that, depending on your dataset and use case, you will need to tweak these lists for optimal results.
 </Tip>
 
 ### Get stop words


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #3028

## What does this PR do?
- Updates a broken link to the stopword list in the documentation
- Replaces outdated website with the official GitHub repository for [stopwords-iso](https://github.com/stopwords-iso/stopwords-iso)
- Improves reliability and clarity of external reference

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!