### PR TITLE
Add missing redirect for update chats route

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1843,6 +1843,10 @@
     {
       "source": "/reference/api/tokenize",
       "destination": "/reference/api/authorization"
+    },
+    {
+      "source": "/reference/api/chats/update-chat",
+      "destination": "/reference/api/chats/update-settings-of-a-chat-workspace"
     }
   ]
 }


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added redirects for legacy API reference URLs to prevent broken links. Users accessing outdated documentation links will be automatically routed to their current locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->