### PR TITLE
docs: add changelog for v1.46 and v1.47

### DIFF
--- a/changelog/changelog.mdx
+++ b/changelog/changelog.mdx
@@ -26,7 +26,7 @@ Meilisearch now exposes additional Prometheus metrics, including document throug
 
 **Search pipeline refactor**
 
-The search pipeline has been refactored so that all search requests run through a unified federated search implementation under the hood. This introduces a small breaking change: some error messages have been updated and a few error codes have changed (for example, `MultiSearchError` and `SearchError` may be swapped in certain cases).
+The search pipeline has been refactored so that all search requests run through a unified federated search implementation under the hood. This introduces a small breaking change: some error messages have been updated and a few error codes have changed (for example, in certain cases `MultiSearchError` may now be returned where `SearchError` was previously returned, and vice versa). If your application inspects error codes, review your error handling when upgrading.
 
 **Bug fixes**
 

--- a/changelog/changelog.mdx
+++ b/changelog/changelog.mdx
@@ -4,6 +4,78 @@ description: "New features and improvements in Meilisearch"
 rss: true
 ---
 
+<Update label="v1.47" description="2026-06-15">
+
+## New Features
+
+**Search personalization on federated search**
+
+You can now use [search personalization](/capabilities/personalization/overview) in federated search requests. As with `page`/`hitsPerPage` and `limit`/`offset`, the personalization option must be set inside the `federation` object. If you place it on an individual query instead, Meilisearch returns an error reminding you to move it into `federation`.
+
+## Improvements
+
+**The new settings indexer is now feature complete**
+
+The new settings indexer now handles tokenizer-related settings, including locales, dictionary, synonyms, stop words, separator tokens, and non-separator tokens. With this addition, all settings tasks are handled by the new indexer unless you set `MEILI_EXPERIMENTAL_NO_EDITION_2024_FOR_SETTINGS=true`. This brings better scaling behavior, much faster task cancellation, and a more precise progress view when updating settings.
+
+**More observability metrics**
+
+Meilisearch now exposes additional Prometheus metrics, including document throughput, making it easier to monitor indexing performance and debug your instance.
+
+## Other
+
+**Search pipeline refactor**
+
+The search pipeline has been refactored so that all search requests run through a unified federated search implementation under the hood. This introduces a small breaking change: some error messages have been updated and a few error codes have changed (for example, `MultiSearchError` and `SearchError` may be swapped in certain cases).
+
+**Bug fixes**
+
+- Placing `attributeRank` or `wordPosition` before `words` in `rankingRules` no longer removes hits from the response.
+- `searchCutoffMs` is no longer ignored under certain conditions when embedding documents.
+- Remote federated search and `useNetwork: true` requests no longer fail when a filter contains a single quote (`'`).
+
+[Find more information on GitHub](https://github.com/meilisearch/meilisearch/releases/tag/v1.47.0)
+
+</Update>
+
+<Update label="v1.46" description="2026-06-08">
+
+## New Features
+
+**Queue document fetch routes (experimental)**
+
+A new experimental feature, `queueDocumentsFetch`, makes the `GET /indexes/:uid/documents` and `POST /indexes/:uid/documents/fetch` routes wait in the search queue when no thread is available to process them, improving stability under heavy load.
+
+## Improvements
+
+**Expanded new settings indexer support**
+
+The new settings indexer now handles more parameters, so changing them no longer requires a full re-indexing:
+
+- Exact words and disable-on-words
+- Exact and disable settings on numbers
+- Prefix search settings (prefix computation)
+
+This makes the engine more efficient when updating these settings.
+
+## Other
+
+**Fixed deletion batching regression**
+
+Fixed a regression introduced in v1.45.0 affecting the auto-batching of deletion by filter together with document additions and updates. This operation is now batched correctly.
+
+**Fixed S3 multipart upload part size**
+
+Meilisearch now respects the configured multipart part size when uploading snapshots to S3, never creating a part larger than the defined size (except for the last part).
+
+**Fixed panic on incomplete filters**
+
+An incomplete filter now returns an error instead of causing an internal panic.
+
+[Find more information on GitHub](https://github.com/meilisearch/meilisearch/releases/tag/v1.46.0)
+
+</Update>
+
 <Update label="v1.45" description="2026-05-26">
 
 ## Improvements


### PR DESCRIPTION
## What changed

Adds changelog entries for the **v1.46** and **v1.47** Meilisearch releases to `changelog/changelog.mdx`.

### v1.47 (2026-06-15)
- **New:** Search personalization on federated search (must be set inside the `federation` object)
- **Improvements:** The new settings indexer is now feature complete (tokenizer-related settings); additional Prometheus observability metrics including document throughput
- **Other:** Search pipeline refactor (small breaking change to some error messages/codes) plus user-facing fixes for `rankingRules` ordering, `searchCutoffMs`, and filters containing single quotes in remote/networked search

### v1.46 (2026-06-08, merges v1.46.0 + v1.46.1)
- **New:** `queueDocumentsFetch` experimental feature
- **Improvements:** Expanded new settings indexer parameter support (exact words, disable-on-words, exact/disable on numbers, prefix search settings)
- **Other:** Fixed the v1.45.0 deletion-batching regression, S3 multipart part size, and incomplete-filter panic

## Why

Keeps the changelog up to date with the latest engine releases. The changelog had only reached v1.45, so v1.46 was added alongside v1.47 to keep the timeline contiguous (matching how the generator groups by minor version).

## Notes for reviewers

- The `generate-changelog` script requires `ANTHROPIC_API_KEY`, which was unavailable, so entries were authored manually from the GitHub release notes following the existing format and the script's filtering rules (excluding CI/dependency/internal-maintenance items).
- No navigation change needed: the Changelog tab points to the single `changelog/changelog` page, which renders all `<Update>` blocks as a timeline.
- Pure internal/CI/dependency items were excluded; a few user-facing bug fixes are kept under "Other", consistent with the existing v1.45 entry.
- No em dashes used, per the documentation writing style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changelog additions for Meilisearch v1.47 and v1.46

Adds two consecutive release entries to `changelog/changelog.mdx`:

### v1.47 (2026-06-15)
- Search personalization support in federated search
- Settings indexer marked as feature complete with tokenizer-related settings support
- Additional Prometheus observability metrics, including document throughput
- Search pipeline refactor with updated/bundled error behavior
- Bug fixes for `rankingRules` ordering, `searchCutoffMs`, and filters with single quotes in remote/networked search

### v1.46 (2026-06-08)
- New `queueDocumentsFetch` experimental feature
- Expanded settings indexer parameter support for exact words, disable-on-words, exact/disable on numbers, and prefix search settings
- Bug fixes for v1.45.0 deletion-batching regression, S3 multipart part size, and incomplete-filter panic

Both releases are added at the top of the changelog to maintain a contiguous timeline from the previous v1.45 entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->