### PR TITLE
Clarify reranking scope, placeholder search limits, and Cohere constraints

### DIFF
--- a/capabilities/personalization/getting_started/personalized_search.mdx
+++ b/capabilities/personalization/getting_started/personalized_search.mdx
@@ -58,7 +58,7 @@ If you need a genuinely personalized candidate set for a homepage feed or infini
 
 **Use `userContext` as `q` with full semantic search.** Set `semanticRatio: 1` and pass the `userContext` string directly as `q`. In this case, the `personalize` parameter is not needed: the semantic retrieval already personalizes which documents are returned. Reserve the `personalize` parameter for when the user has typed their own query.
 
-**Run one search per interest area.** Generate a short list of distinct interest terms from the user profile and run a [multi-search](/references/multi_search) with one semantic query per term. Each query gets its own retrieval pass, so the merged result pool naturally covers more variety. This produces more diverse results but uses more queries.
+**Run one search per interest area.** Generate a short list of distinct interest terms from the user profile and run a [multi-search](/references/api/multi-search/perform-a-multi-search) with one semantic query per term. Each query gets its own retrieval pass, so the merged result pool naturally covers more variety. This produces more diverse results but uses more queries.
 
 **Increase `limit`.** If you keep `q` empty, a higher `limit` gives the reranker a wider fixed pool to reorder within. This is the lowest-effort option but does not change which documents are retrieved.
 

--- a/capabilities/personalization/getting_started/personalized_search.mdx
+++ b/capabilities/personalization/getting_started/personalized_search.mdx
@@ -56,11 +56,11 @@ This has two consequences worth understanding before building a personalized fee
 
 If you need a genuinely personalized candidate set for a homepage feed or infinite scroll, consider these alternatives:
 
-**Use `userContext` as `q` with full semantic search.** Set `semanticRatio: 1` and pass the `userContext` string directly as `q`. In this case, the `personalize` parameter is not needed: the semantic retrieval already personalizes which documents are returned. Reserve the `personalize` parameter for when the user has typed their own query.
+- **Use `userContext` as `q` with full semantic search.** Set `semanticRatio: 1` and pass the `userContext` string directly as `q`. In this case, the `personalize` parameter is not needed: the semantic retrieval already personalizes which documents are returned. Reserve the `personalize` parameter for when the user has typed their own query.
 
-**Run one search per interest area.** Generate a short list of distinct interest terms from the user profile and run a [multi-search](/references/api/multi-search/perform-a-multi-search) with one semantic query per term. Each query gets its own retrieval pass, so the merged result pool naturally covers more variety. This produces more diverse results but uses more queries.
+- **Run one search per interest area.** Generate a short list of distinct interest terms from the user profile and run a [multi-search](/references/api/multi-search/perform-a-multi-search) with one semantic query per term. Each query gets its own retrieval pass, so the merged result pool naturally covers more variety. This produces more diverse results but uses more queries.
 
-**Increase `limit`.** If you keep `q` empty, a higher `limit` gives the reranker a wider fixed pool to reorder within. This is the lowest-effort option but does not change which documents are retrieved.
+- **Increase `limit`.** If you keep `q` empty, a higher `limit` gives the reranker a wider fixed pool to reorder within. This is the lowest-effort option but does not change which documents are retrieved.
 
 ## Next steps
 

