### PR TITLE
feat: how to exclude search from analytics

### DIFF
--- a/capabilities/analytics/how_to/ignore_search_requests.mdx
+++ b/capabilities/analytics/how_to/ignore_search_requests.mdx
@@ -1,0 +1,18 @@
+---
+title: Exclude search requests from analytics
+sidebarTitle: Exclude search requests from analytics
+description: Learn how to improve your analytics by excluding search requests.
+---
+
+import CodeSamplesAnalyticsExcludeSearchRequests from "/snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx";
+
+You may want to exclude specific search requests from analytics in certain use cases, such as:
+
+- When initializing a page and displaying initial results to users
+- When building UI components such as category filters
+
+# Exclude searches from your analytics
+
+To exclude specific searches from your analytics, set the `analytics` parameter to `false`.
+
+<CodeSamplesAnalyticsExcludeSearchRequests />

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -298,7 +298,8 @@
                   "pages": [
                     "capabilities/analytics/how_to/bind_events_to_user",
                     "capabilities/analytics/how_to/track_click_events",
-                    "capabilities/analytics/how_to/track_conversion_events"
+                    "capabilities/analytics/how_to/track_conversion_events",
+                    "capabilities/analytics/how_to/ignore_search_requests"
                   ]
                 },
                 {

--- a/snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx
+++ b/snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx
@@ -1,0 +1,12 @@
+<CodeGroup>
+
+```bash cURL
+curl \
+  -X POST 'MEILISEARCH_URL/indexes/INDEX_NAME/search?analytics=false' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer DEFAULT_SEARCH_API_KEY' \
+  -H 'X-MS-USER-ID: MEILISEARCH_USER_ID' \
+  --data-binary '{}'
+```
+
+</CodeGroup>


### PR DESCRIPTION
## Description

Add documentation on how to exclude search requests from analytics

## Checklist

For internal Meilisearch team member only:
- [ ] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [ ] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR adds documentation that shows how to exclude individual search requests from analytics in Meilisearch and includes a runnable code sample.

The PR also contains contributor checklists in the pull request description: an internal checklist for Meilisearch team members (links to internal guidelines and a reminder to update code samples) and a disclosure checklist for external maintainers (AI tool disclosure and title confirmation).

## Changes

- **New documentation page**: capabilities/analytics/how_to/ignore_search_requests.mdx — frontmatter (title, sidebarTitle, description), guidance on when to exclude searches (e.g., initializing a page or building UI components like category filters), instruction to set the analytics parameter to false for requests, and an embedded generated code-sample component.
- **Navigation update**: config/navigation.json — added the new page under Analytics → How to.
- **Code sample**: snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx — added a CodeGroup with a cURL example for POST /indexes/{index}/search with analytics=false, including headers (Content-Type, Authorization using DEFAULT_SEARCH_API_KEY, X-MS-USER-ID) and an empty JSON body.

This change provides brief rationale, clear instruction, and a runnable example for excluding specific search requests from analytics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->