### PR TITLE
Add missing default API keys in the engine

### DIFF
--- a/guides/vercel.mdx
+++ b/guides/vercel.mdx
@@ -67,7 +67,7 @@ Once you click on **Create project**, you should see the following message: “Y
 
 ### Understand and use Meilisearch API keys
 
-Meilisearch creates two default API keys: [`Default Search API Key` and `Default Admin API Key`](/learn/security/basic_security#obtaining-api-keys).
+Meilisearch creates [four default API keys](/learn/security/basic_security#obtaining-api-keys): `Default Search API Key`, `Default Admin API Key`, `Default Read-Only Admin API Key`, and `Default Chat API Key`.
 
 #### Admin API key
 
@@ -77,7 +77,7 @@ Use the `Default Admin API Key`, to control who can access or create new documen
 
 Use the `Default Search API Key` to access the [search route](/reference/api/search). This is the one you want to use in your front end.
 
-Both keys are automatically added to Vercel along with the Meilisearch URL.
+The Search and Admin API keys are automatically added to Vercel along with the Meilisearch URL. For more information on the other default keys, consult the [security documentation](/learn/security/basic_security#obtaining-api-keys).
 
 <Tip>
 The master key–which hasn’t been added to Vercel–grants users full control over an instance. You can find it in your project’s overview on your [Meilisearch Cloud dashboard](https://cloud.meilisearch.com/projects/?utm_campaign=oss&utm_source=docs&utm_medium=vercel-integration). Read more about [Meilisearch security](https://www.meilisearch.com/docs/learn/security/master_api_keys).

--- a/learn/security/basic_security.mdx
+++ b/learn/security/basic_security.mdx
@@ -83,7 +83,7 @@ Restart Meilisearch with the argument above to use this new and secure master ke
 
 ## Obtaining API keys
 
-When your project is protected, Meilisearch automatically generates two API keys: `Default Search API Key` and `Default Admin API Key`. API keys are authorization tokens designed to safely communicate with the Meilisearch API.
+When your project is protected, Meilisearch automatically generates four API keys: `Default Search API Key`, `Default Admin API Key`, `Default Read-Only Admin API Key`, and `Default Chat API Key`. API keys are authorization tokens designed to safely communicate with the Meilisearch API.
 
 ### Obtaining API keys in Meilisearch Cloud
 
@@ -103,7 +103,7 @@ Use your master key to query the `/keys` endpoint to view all API keys in your i
 Only use the master key to manage API keys. Never use the master key to perform searches or other common operations.
 </Warning>
 
-Meilisearch's response will include at least the two default API keys:
+Meilisearch's response will include at least the default API keys:
 
 ```json
 {
@@ -112,7 +112,7 @@ Meilisearch's response will include at least the two default API keys:
       "name": "Default Search API Key",
       "description": "Use it to search from the frontend",
       "key": "0beec7b5ea3f0fdbc95d0dd47f3c5bc275da8a33",
-      "uid": "123-345-456-987-abc",
+      "uid": "74c9c733-3368-4738-bbe5-1d18a5fecb37",
       "actions": [
         "search"
       ],
@@ -127,7 +127,7 @@ Meilisearch's response will include at least the two default API keys:
       "name": "Default Admin API Key",
       "description": "Use it for anything that is not a search operation. Caution! Do not expose it on a public frontend",
       "key": "62cdb7020ff920e5aa642c3d4066950dd1f01f4d",
-      "uid": "123-345-456-987-abc",
+      "uid": "20f7e4c4-612c-4dd1-b783-7934cc038213",
       "actions": [
         "*"
       ],
@@ -137,6 +137,38 @@ Meilisearch's response will include at least the two default API keys:
       "expiresAt": null,
       "createdAt": "2024-01-25T16:19:53.94816Z",
       "updatedAt": "2024-01-25T16:19:53.94816Z"
+    },
+    {
+      "name": "Default Read-Only Admin API Key",
+      "description": "Use it to read information across the whole database. Caution! Do not expose this key on a public frontend",
+      "key": "9e32fb64e3569a749b0b87900d1026074e798743",
+      "uid": "7dc1ec09-94fb-49b5-b77b-03ce75af89a0",
+      "actions": [
+        "*.get",
+        "keys.get"
+      ],
+      "indexes": [
+        "*"
+      ],
+      "expiresAt": null,
+      "createdAt": "2024-01-25T16:19:53.94716Z",
+      "updatedAt": "2024-01-25T16:19:53.94716Z"
+    },
+    {
+      "name": "Default Chat API Key",
+      "description": "Use it to chat and search from the frontend",
+      "key": "0acaa4f3d57517e4b4d7c0052b02772620bd375a",
+      "uid": "d4e13ace-2a00-428c-90d1-b1c99eec98bd",
+      "actions": [
+        "chatCompletions",
+        "search"
+      ],
+      "indexes": [
+        "*"
+      ],
+      "expiresAt": null,
+      "createdAt": "2024-01-25T16:19:53.94606Z",
+      "updatedAt": "2024-01-25T16:19:53.94606Z"
     }
   ],
   …
@@ -154,6 +186,21 @@ Use the `Default Admin API Key` to perform sensitive operations, such as creatin
 Then use the `Default Search API Key` to perform search operations in the index you just created:
 
 <CodeSamplesBasicSecurityTutorialSearch1 />
+
+### Admin API keys
+
+Meilisearch provides two admin API keys for managing your instance:
+
+- The `Default Admin API Key` grants full access to all Meilisearch operations except API key management. Use it to configure index settings, add documents, and perform other administrative tasks.
+- The `Default Read-Only Admin API Key` allows read-only access to the whole database. Use it when you need to retrieve information from your Meilisearch instance without being able to modify it.
+
+<Warning>
+Do not expose admin API keys on a public frontend.
+</Warning>
+
+### Chat API key
+
+The `Default Chat API Key` is designed for frontend usage with [conversational search](/learn/chat/getting_started_with_chat). It has access to both `search` and `chatCompletions` actions, allowing users to both perform searches and interact with the chat completions feature.
 
 ## Conclusion
 

--- a/learn/security/differences_master_api_keys.mdx
+++ b/learn/security/differences_master_api_keys.mdx
@@ -24,4 +24,9 @@ API keys grant access to a specific set of indexes, routes, and endpoints. You c
 
 **Use API keys for all API operations except API key management.** This includes search, configuring index settings, managing indexes, and adding and updating documents.
 
-In many cases, the default API keys are all you need to safely manage your Meilisearch project. Use the `Default Search API key` for searching, and the `Default Admin API Key` to configure index settings, add documents, and other operations.
+In many cases, the default API keys are all you need to safely manage your Meilisearch project:
+
+- Use the `Default Search API Key` for search operations from the frontend
+- Use the `Default Admin API Key` to configure index settings, add documents, and other operations. Do not expose it on a public frontend
+- Use the `Default Read-Only Admin API Key` for read-only access to all indexes, documents, and settings. Do not expose it on a public frontend
+- Use the `Default Chat API Key` for [conversational search](/learn/chat/getting_started_with_chat). It can be safely used from the frontend

--- a/reference/api/keys.mdx
+++ b/reference/api/keys.mdx
@@ -198,7 +198,7 @@ Results can be paginated using the `offset` and `limit` query parameters.
     },
     {
       "name": "Default Search API Key",
-      "description": "Use it to search from the frontend code",
+      "description": "Use it to search from the frontend",
       "key": "0a6e572506c52ab0bd6195921575d23092b7f0c284ab4ac86d12346c33057f99",
       "uid": "74c9c733-3368-4738-bbe5-1d18a5fecb37",
       "actions": [
@@ -225,11 +225,43 @@ Results can be paginated using the `offset` and `limit` query parameters.
       "expiresAt": null,
       "createdAt": "2021-08-11T10:00:00Z",
       "updatedAt": "2021-08-11T10:00:00Z"
+    },
+    {
+      "name": "Default Read-Only Admin API Key",
+      "description": "Use it to read information across the whole database. Caution! Do not expose this key on a public frontend",
+      "key": "9e32fb64e3569a749b0b87900d1026074e798743cde77bf44c9ef33884100923",
+      "uid": "7dc1ec09-94fb-49b5-b77b-03ce75af89a0",
+      "actions": [
+        "*.get",
+        "keys.get"
+      ],
+      "indexes": [
+        "*"
+      ],
+      "expiresAt": null,
+      "createdAt": "2021-08-11T10:00:00Z",
+      "updatedAt": "2021-08-11T10:00:00Z"
+    },
+    {
+      "name": "Default Chat API Key",
+      "description": "Use it to chat and search from the frontend",
+      "key": "0acaa4f3d57517e4b4d7c0052b02772620bd375a2a5e742aaebf7f6b8b9638cc",
+      "uid": "d4e13ace-2a00-428c-90d1-b1c99eec98bd",
+      "actions": [
+        "chatCompletions",
+        "search"
+      ],
+      "indexes": [
+        "*"
+      ],
+      "expiresAt": null,
+      "createdAt": "2021-08-11T10:00:00Z",
+      "updatedAt": "2021-08-11T10:00:00Z"
     }
   ],
   "offset": 0,
-  "limit": 3,
-  "total": 7
+  "limit": 20,
+  "total": 5
 }
 ```
 


### PR DESCRIPTION
Had been integrated into v1.16.0 but never put in [the docs](https://github.com/meilisearch/meilisearch/releases/v1.16.0) or promoted 😢 