### PR TITLE
Switch navigation to horizontal tabs

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -154,10 +154,9 @@
     "versions": [
       {
         "version": "latest",
-        "anchors": [
+        "tabs": [
           {
-            "anchor": "Learn",
-            "icon": "book",
+            "tab": "Learn",
             "groups": [
               {
                 "group": "Getting started",
@@ -344,8 +343,7 @@
             ]
           },
           {
-            "anchor": "API Reference",
-            "icon": "code",
+            "tab": "Reference",
             "groups": [
               {
                 "group": "Overview",
@@ -753,8 +751,7 @@
             ]
           },
           {
-            "anchor": "Guides",
-            "icon": "file-lines",
+            "tab": "Guides",
             "groups": [
               {
                 "group": "Front end",


### PR DESCRIPTION
## Summary
- Replace vertical anchor-based sidebar navigation with horizontal tab navigation in `docs.json`
- Rename "API Reference" tab to "Reference"

## Test plan
- [x] Run `mintlify dev` and verify the three tabs (Learn, Reference, Guides) appear as horizontal tabs at the top
- [x] Verify sidebar content under each tab remains unchanged


This PR is required for adding #3497 and #3496 

Fixes #3489 