### PR TITLE
Fix mermaid chart not rendering in hybrid search overview

### DIFF
--- a/capabilities/hybrid_search/how_to/choose_an_embedder.mdx
+++ b/capabilities/hybrid_search/how_to/choose_an_embedder.mdx
@@ -81,8 +81,6 @@ If you work with non-textual content (images, audio) or already generate embeddi
 
 ## Decision flowchart
 
-<CodeGroup>
-
 ```mermaid
 flowchart TD
     A[Starting out?] -->|Yes| B[Use OpenAI text-embedding-3-small<br/>or Voyage 4-lite]
@@ -94,5 +92,3 @@ flowchart TD
     G -->|Yes| H[Cohere embed-v4.0,<br/>Jina v4, or BGE multilingual]
     G -->|No| I[Pick the cheapest model<br/>that meets your needs]
 ```
-
-</CodeGroup>

--- a/capabilities/hybrid_search/overview.mdx
+++ b/capabilities/hybrid_search/overview.mdx
@@ -19,8 +19,6 @@ Meilisearch uses embedding models for hybrid and semantic search, making it orde
 
 When you configure an embedder, Meilisearch automatically generates vector embeddings for every document in your index. You don't need to compute or manage embeddings yourself.
 
-<CodeGroup>
-
 ```mermaid
 flowchart LR
     A[Documents] --> B[Meilisearch]
@@ -29,8 +27,6 @@ flowchart LR
     E[Search query] --> B
     B --> F[Merge & rank results]
 ```
-
-</CodeGroup>
 
 At search time, Meilisearch runs both keyword and semantic search in parallel, then merges the results using a smart scoring system.
 


### PR DESCRIPTION
## Summary
- Remove `<CodeGroup>` wrapper around the mermaid flowchart in the hybrid search overview page
- Mintlify renders mermaid diagrams from standalone fenced code blocks, but wrapping them in `<CodeGroup>` causes the raw syntax to be displayed instead

Fixes #3543

## Test plan
- [ ] Verify the mermaid flowchart renders correctly on the deployed preview at `/docs/capabilities/hybrid_search/overview#how-it-works`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the hybrid search overview to improve presentation and layout of the workflow diagram for clearer reading.
  * Updated the “choose an embedder” guide to simplify the decision flowchart’s presentation and improve diagram clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->