### PR TITLE
Fix HTTP method in chat workspace configuration from PUT to PATCH

### DIFF
--- a/learn/chat/getting_started_with_chat.mdx
+++ b/learn/chat/getting_started_with_chat.mdx
@@ -70,7 +70,7 @@ Create a workspace with your LLM provider settings. Here are examples for differ
 
 ```bash openAi
 curl \
-  -X PUT 'http://localhost:7700/chats/my-assistant/settings' \
+  -X PATCH 'http://localhost:7700/chats/my-assistant/settings' \
   -H 'Authorization: Bearer MEILISEARCH_KEY' \
   -H 'Content-Type: application/json' \
   --data-binary '{
@@ -85,7 +85,7 @@ curl \
 
 ```bash azureOpenAi
 curl \
-  -X PUT 'http://localhost:7700/chats/my-assistant/settings' \
+  -X PATCH 'http://localhost:7700/chats/my-assistant/settings' \
   -H 'Authorization: Bearer MEILISEARCH_KEY' \
   -H 'Content-Type: application/json' \
   --data-binary '{
@@ -100,7 +100,7 @@ curl \
 
 ```bash mistral
 curl \
-  -X PUT 'http://localhost:7700/chats/my-assistant/settings' \
+  -X PATCH 'http://localhost:7700/chats/my-assistant/settings' \
   -H 'Authorization: Bearer MEILISEARCH_KEY' \
   -H 'Content-Type: application/json' \
   --data-binary '{
@@ -114,7 +114,7 @@ curl \
 
 ```bash gemini
 curl \
-  -X PUT 'http://localhost:7700/chats/my-assistant/settings' \
+  -X PATCH 'http://localhost:7700/chats/my-assistant/settings' \
   -H 'Authorization: Bearer MEILISEARCH_KEY' \
   -H 'Content-Type: application/json' \
   --data-binary '{
@@ -128,7 +128,7 @@ curl \
 
 ```bash vLlm
 curl \
-  -X PUT 'http://localhost:7700/chats/my-assistant/settings' \
+  -X PATCH 'http://localhost:7700/chats/my-assistant/settings' \
   -H 'Authorization: Bearer MEILISEARCH_KEY' \
   -H 'Content-Type: application/json' \
   --data-binary '{
@@ -349,7 +349,7 @@ except Exception as error:
 2. Update with valid API key:
 
    ```bash
-   curl -X PUT http://localhost:7700/chats/my-assistant/settings \
+   curl -X PATCH http://localhost:7700/chats/my-assistant/settings \
      -H "Authorization: Bearer MEILISEARCH_KEY" \
      -H "Content-Type: application/json" \
      -d '{"apiKey": "your-valid-api-key"}'


### PR DESCRIPTION
## Summary
- Fixed incorrect HTTP method in the chat completions workspace configuration documentation
- Changed from PUT to PATCH for all provider examples (OpenAI, Azure OpenAI, Mistral, Gemini, vLlm)
- Also fixed the troubleshooting section example

## Context
The  endpoint uses PATCH, not PUT. This PR corrects all instances in the getting started guide to prevent confusion for users.

## Changes
- Updated 5 provider configuration examples in the main guide
- Updated 1 troubleshooting example

All changes are in: 