### PR TITLE
fix: resolve $ref in docs.json for OpenAPI routes coverage check

### DIFF
--- a/scripts/check-openapi-routes-coverage.mjs
+++ b/scripts/check-openapi-routes-coverage.mjs
@@ -9,7 +9,7 @@
  */
 
 import { readFileSync } from "fs";
-import { resolve } from "path";
+import { resolve, dirname } from "path";
 
 const OPENAPI_PATH = resolve(
   process.cwd(),
@@ -92,9 +92,30 @@ function normalizeRoute(route) {
   });
 }
 
+// --- Resolve $ref pointers in a JSON object (one level deep, relative to baseDir) ---
+function resolveRefs(obj, baseDir) {
+  if (Array.isArray(obj)) {
+    return obj.map((item) => resolveRefs(item, baseDir));
+  }
+  if (typeof obj === "object" && obj !== null) {
+    if (typeof obj["$ref"] === "string") {
+      const refPath = resolve(baseDir, obj["$ref"]);
+      const refContent = JSON.parse(readFileSync(refPath, "utf8"));
+      return resolveRefs(refContent, dirname(refPath));
+    }
+    const result = {};
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = resolveRefs(value, baseDir);
+    }
+    return result;
+  }
+  return obj;
+}
+
 // --- Main ---
 const spec = JSON.parse(readFileSync(OPENAPI_PATH, "utf8"));
-const docsJson = JSON.parse(readFileSync(DOCS_JSON_PATH, "utf8"));
+const rawDocsJson = JSON.parse(readFileSync(DOCS_JSON_PATH, "utf8"));
+const docsJson = resolveRefs(rawDocsJson, dirname(DOCS_JSON_PATH));
 
 const openapiRoutes = getOpenapiRoutes(spec);
 const docsJsonRoutes = getDocsJsonRoutes(docsJson);
@@ -146,7 +167,7 @@ if (extra.length > 0) {
 }
 
 if (missing.length === 0 && extra.length === 0) {
-  console.log("✓ All OpenAPI routes are covered in docs.json and vice versa.");
+  console.log("✓ All OpenAPI routes are covered in docs.json (and referenced files) and vice versa.");
 }
 
 if (missing.length > 0) {

--- a/scripts/check-openapi-routes-coverage.mjs
+++ b/scripts/check-openapi-routes-coverage.mjs
@@ -93,19 +93,27 @@ function normalizeRoute(route) {
 }
 
 // --- Resolve $ref pointers in a JSON object (one level deep, relative to baseDir) ---
-function resolveRefs(obj, baseDir) {
+function resolveRefs(obj, baseDir, refStack = new Set()) {
   if (Array.isArray(obj)) {
-    return obj.map((item) => resolveRefs(item, baseDir));
+    return obj.map((item) => resolveRefs(item, baseDir, refStack));
   }
   if (typeof obj === "object" && obj !== null) {
     if (typeof obj["$ref"] === "string") {
       const refPath = resolve(baseDir, obj["$ref"]);
+      if (refStack.has(refPath)) {
+        throw new Error(
+          `Circular $ref detected: ${[...refStack].join(" -> ")} -> ${refPath}`
+        );
+      }
       const refContent = JSON.parse(readFileSync(refPath, "utf8"));
-      return resolveRefs(refContent, dirname(refPath));
+      refStack.add(refPath);
+      const resolved = resolveRefs(refContent, dirname(refPath), refStack);
+      refStack.delete(refPath);
+      return resolved;
     }
     const result = {};
     for (const [key, value] of Object.entries(obj)) {
-      result[key] = resolveRefs(value, baseDir);
+      result[key] = resolveRefs(value, baseDir, refStack);
     }
     return result;
   }


### PR DESCRIPTION
## Summary

- The CI check `Require all OpenAPI routes in docs.json` was failing because navigation data (including OpenAPI routes) was moved from `docs.json` into `config/navigation.json`, referenced via a `$ref` pointer
- The script `check-openapi-routes-coverage.mjs` now resolves `$ref` pointers recursively before walking the tree, so it works regardless of how the navigation is split across files
- Updated the success message to mention "referenced files" for accuracy

Fixes #3567

## Test plan

- [x] Script passes with all 138 routes present
- [x] Script fails with exit code 1 when a route is removed from `navigation.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved API documentation coverage validation to expand referenced definitions so coverage includes routes pulled in via references.
  * Added detection for circular references to prevent infinite processing and surface errors when cycles exist.
  * Updated success messaging to clearly state coverage now accounts for both OpenAPI routes and referenced files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->