### PR TITLE
Add 17 missing redirects for 404 URLs from traffic data

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -2071,7 +2071,7 @@
     },
     {
       "source": "/learn/resources/contributing-docs",
-      "destination": "/resources/help/contributing"
+      "destination": "/resources/help/contributing_docs"
     },
     {
       "source": "/learn/advanced/security",
@@ -2136,6 +2136,74 @@
     {
       "source": "/guides/introduction/quick_start_guide",
       "destination": "/getting_started/first_project"
+    },
+    {
+      "source": "/guides/security/http2_ssl",
+      "destination": "/resources/self_hosting/security/http2_ssl"
+    },
+    {
+      "source": "/guides/security/multitenancy_nodejs",
+      "destination": "/capabilities/security/overview"
+    },
+    {
+      "source": "/learn/cookbooks/multitenancy_nodejs",
+      "destination": "/capabilities/security/overview"
+    },
+    {
+      "source": "/guides/back_end/strapi_v4",
+      "destination": "/getting_started/frameworks/strapi"
+    },
+    {
+      "source": "/guides/deployment/railway",
+      "destination": "/resources/self_hosting/deployment/overview"
+    },
+    {
+      "source": "/learn/advanced/snapshots",
+      "destination": "/resources/self_hosting/data_backup/snapshots"
+    },
+    {
+      "source": "/learn/advanced/snapshots_vs_dumps",
+      "destination": "/resources/self_hosting/data_backup/overview"
+    },
+    {
+      "source": "/learn/experimental/metrics",
+      "destination": "/reference/api/stats/get-prometheus-metrics"
+    },
+    {
+      "source": "/learn/experimental/log_customization",
+      "destination": "/reference/api/logs/retrieve-logs"
+    },
+    {
+      "source": "/learn/experimental/puffin_reports",
+      "destination": "/resources/help/experimental_features_overview"
+    },
+    {
+      "source": "/learn/cookbooks/qovery",
+      "destination": "/resources/self_hosting/deployment/overview"
+    },
+    {
+      "source": "/learn/contributing/contributing_docs",
+      "destination": "/resources/help/contributing_docs"
+    },
+    {
+      "source": "/learn/ai-powered-search/search_with_user_provided_embeddings",
+      "destination": "/capabilities/hybrid_search/how_to/search_with_user_provided_embeddings"
+    },
+    {
+      "source": "/guides/performance/large_documents",
+      "destination": "/capabilities/indexing/how_to/import_large_datasets"
+    },
+    {
+      "source": "/learn/analytics/configure_monitoring",
+      "destination": "/capabilities/analytics/getting_started"
+    },
+    {
+      "source": "/reference/api/settings/get-vectorstore",
+      "destination": "/reference/api/settings/get-embedders"
+    },
+    {
+      "source": "/reference/api/settings/reset-vectorstore",
+      "destination": "/reference/api/settings/get-embedders"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add 17 new redirects for URLs that are returning 404s based on recent traffic data
- Fix 1 existing broken redirect (`/learn/resources/contributing-docs` was pointing to `/resources/help/contributing` instead of `/resources/help/contributing_docs`)

### New redirects added

| Source | Destination |
|---|---|
| `/guides/security/http2_ssl` | `/resources/self_hosting/security/http2_ssl` |
| `/guides/security/multitenancy_nodejs` | `/capabilities/security/overview` |
| `/learn/cookbooks/multitenancy_nodejs` | `/capabilities/security/overview` |
| `/guides/back_end/strapi_v4` | `/getting_started/frameworks/strapi` |
| `/guides/deployment/railway` | `/resources/self_hosting/deployment/overview` |
| `/learn/advanced/snapshots` | `/resources/self_hosting/data_backup/snapshots` |
| `/learn/advanced/snapshots_vs_dumps` | `/resources/self_hosting/data_backup/overview` |
| `/learn/experimental/metrics` | `/reference/api/stats/get-prometheus-metrics` |
| `/learn/experimental/log_customization` | `/reference/api/logs/retrieve-logs` |
| `/learn/experimental/puffin_reports` | `/resources/help/experimental_features_overview` |
| `/learn/cookbooks/qovery` | `/resources/self_hosting/deployment/overview` |
| `/learn/contributing/contributing_docs` | `/resources/help/contributing_docs` |
| `/learn/ai-powered-search/search_with_user_provided_embeddings` | `/capabilities/hybrid_search/how_to/search_with_user_provided_embeddings` |
| `/guides/performance/large_documents` | `/capabilities/indexing/how_to/import_large_datasets` |
| `/learn/analytics/configure_monitoring` | `/capabilities/analytics/getting_started` |
| `/reference/api/settings/get-vectorstore` | `/reference/api/settings/get-embedders` |
| `/reference/api/settings/reset-vectorstore` | `/reference/api/settings/get-embedders` |

## Test plan

- [ ] Verify redirects work on Mintlify preview deployment
- [ ] Spot-check a few redirects land on the correct destination pages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated legacy documentation redirect mappings to ensure previously published links continue to function properly, routing to their current corresponding locations across deployment guides, features, API references, and additional resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->