### PR TITLE
Add page about carbon footprint

### DIFF
--- a/config/navigation.json
+++ b/config/navigation.json
@@ -989,6 +989,7 @@
                 "resources/help/telemetry",
                 "resources/help/versioning",
                 "resources/help/contributing_docs",
+                "resources/help/carbon_footprint",
                 "resources/migration/previous_docs_version"
               ]
             }

--- a/resources/help/carbon_footprint.mdx
+++ b/resources/help/carbon_footprint.mdx
@@ -1,0 +1,38 @@
+---
+title: Carbon footprint of Meilisearch Cloud regions
+sidebarTitle: Carbon footprint
+description: Understand the grid carbon intensity displayed next to Meilisearch Cloud regions, how it is calculated, and why it matters.
+---
+
+When selecting a region for your Meilisearch Cloud project, you may notice a green leaf icon next to certain regions. This page explains what that means and how we calculate the associated figures.
+
+## What is grid carbon intensity?
+
+Grid carbon intensity measures how much CO2 is emitted, on average, to produce one kilowatt-hour (kWh) of electricity in a given location. It is expressed in **grams of CO2 equivalent per kilowatt-hour (gCO2e/kWh)**.
+
+A lower number means the local electricity grid relies more on low-carbon energy sources (hydro, wind, solar, nuclear), while a higher number indicates a heavier reliance on fossil fuels (coal, gas).
+
+The green leaf icon highlights regions with a **low carbon intensity (below 150 gCO2e/kWh)**.
+
+## How is it calculated?
+
+We use the **location-based methodology** recommended by the [GHG Protocol](https://ghgprotocol.org/). This approach reflects the actual carbon mix of the local electricity grid, regardless of any renewable energy certificates (RECs) or power purchase agreements (PPAs) the cloud provider may have purchased.
+
+We chose this methodology because it gives the most honest, comparable picture across regions.
+
+Values are annual averages. Real-time intensity varies by hour, season, and weather conditions. We review these figures yearly as grid mixes evolve.
+
+## Data sources
+
+Figures are aggregated from the following sources:
+
+- **U.S. regions**: [EPA eGRID](https://www.epa.gov/egrid/download-data)
+- **European regions**: [European Environment Agency](https://www.eea.europa.eu/data-and-maps/daviz/co2-emission-intensity-9/)
+- **Asia-Pacific and South America**: [IEA Emissions Factors 2025](https://www.iea.org/data-and-statistics/data-product/emissions-factors-2025)
+- **Aggregated coefficients**: [Cloud Carbon Footprint open methodology](https://www.cloudcarbonfootprint.org/docs/methodology/)
+
+## Why we share this
+
+Carbon intensity is becoming an important criterion for many teams, particularly in enterprise procurement. We want to give you the information you need to make an informed choice. Showing this data does not restrict access to any region; it is provided for transparency only.
+
+If you have questions or feedback, feel free to reach out via [Discord](https://discord.gg/meilisearch) or the [Meilisearch helpdesk](https://help.meilisearch.com/).

--- a/resources/help/carbon_footprint.mdx
+++ b/resources/help/carbon_footprint.mdx
@@ -26,7 +26,7 @@ Values are annual averages. Real-time intensity varies by hour, season, and weat
 
 Figures are aggregated from the following sources:
 
-- **U.S. regions**: [EPA eGRID](https://www.epa.gov/egrid/download-data)
+- **US regions**: [EPA eGRID](https://www.epa.gov/egrid/download-data)
 - **European regions**: [European Environment Agency](https://www.eea.europa.eu/data-and-maps/daviz/co2-emission-intensity-9/)
 - **Asia-Pacific and South America**: [IEA Emissions Factors 2025](https://www.iea.org/data-and-statistics/data-product/emissions-factors-2025)
 - **Aggregated coefficients**: [Cloud Carbon Footprint open methodology](https://www.cloudcarbonfootprint.org/docs/methodology/)


### PR DESCRIPTION
Adding explanation to redirect people from Cloud UI needing more details

Based on https://linear.app/meilisearch/issue/EXP-1157/disclose-grid-carbon-intensity-gco2ekwh-in-the-region-picker-on


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a help page explaining Meilisearch Cloud region "green leaf" carbon footprint indicators, covering grid carbon intensity metrics, the location-based calculation approach, data source aggregations, threshold for "low carbon intensity," and guidance for transparency and region selection.

* **Chores**
  * Updated site navigation to add the new carbon footprint documentation under the Resources tab.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->