### PR TITLE
fix: correct _geoBoundingBox corner labels (top-left/bottom-right → top-right/bottom-left)

### DIFF
--- a/capabilities/geo_search/how_to/filter_by_geo_bounding_box.mdx
+++ b/capabilities/geo_search/how_to/filter_by_geo_bounding_box.mdx
@@ -5,29 +5,29 @@ description: Filter search results within a rectangular geographic area defined 
 
 import CodeSamplesGeosearchGuideFilterUsage3 from '/snippets/generated-code-samples/code_samples_geosearch_guide_filter_usage_3.mdx';
 
-The `_geoBoundingBox` filter returns documents located within a rectangle defined by its top-left and bottom-right coordinates. This is especially useful for map-based interfaces where you want to display results that fit within the current viewport.
+The `_geoBoundingBox` filter returns documents located within a rectangle defined by its top-right and bottom-left coordinates. This is especially useful for map-based interfaces where you want to display results that fit within the current viewport.
 
 ## Syntax
 
 <CodeGroup>
 
 ```
-_geoBoundingBox([topLeftLat, topLeftLng], [bottomRightLat, bottomRightLng])
+_geoBoundingBox([topRightLat, topRightLng], [bottomLeftLat, bottomLeftLng])
 ```
 
 </CodeGroup>
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
-| `topLeftLat` | Float | Latitude of the top-left corner (northern boundary) |
-| `topLeftLng` | Float | Longitude of the top-left corner (western boundary) |
-| `bottomRightLat` | Float | Latitude of the bottom-right corner (southern boundary) |
-| `bottomRightLng` | Float | Longitude of the bottom-right corner (eastern boundary) |
+| `topRightLat` | Float | Latitude of the top-right corner (northern boundary) |
+| `topRightLng` | Float | Longitude of the top-right corner (eastern boundary) |
+| `bottomLeftLat` | Float | Latitude of the bottom-left corner (southern boundary) |
+| `bottomLeftLng` | Float | Longitude of the bottom-left corner (western boundary) |
 
-The first coordinate pair defines the **top-left** (northwest) corner of the rectangle, and the second defines the **bottom-right** (southeast) corner. This means:
+The first coordinate pair defines the **top-right** (northeast) corner of the rectangle, and the second defines the **bottom-left** (southwest) corner. This means:
 
-- `topLeftLat` should be greater than `bottomRightLat`
-- `topLeftLng` should be less than `bottomRightLng`
+- `topRightLat` should be greater than `bottomLeftLat`
+- `topRightLng` should be greater than `bottomLeftLng`
 
 ## Filter by bounding box
 
@@ -92,7 +92,7 @@ const sw = bounds.getSouthWest();
 
 // Search for results in the visible area
 const results = await client.index('restaurants').search('', {
-  filter: `_geoBoundingBox([${ne.lat}, ${sw.lng}], [${sw.lat}, ${ne.lng}])`
+  filter: `_geoBoundingBox([${ne.lat}, ${ne.lng}], [${sw.lat}, ${sw.lng}])`
 });
 ```
 


### PR DESCRIPTION
## Description

The filter_by_geo_bounding_box.mdx page incorrectly describes the two coordinate pairs of _geoBoundingBox as top-left / bottom-right. According to the [official specification](https://specs.meilisearch.dev/specifications/text/0059-geo-search.html), the correct corners are top-right / bottom-left.

AI used to write issue and PR descriptions.

Fixes #3560 

**Changes**

- Replaced all references to "top-left" / "bottom-right" with "top-right" / "bottom-left"
- Updated parameter names: topLeftLat/topLeftLng/bottomRightLat/bottomRightLng → topRightLat/topRightLng/bottomLeftLat/bottomLeftLng
- Fixed the JavaScript map example to use [ne.lat, ne.lng] and [sw.lat, sw.lng] instead of mixing NE/SW coordinates

## Checklist

For external maintainers
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Have you made sure that the title is accurate and descriptive of the changes?
