### PR TITLE
Fix frontend integration guides

### DIFF
--- a/getting_started/instant_meilisearch/docsearch.mdx
+++ b/getting_started/instant_meilisearch/docsearch.mdx
@@ -11,8 +11,6 @@ This tutorial will guide you through the steps of building a relevant and powerf
   - [Configuration file](#configuration-file)
   - [Run the scraper](#run-the-scraper)
 - [Integrate the search bar](#integrate-the-search-bar)
-  - [For VuePress documentation sites](#for-vuepress-documentation-sites)
-  - [For all kinds of documentation](#for-all-kinds-of-documentation)
 - [What's next?](#next-steps)
 
 ## Run a Meilisearch instance
@@ -108,63 +106,7 @@ We recommend running the scraper at each new deployment of your documentation us
 
 ## Integrate the search bar
 
-If your documentation is not a VuePress application, you can directly go to [this section](#for-all-kinds-of-documentation).
-
-### For VuePress documentation sites
-
-If you use VuePress for your documentation, we provide a [VuePress plugin](https://github.com/meilisearch/vuepress-plugin-meilisearch). This plugin is used in production in the Meilisearch documentation.
-
-In your VuePress project:
-
-<Tabs>
-<Tab title="yarn">
-
-```bash
-yarn add vuepress-plugin-meilisearch
-```
-
-</Tab>
-
-<Tab title="npm">
-
-```bash
-npm install vuepress-plugin-meilisearch
-```
-
-</Tab>
-</Tabs>
-
-In your `config.js` file:
-
-```js
-module.exports = {
-  plugins: [
-    [
-      "vuepress-plugin-meilisearch",
-      {
-        "hostUrl": "<your-meilisearch-host-url>",
-        "apiKey": "<your-meilisearch-api-key>",
-        "indexUid": "docs"
-      }
-    ],
-  ],
-}
-```
-
-The `hostUrl` and the `apiKey` fields are the credentials of the Meilisearch instance. Following on from this tutorial, they are respectively `MEILISEARCH_URL` and your `Default Search API Key`.
-
-`indexUid` is the index identifier in your Meilisearch instance in which your website content is stored. It has been defined in the [config file](#configuration-file).
-
-These three fields are mandatory, but more [optional fields are available](https://github.com/meilisearch/vuepress-plugin-meilisearch#customization) to customize your search bar.
-
-<Warning>
-Since the configuration file is public, we strongly recommend providing a key that can only access [the search endpoint](/reference/api/search/search-with-post) , such as the `Default Search API Key`, in a production environment.
-Read more about [Meilisearch security](/resources/self_hosting/security/basic_security).
-</Warning>
-
-### For all kinds of documentation
-
-If you don't use VuePress for your documentation, we provide a [front-end SDK](https://github.com/meilisearch/docs-searchbar.js) to integrate a powerful and relevant search bar to any documentation website.
+You can use [meilisearch-docsearch](https://github.com/tauri-apps/meilisearch-docsearch), a community-maintained front-end component, to integrate a search bar into any documentation website.
 
 ![Docxtemplater search bar updating results for "HTML"](/assets/images/tuto-searchbar-for-docs/docxtemplater-searchbar-demo.gif)
 _[Docxtemplater](https://docxtemplater.com/) search bar demo_
@@ -173,45 +115,39 @@ _[Docxtemplater](https://docxtemplater.com/) search bar demo_
 <!DOCTYPE html>
 <html>
   <head>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/docs-searchbar.js@{version}/dist/cdn/docs-searchbar.min.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/meilisearch-docsearch@latest/dist/index.css"
+    />
   </head>
-
   <body>
-    <input type="search" id="search-bar-input">
-    <script src="https://cdn.jsdelivr.net/npm/docs-searchbar.js@{version}/dist/cdn/docs-searchbar.min.js"></script>
+    <div id="docsearch"></div>
+
+    <script src="https://unpkg.com/meilisearch-docsearch@latest/dist/index.global.js"></script>
     <script>
-      docsSearchBar({
-        hostUrl: '<your-meilisearch-host-url>',
+      const { docsearch } = window.__docsearch_meilisearch__;
+      docsearch({
+        container: '#docsearch',
+        host: '<your-meilisearch-host-url>',
         apiKey: '<your-meilisearch-api-key>',
         indexUid: 'docs',
-        inputSelector: '#search-bar-input',
-        debug: true // Set debug to true if you want to inspect the dropdown
       });
     </script>
   </body>
 </html>
 ```
 
-<Note>
-Replace `{version}` in the CDN URLs above with the actual docs-searchbar.js version number, for example `2.0.5`. Check the [docs-searchbar.js releases page](https://github.com/meilisearch/docs-searchbar.js/releases) for the latest version.
-</Note>
-
-The `hostUrl` and the `apiKey` fields are the credentials of the Meilisearch instance. Following on from this tutorial, they are respectively `MEILISEARCH_URL` and your `Default Search API Key`.
+The `host` and the `apiKey` fields are the credentials of the Meilisearch instance. Following on from this tutorial, they are respectively `MEILISEARCH_URL` and your `Default Search API Key`.
 
 `indexUid` is the index identifier in your Meilisearch instance in which your website content is stored. It has been defined in the [config file](#configuration-file).
-`inputSelector` is the `id` attribute of the HTML search input tag.
+
+`container` is the CSS selector of the div element where the search box will be rendered. 
 
 <Warning>
 We strongly recommend providing a `Default Search API Key` in a production environment, which is enough to perform search requests.
 
 Read more about [Meilisearch security](/resources/self_hosting/security/basic_security).
 </Warning>
-
-The default behavior of this library fits perfectly for a documentation search bar, but you might need [some customizations](https://github.com/meilisearch/docs-searchbar.js#customization).
-
-<Note>
-For more concrete examples, you can check out this [basic HTML file](https://github.com/meilisearch/docs-searchbar.js/blob/main/playgrounds/html/index.html) or [this more advanced Vue file](https://github.com/meilisearch/vuepress-plugin-meilisearch/blob/main/MeiliSearchBox.vue).
-</Note>
 
 ## Next steps
 

--- a/getting_started/instant_meilisearch/javascript.mdx
+++ b/getting_started/instant_meilisearch/javascript.mdx
@@ -30,20 +30,11 @@ Create an `index.html` file with the following code:
       <div id="hits"></div>
     </div>
 
-    <!-- instant-meilisearch peer dependency -->
-    <script type="importmap">
-      {
-        "imports": {
-          "meilisearch": "https://cdn.jsdelivr.net/npm/meilisearch/dist/index.min.js"
-        }
-      }
-    </script>
+    <script src="https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/instant-meilisearch.umd.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/instantsearch.js@4"></script>
 
-    <script type="module">
-      import { instantMeilisearch } from 'https://cdn.jsdelivr.net/npm/@meilisearch/instant-meilisearch/dist/index.min.js'
-      import 'https://cdn.jsdelivr.net/npm/instantsearch.js@4'
-
-      const { searchClient } = instantMeilisearch(
+    <script>
+      const { searchClient } = instantMeiliSearch(
         'https://ms-adf78ae33284-106.lon.meilisearch.io',
         'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303'
       );
@@ -54,9 +45,7 @@ Create an `index.html` file with the following code:
       });
 
       search.addWidgets([
-        instantsearch.widgets.searchBox({
-          container: '#searchbox'
-        }),
+        instantsearch.widgets.searchBox({ container: '#searchbox' }),
         instantsearch.widgets.hits({
           container: '#hits',
           templates: {

--- a/getting_started/instant_meilisearch/react.mdx
+++ b/getting_started/instant_meilisearch/react.mdx
@@ -32,9 +32,9 @@ Use the following URL and API key to connect to a Meilisearch instance containin
 
 ```jsx
 import React from 'react';
-import { instantMeilisearch } from '@meilisearch/instant-meilisearch';
+import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 
-const { searchClient } = instantMeilisearch(
+const { searchClient } = instantMeiliSearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303'
 );
@@ -47,9 +47,9 @@ const { searchClient } = instantMeilisearch(
 ```jsx
 import React from 'react';
 import { InstantSearch } from 'react-instantsearch';
-import { instantMeilisearch } from '@meilisearch/instant-meilisearch';
+import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 
-const { searchClient } = instantMeilisearch(
+const { searchClient } = instantMeiliSearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303'
 );
@@ -74,10 +74,10 @@ Import the CSS library to style the search components.
 ```jsx
 import React from 'react';
 import { InstantSearch, SearchBox, InfiniteHits } from 'react-instantsearch';
-import { instantMeilisearch } from '@meilisearch/instant-meilisearch';
+import { instantMeiliSearch } from '@meilisearch/instant-meilisearch';
 import 'instantsearch.css/themes/satellite.css';
 
-const { searchClient } = instantMeilisearch(
+const { searchClient } = instantMeiliSearch(
   'https://ms-adf78ae33284-106.lon.meilisearch.io',
   'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303'
 );

--- a/getting_started/instant_meilisearch/vue.mdx
+++ b/getting_started/instant_meilisearch/vue.mdx
@@ -49,12 +49,12 @@ Add the code below to the `App.vue` file.
 </template>
 
 <script>
-import { instantMeilisearch } from "@meilisearch/instant-meilisearch";
+import { instantMeiliSearch } from "@meilisearch/instant-meilisearch";
 
 export default {
   data() {
     return {
-      searchClient: instantMeilisearch(
+      searchClient: instantMeiliSearch(
         'https://ms-adf78ae33284-106.lon.meilisearch.io',
         'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
       ).searchClient,
@@ -91,13 +91,13 @@ Import the CSS library to style the search components.
 </template>
 
 <script>
-import { instantMeilisearch } from "@meilisearch/instant-meilisearch";
+import { instantMeiliSearch } from "@meilisearch/instant-meilisearch";
 import "instantsearch.css/themes/satellite-min.css";
 
 export default {
 data() {
     return {
-    searchClient: instantMeilisearch(
+    searchClient: instantMeiliSearch(
         'https://ms-adf78ae33284-106.lon.meilisearch.io',
         'a63da4928426f12639e19d62886f621130f3fa9ff3c7534c5d179f0f51c4f303',
     ).searchClient,


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->
Fixes #3165 

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR fixes frontend integration documentation and examples by updating code snippets and dependencies across multiple Instant Meilisearch integration guides. The changes address issue `#3165`, which reported that example codes were missing required parameters and contained deprecated references.

## Changes

### Documentation Updates

**docsearch.mdx**
- Removed the prior VuePress-specific branching guidance
- Updated HTML integration example to use the community-maintained `meilisearch-docsearch` component
- Replaced deprecated `docs-searchbar.js` references with `meilisearch-docsearch` CDN assets from `unpkg`
- Updated initialization to include required parameters: `host`, `apiKey`, and `indexUid`
- Removed version-substitution notes and `inputSelector` configuration discussion

**javascript.mdx**
- Updated the quick example from ES module imports (importmap-based) to CDN UMD builds
- Changed to use `instant-meilisearch.umd.min.js` and `instantsearch.js@4` from CDN
- Simplified `searchBox` widget configuration to use shorthand factory syntax

**react.mdx**
- Updated import and usage from `instant-meilisearch` to `instantMeiliSearch`
- Modified `searchClient` initialization to use the correct `instantMeiliSearch` API call pattern

**vue.mdx**
- Corrected capitalization: `instantMeilisearch` → `instantMeiliSearch`
- Updated code snippets in both initial and subsequent `App.vue` examples
- Adjusted indentation formatting in `searchClient` initialization

## Impact
All four documentation files now include correct API references and initialization patterns, enabling users to properly implement frontend search integration with the required public API key parameter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->