### PR TITLE
Update edge.meilisearch.com deprecation status

### DIFF
--- a/learn/analytics/migrate_analytics_monitoring.mdx
+++ b/learn/analytics/migrate_analytics_monitoring.mdx
@@ -18,4 +18,4 @@ curl \
   --data-binary '{ "q": "green socks" }'
 ```
 
-`edge.meilisearch.com` remains functional, but no longer provides any benefit and will be discontinued in the future. If you created any custom API keys using the previous URL, you will also need to replace them.
+`edge.meilisearch.com` was deprecated on February 28, 2026 and is no longer functional. You must update all API requests to use your project URL. If you created any custom API keys using the previous URL, you will also need to replace them.


### PR DESCRIPTION
## Summary
- Updated the analytics migration guide to reflect that `edge.meilisearch.com` was deprecated on February 28, 2026 and is no longer functional
- Replaced the previous wording that said it "will be discontinued in the future"

## Test plan
- [ ] Verify the Mintlify preview renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration guidance for edge.meilisearch.com with deprecation date and transition requirements.
  * Clarified requirement to migrate all requests to the project URL.
  * Added note to replace API keys during migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->