### PR TITLE
fix: add 4 missing redirects causing CI to always fail

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -276,6 +276,10 @@
     "destination": "/resources/self_hosting/configuration/overview"
   },
   {
+    "source": "/learn/self_hosting/configure_meilisearch_at_launch",
+    "destination": "/resources/self_hosting/configuration/overview"
+  },
+  {
     "source": "/learn/self_hosted/install_meilisearch_locally",
     "destination": "/resources/self_hosting/getting_started/install_locally"
   },
@@ -582,6 +586,10 @@
   {
     "source": "/learn/ai_powered_search/vector_search",
     "destination": "/capabilities/hybrid_search/getting_started"
+  },
+  {
+    "source": "/learn/ai_powered_search/overview",
+    "destination": "/capabilities/hybrid_search/overview"
   },
   {
     "source": "/learn/ai_powered_search/hybrid_search",
@@ -1228,6 +1236,10 @@
     "destination": "/capabilities/security/overview"
   },
   {
+    "source": "/learn/security",
+    "destination": "/capabilities/security/overview"
+  },
+  {
     "source": "/learn/advanced/meilisearch_vs_elasticsearch",
     "destination": "/resources/comparisons/elasticsearch"
   },
@@ -1589,6 +1601,10 @@
   },
   {
     "source": "/learn/fine_tuning_results/hybrid_search",
+    "destination": "/capabilities/hybrid_search/overview"
+  },
+  {
+    "source": "/learn/fine_tuning_results/vector_search",
     "destination": "/capabilities/hybrid_search/overview"
   },
   {


### PR DESCRIPTION
## Summary

The `check-missing-redirects` CI check was failing on every PR because 4 URLs with real traffic had no matching page or redirect. These were pre-existing gaps unrelated to any specific PR content.

Missing redirects added:

| Old URL | New destination |
|---------|----------------|
| `/learn/ai_powered_search/overview` | `/capabilities/hybrid_search/overview` |
| `/learn/security` | `/capabilities/security/overview` |
| `/learn/fine_tuning_results/vector_search` | `/capabilities/hybrid_search/overview` |
| `/learn/self_hosting/configure_meilisearch_at_launch` | `/resources/self_hosting/configuration/overview` |

## Test plan

- [x] JSON is valid
- CI `check-missing-redirects` should now pass on this PR and all subsequent PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated URL redirects for documentation pages related to self-hosted configuration, AI-powered search, and security features to point to their new locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->