### PR TITLE
Correct limitation on number of attributes

### DIFF
--- a/resources/help/known_limitations.mdx
+++ b/resources/help/known_limitations.mdx
@@ -55,9 +55,9 @@ If your query is `Hello - World`:
 `-` takes 1 position as it is a soft separator. You can read more about word separators in our [article about data types](/resources/internals/datatypes#string).
 </Note>
 
-## Maximum number of attributes per document
+## Maximum number of attributes per index
 
-**Limitation:** Meilisearch can index a maximum of **65,536 attributes per document**. If a document contains more than 65,536 attributes, an error will be thrown.
+**Limitation:** Meilisearch can index a maximum of **65,536 attributes per index**. If an index contains more than 65,536 attributes, an error will be thrown.
 
 **Explanation:** This limit is enforced for performance and storage reasons. Overly large internal data structures—resulting from documents with too many fields—lead to overly large databases on disk, and slower search performance.
 


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->

The docs stated that there was a max number of attributes per document, when this limitation is actually per index, not per document according to @Kerollmops.  

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

Corrects documentation regarding the hard limit on attributes in Meilisearch. The limitation is clarified to be per index (rather than per document), maintaining the numeric threshold of 65,536 attributes. When an index exceeds this limit, an error is thrown. The explanation emphasizes that this limit exists for performance and storage reasons to prevent overly large internal data structures and slower search performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/documentation/pull/3590?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->