### PR TITLE
Update autobatch requirements description

### DIFF
--- a/learn/getting_started/documents.mdx
+++ b/learn/getting_started/documents.mdx
@@ -144,12 +144,7 @@ Since CSV does not support arrays or nested objects, `cast` cannot be converted 
 
 ### Auto-batching
 
-Auto-batching combines similar consecutive operations into a single batch and processes them together. This significantly speeds up the indexing process.
-
-Meilisearch batches operations such as document addition and deletion when they:
-
-- Target the same index
-- Are immediately consecutive
+Auto-batching combines similar operations in the same index into a single batch and processes them together. This significantly speeds up the indexing process.
 
 Tasks within the same batch share the same values for `startedAt`, `finishedAt`, and `duration`.
 

--- a/snippets/samples/code_samples_export_post_1.mdx
+++ b/snippets/samples/code_samples_export_post_1.mdx
@@ -1,0 +1,16 @@
+<CodeGroup>
+
+```bash cURL
+curl \
+  -X POST 'MEILISEARCH_URL/export' \
+  -H 'Content-Type: application/json' \
+  --data-binary '{
+    "url": "TARGET_INSTANCE_URL",
+    "indexes": {
+      "*": {
+        "overrideSettings": true
+      }
+    }
+  }'
+```
+</CodeGroup>

--- a/snippets/samples/code_samples_search_parameter_reference_locales_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_reference_locales_1.mdx
@@ -35,7 +35,7 @@ client.index('INDEX_NAME').search('進撃の巨人', { locales: ['jpn'] })
 
 ```go Go
 client.index("INDEX_NAME").Search("QUERY TEXT IN JAPANESE", &meilisearch.SearchRequest{
-    Locates: []string{"jpn"}
+    Locales: []string{"jpn"}
 })
 ```
 

--- a/snippets/samples/code_samples_search_parameter_reference_media_1.mdx
+++ b/snippets/samples/code_samples_search_parameter_reference_media_1.mdx
@@ -1,0 +1,20 @@
+<CodeGroup>
+
+```bash cURL
+curl \
+-X POST 'MEILISEARCH_URL/indexes/INDEX_NAME/search' \
+-H 'Content-Type: application/json' \
+--data-binary '{
+  "hybrid": {
+    "embedder": "EMBEDDER_NAME"
+  },
+  "media": {
+    "FIELD_A": "VALUE_A",
+    "FIELD_B" : {
+      "FIELD_C": "VALUE_B"
+      "FIELD_D": "VALUE_C"
+    }
+  }
+}'
+```
+</CodeGroup>


### PR DESCRIPTION
Autobatching no longer requires tasks to be immediately consecutive.

## Reference
- linear issue (private link): https://linear.app/meilisearch/issue/CSX-1009/alice-yu-scorability-task-batching-behavior-for-multiple-indexes#comment-9f914a59