### PR TITLE
Add contextual menu (copy, view, ChatGPT, Claude, Cursor)

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -27,6 +27,15 @@
   "appearance": {
     "default": "dark"
   },
+  "contextual": {
+    "options": [
+      "copy",
+      "view",
+      "chatgpt",
+      "claude",
+      "cursor"
+    ]
+  },
   "navbar": {
     "primary": {
       "type": "button",


### PR DESCRIPTION
## Description

Enables Mintlify's [contextual menu](https://www.mintlify.com/docs/ai/contextual-menu) on every documentation page. Readers can now:

- **Copy page** as Markdown
- **View as Markdown**
- **Open in ChatGPT**
- **Open in Claude**
- **Connect to Cursor**

The menu appears in the page header by default.

Closes #3577

### Change

A single `contextual` block added to `docs.json`:

```json
"contextual": {
  "options": ["copy", "view", "chatgpt", "claude", "cursor"]
}
```

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [ ] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) — not applicable, config-only change

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes — Claude Code was used to look up the Mintlify config shape and edit `docs.json`.
- [x] Have you made sure that the title is accurate and descriptive of the changes?