### PR TITLE
Add automation to open issue for undocumented API routes

### DIFF
--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -199,7 +199,10 @@ jobs:
       - name: Check for undocumented routes
         id: coverage
         run: |
-          output=$(npm run check-openapi-routes-coverage 2>&1) || true
+          set +e
+          output=$(npm run check-openapi-routes-coverage 2>&1)
+          status=$?
+          set -e
           echo "$output"
           missing=$(echo "$output" | grep '^\s*-' | sed 's/^\s*- //' || true)
           if [ -n "$missing" ]; then
@@ -210,6 +213,9 @@ jobs:
               echo "EOF"
             } >> "$GITHUB_OUTPUT"
           else
+            if [ "$status" -ne 0 ]; then
+              exit "$status"
+            fi
             echo "has_missing=false" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- Adds a new `check-undocumented-routes` job to the post-deployment workflow
- Runs after the Mintlify OpenAPI file is generated, uses the existing `check-openapi-routes-coverage` script
- If missing routes are found and no open issue with the same title exists, creates a GitHub issue listing them

## Test plan
- [ ] Trigger the workflow manually and verify the job runs correctly
- [ ] Temporarily remove a route from `docs.json` and confirm an issue is created
- [ ] Verify no duplicate issue is created on a second run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated post-deployment check that detects undocumented API routes and, when gaps are found, automatically files a tracking issue listing the missing routes and next steps. Workflow permissions were updated to allow creating and updating those issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->