### PR TITLE
docs: clarify dump/snapshot staging uses TMPDIR

### DIFF
--- a/resources/self_hosting/configuration/reference.mdx
+++ b/resources/self_hosting/configuration/reference.mdx
@@ -125,6 +125,10 @@ Dumpless upgrade are not currently atomic. It is possible some processes fail an
 
 Sets the directory where Meilisearch will create dump files.
 
+<Note>
+`--dump-dir` only controls where the final compressed `.dump` file is written. While creating a dump, Meilisearch first builds an uncompressed copy of your data in a temporary staging directory. This directory is located in the path indicated by the `TMPDIR` environment variable, defaulting to `/tmp` on most systems, and not in `--dump-dir`. On instances with a large database and a small `/tmp` partition, this can cause `No space left on device` errors even when `--dump-dir` points to a volume with plenty of free space. To avoid this, set `TMPDIR` to a directory on a volume with enough space for an uncompressed copy of your data before launching Meilisearch.
+</Note>
+
 [Learn more about creating dumps](/reference/api/management/create-dump).
 
 ### Import dump
@@ -292,6 +296,10 @@ When using the configuration file, it is also possible to explicitly pass a bool
 **Expected value**: a filepath pointing to a valid directory
 
 Sets the directory where Meilisearch will store snapshots.
+
+<Note>
+`--snapshot-dir` only controls where the final `.snapshot` file is written. While creating a snapshot, Meilisearch first copies a full flat copy of your database into a temporary staging directory. This directory is located in the path indicated by the `TMPDIR` environment variable, defaulting to `/tmp` on most systems, and not in `--snapshot-dir`. On instances with a large database and a small `/tmp` partition, this can cause `No space left on device` errors even when `--snapshot-dir` points to a volume with plenty of free space. To avoid this, set `TMPDIR` to a directory on a volume with enough space for a full copy of your database before launching Meilisearch.
+</Note>
 
 ### Uncompressed snapshots <NoticeTag type="experimental" label="experimental" />
 

--- a/resources/self_hosting/configuration/reference.mdx
+++ b/resources/self_hosting/configuration/reference.mdx
@@ -298,7 +298,7 @@ When using the configuration file, it is also possible to explicitly pass a bool
 Sets the directory where Meilisearch will store snapshots.
 
 <Note>
-`--snapshot-dir` only controls where the final `.snapshot` file is written. While creating a snapshot, Meilisearch first copies a full flat copy of your database into a temporary staging directory. This directory is located in the path indicated by the `TMPDIR` environment variable, defaulting to `/tmp` on most systems, and not in `--snapshot-dir`. On instances with a large database and a small `/tmp` partition, this can cause `No space left on device` errors even when `--snapshot-dir` points to a volume with plenty of free space. To avoid this, set `TMPDIR` to a directory on a volume with enough space for a full copy of your database before launching Meilisearch.
+`--snapshot-dir` only controls where the final `.snapshot` file is written. While creating a snapshot, Meilisearch first copies your entire database (the raw database files) into a temporary staging directory. This directory is located in the path indicated by the `TMPDIR` environment variable, defaulting to `/tmp` on most systems, and not in `--snapshot-dir`. On instances with a large database and a small `/tmp` partition, this can cause `No space left on device` errors even when `--snapshot-dir` points to a volume with plenty of free space. To avoid this, set `TMPDIR` to a directory on a volume with enough space for a full copy of your database before launching Meilisearch.
 </Note>
 
 ### Uncompressed snapshots <NoticeTag type="experimental" label="experimental" />


### PR DESCRIPTION
## Description

Creating a dump or snapshot first builds an uncompressed staging copy in the directory pointed to by TMPDIR (default /tmp), not in --dump-dir or --snapshot-dir. On instances with a large database and a small /tmp partition this causes "No space left on device" even when the configured output directory has free space. Document the behavior and the TMPDIR fix.

So i struggled with this one for quite a while until realising the TMPDIR nuance so think it should be part of the docs at least.

I used Claude code for partial investigation of what is happening with TMPDIR.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Documentation Clarification: Dump and Snapshot Staging Behavior

This documentation PR clarifies how Meilisearch handles dump and snapshot creation, particularly around where temporary staging files are written.

### What Changed
- Updated `resources/self_hosting/configuration/reference.mdx` with new notes for `--dump-dir`/`MEILI_DUMP_DIR` and `--snapshot-dir`/`MEILI_SNAPSHOT_DIR`.
- Clarified that these options only control the location of the final compressed dump/snapshot output files.

### Key Points
- During dump/snapshot creation, Meilisearch first creates an uncompressed staging copy in a temporary directory under `TMPDIR` (defaulting to `/tmp`).
- As a result, users can encounter “No space left on device” errors when `/tmp` is too small—even if the configured dump/snapshot output directory has sufficient free space.
- The documentation provides guidance to resolve storage issues by setting `TMPDIR` to a filesystem with adequate capacity.

### Technical Details
- **Files changed**: `resources/self_hosting/configuration/reference.mdx`
- **Lines changed**: +8/-0
- **Impact**: Documentation only; no code behavior changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->