### PR TITLE
Add missing redirect for /home

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -1130,6 +1130,10 @@
   },
   "redirects": [
     {
+      "source": "/home",
+      "destination": "/getting_started/overview"
+    },
+    {
       "source": "/learn/advanced",
       "destination": "/capabilities/overview"
     },


### PR DESCRIPTION
## Summary
- Adds a redirect from `/home` to `/getting_started/overview`
- The `home.mdx` page was deleted in a recent commit but no redirect was added, causing 404s

## Test plan
- [ ] Verify `/docs/home` redirects to `/docs/getting_started/overview` after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)