### PR TITLE
Remove unused code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1266,13 +1266,6 @@ list_index_fields_1: |-
   curl \
     -X POST 'MEILISEARCH_URL/indexes/INDEX_NAME/fields' \
     -H 'Content-Type: application/json'
-update_experimental_features_chat_1: |-
-  curl \
-    -X PATCH 'MEILISEARCH_URL/experimental-features/' \
-    -H 'Content-Type: application/json' \
-    --data-binary '{
-      "chatCompletions": true
-    }'
 update_experimental_features_contains_1: |-
   curl \
     -X PATCH 'MEILISEARCH_URL/experimental-features/' \


### PR DESCRIPTION
Following the CI report https://github.com/meilisearch/documentation/actions/runs/25095222137/job/73530293931

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Removed outdated curl example for configuring the experimental `chatCompletions` feature. Other experimental feature documentation remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->