### PR TITLE
fix(postman): correct OpenAPI download link to meilisearch releases

### DIFF
--- a/getting_started/integrations/postman.mdx
+++ b/getting_started/integrations/postman.mdx
@@ -10,7 +10,7 @@ If you don't have Postman already, you can [download it here](https://www.postma
 
 ## Prerequisites
 
-Download the Meilisearch OpenAPI specification file from the [Meilisearch GitHub repository](https://github.com/meilisearch/open-api/releases/latest). Save it somewhere on your computer.
+Download the Meilisearch OpenAPI specification file from the [latest Meilisearch release on GitHub](https://github.com/meilisearch/meilisearch/releases/latest). Scroll down to the **Assets** section of the release and download `meilisearch-openapi.json`. Save it somewhere on your computer.
 
 ## Import the OpenAPI specification
 


### PR DESCRIPTION
Closes #3568

## Description

The Postman integration page told users to download the OpenAPI specification from `https://github.com/meilisearch/open-api/releases/latest`, but that repository is [archived](https://github.com/meilisearch/open-api) and its spec is outdated (last published at v1.15). The current OpenAPI spec ships as an asset (`meilisearch-openapi.json`) on each release of the main `meilisearch/meilisearch` repository, and there is no direct download URL.

This PR updates the **Prerequisites** section of [`getting_started/integrations/postman.mdx`](getting_started/integrations/postman.mdx) to:

- Link to https://github.com/meilisearch/meilisearch/releases/latest
- Explain that users must scroll to the **Assets** section and download `meilisearch-openapi.json` from there

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [ ] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) — N/A, no code samples touched

For external maintainers
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? Yes — Claude Code was used to make the wording change.
- [x] Have you made sure that the title is accurate and descriptive of the changes?