### PR TITLE
Update sharding compatibility following v1.44.0

### DIFF
--- a/resources/self_hosting/sharding/overview.mdx
+++ b/resources/self_hosting/sharding/overview.mdx
@@ -118,7 +118,7 @@ Most Meilisearch features work transparently across a sharded network. The follo
 |---------|---------------------|-------|
 | Full-text search | Yes | Results merged and ranked across all remotes |
 | Filtering and sorting | Yes | Filters applied on each remote before merging |
-| Faceted search | Partial | Facet distribution in search results works across remotes, but the `/facet-search` endpoint does not support `useNetwork` |
+| Faceted search | Yes | Facet distribution in search results works across remotes, and the `/facet-search` endpoint supports `useNetwork` |
 | Hybrid/semantic search | Yes | Each remote runs its own vector search, results merged |
 | Geo search | Yes | Geographic filters and sorting work across remotes |
 | Multi-search | Yes | Works per query; `useNetwork` defaults to `true` when a network is configured |


### PR DESCRIPTION
## Description

https://github.com/meilisearch/meilisearch/pull/6375 introduces `useNetwork` for `PATCH /facet-search`.  This PR updates the compatiblity table in sharding overview to reflect this change.
