### PR TITLE
docs: add `experimental` notice to `STARTS WITH` filter

### DIFF
--- a/learn/filtering_and_sorting/filter_expression_reference.mdx
+++ b/learn/filtering_and_sorting/filter_expression_reference.mdx
@@ -206,10 +206,13 @@ curl \
     "containsFilter": true
   }'
 ```
+
+This also enables the `STARTS WITH` filter.
 </Note>
 
 ### `STARTS WITH`
 
+<NoticeTag type="experimental" label="experimental" />
 `STARTS WITH` filters results whose values start with the specified string pattern.
 
 The following expression returns all dairy products whose name start with `"kef"`:
@@ -224,6 +227,21 @@ The negated form of the above expression can be written as:
 dairy_products.name NOT STARTS WITH kef
 NOT dairy_product.name STARTS WITH kef
 ```
+
+<Note>
+This is an experimental feature. Use the experimental features endpoint to activate it:
+
+```sh
+curl \
+  -X PATCH 'MEILISEARCH_URL/experimental-features/' \
+  -H 'Content-Type: application/json' \
+  --data-binary '{
+    "containsFilter": true
+  }'
+```
+
+This also enables the `CONTAINS` filter.
+</Note>
 
 ### `NOT`
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number> _(no related issue)_

## What does this PR do?
- the `STARTS WITH` filter is an experimental feature
- the docs are currently not marking it as experimental
- this PR marks it as experimental and mentions that enabling the `CONTAINS` filter will also enable `STARTS WITH` and vice versa

when looking at the commit history it appears that it was marked as experimental before, but was removed at some point (I think during the migration to Mintlify?)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
