### PR TITLE
Add more info about the rankingScoreThreshold

### DIFF
--- a/reference/api/search.mdx
+++ b/reference/api/search.mdx
@@ -1136,9 +1136,7 @@ The code sample below returns the `_rankingScoreDetail` when searching for `drag
 **Expected value**: A number between `0.0` and `1.0`<br />
 **Default value**: `null`
 
-Excludes results below the specified ranking score.
-
-The threshold applies to all search types including full-text search, semantic search, and hybrid search. This allows you to filter out low-quality matches regardless of the search method being used.
+Excludes results below the specified ranking score. The threshold applies to all search types including full-text search, semantic search, and hybrid search.
 
 Excluded results do not count towards `estimatedTotalHits`, `totalHits`, and facet distribution.
 


### PR DESCRIPTION
I've added a clarification to the Ranking score threshold section that explains how the threshold applies to all search types.