--- a/capabilities/personalization/getting_started/personalized_search.mdx
+++ b/capabilities/personalization/getting_started/personalized_search.mdx
@@ -27,6 +27,41 @@ Submit a search query and include the `personalize` search parameter. `personali
 
 <CodeSamplesPersonalizationSearch1 />
 
+## Reranking scope and the `limit` parameter
+
+The reranker only sees the documents that Meilisearch returns for a given query. This means `limit` directly controls how many documents the reranker can choose from.
+
+If you set `limit` to 20, the reranker picks the best order from those 20 documents. It cannot promote a document that Meilisearch did not return. Increasing `limit` gives the reranker a wider pool to work with, but also increases latency and the number of tokens sent to the reranking model.
+
+A `limit` between 20 and 100 is a reasonable starting point for most personalized search use cases. Go higher if ranking quality matters more than latency for your application.
+
+## Limits
+
+Personalized search is subject to the following [Cohere reranking limits](https://docs.cohere.com/v2/docs/reranking-best-practices#max-number-of-documents):
+
+- `userContext` + `q` combined must stay under 2048 tokens
+- Each document sent to the reranker can be at most 32,664 tokens
+- The reranker accepts at most 10,000 documents per request, so `limit` cannot usefully exceed 10,000
+
+As a rough guide, one word is about 2 to 3 tokens and a paragraph is about 128 tokens.
+
+## Personalized feeds and placeholder search
+
+When `q` is empty, Meilisearch returns a deterministic set of documents based on ranking rules and filters. The `userContext` can only reorder that fixed set. It cannot change which documents are retrieved.
+
+This has two consequences worth understanding before building a personalized feed:
+
+- Two very different `userContext` values will return the same documents, just in a different order, because the underlying candidate pool is the same for both calls
+- Two slightly different phrasings of the same `userContext` can produce different result orders, because the reranker is sensitive to wording
+
+If you need a genuinely personalized candidate set for a homepage feed or infinite scroll, consider these alternatives:
+
+**Use `userContext` as `q` with full semantic search.** Set `semanticRatio: 1` and pass the `userContext` string directly as `q`. In this case, the `personalize` parameter is not needed: the semantic retrieval already personalizes which documents are returned. Reserve the `personalize` parameter for when the user has typed their own query.
+
+**Run one search per interest area.** Generate a short list of distinct interest terms from the user profile and run a [multi-search](/references/multi_search) with one semantic query per term. Each query gets its own retrieval pass, so the merged result pool naturally covers more variety. This produces more diverse results but uses more queries.
+
+**Increase `limit`.** If you keep `q` empty, a higher `limit` gives the reranker a wider fixed pool to reorder within. This is the lowest-effort option but does not change which documents are retrieved.
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/capabilities/personalization/overview.mdx
+++ b/capabilities/personalization/overview.mdx
@@ -22,7 +22,7 @@ For example, in an e-commerce site, someone who often shops for sportswear might
 1. Generate a user profile: `"The user prefers genres like Documentary, Music, Drama"`
 2. Submit the profile together with the search request
 3. Meilisearch retrieves documents based on the query as usual
-4. The re-ranking model reorders results based on the user profile
+4. The re-ranking model reorders results based on the user profile, within the set of documents returned by the search
 
 ## Recommendations
 


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->
Fixes #3587 
Fixes #3580 

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This documentation PR clarifies key aspects of Meilisearch's personalization features by updating two documentation pages to address issues `#3580` and `#3587`.

## Changes

**`capabilities/personalization/getting_started/personalized_search.mdx`**
- Added "Reranking scope and the `limit` parameter" section explaining that the reranker only sees the documents that Meilisearch returns for the query, and that `limit` directly controls the size of the reranking pool. Provides guidance on choosing a reasonable `limit` value (20-100 as a starting point).
- Added "Limits" subsection documenting Cohere reranking constraints:
  - Combined `userContext` + `q` must stay under 2048 tokens
  - Each document sent to the reranker can be at most 32,664 tokens
  - Maximum 10,000 documents per request, so `limit` cannot usefully exceed 10,000
  - Includes token estimation guidance (approximately 2-3 tokens per word, 128 tokens per paragraph)
- Added "Personalized feeds and placeholder search" section clarifying that when `q` is empty, Meilisearch returns a deterministic candidate set and `userContext` can only reorder those candidates, not change which documents are retrieved. Provides three alternative strategies:
  - Use `userContext` as `q` with `semanticRatio: 1`
  - Run multi-search per interest area
  - Increase `limit`

**`capabilities/personalization/overview.mdx`**
- Updated the "How it works" section to clarify that the re-ranking model reorders results based on the user profile within the set of documents returned by the search.

## Impact

These changes provide users with essential information about reranking behavior, Cohere API constraints, and practical strategies for building personalized feeds, reducing confusion about placeholder search behavior and token limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->