### PR TITLE
fix: update link for movies.json file

### DIFF
--- a/learn/self_hosted/getting_started_with_self_hosted_meilisearch.mdx
+++ b/learn/self_hosted/getting_started_with_self_hosted_meilisearch.mdx
@@ -73,7 +73,7 @@ To learn more about securing Meilisearch, refer to the [security tutorial](/lear
 
 In this quick start, you will search through a collection of movies.
 
-To follow along, first click this link to download the file: <a href="/assets/datasets/movies.json" download="movies.json">movies.json</a>. Then, move the downloaded file into your working directory.
+To follow along, first click this link to download the file: <a href="https://www.meilisearch.com/movies.json" download="movies.json">movies.json</a>. Then, move the downloaded file into your working directory.
 
 <Note>
 Meilisearch accepts data in JSON, NDJSON, and CSV formats.


### PR DESCRIPTION
The Link of the `movies.json` file was not working in the rendered page. There I got an 404 pointing to https://meilisearch.com/assets/datasets/movies.json

It was only working from the source file on GitHub which points to https://github.com/meilisearch/documentation/blob/main/assets/datasets/movies.json

So I decided to update the link to point to https://www.meilisearch.com/movies.json which should work for both.
