### PR TITLE
fix: missing analytics code sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1290,6 +1290,13 @@ analytics_event_bind_event_1: |-
       "objectId": "0",
       "position": 0
     }'
+analytics_exclude_search_requests: |-
+  curl \
+    -X POST 'MEILISEARCH_URL/indexes/INDEX_NAME/search?analytics=false' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Bearer DEFAULT_SEARCH_API_KEY' \
+    -H 'X-MS-USER-ID: MEILISEARCH_USER_ID' \
+    --data-binary '{}'
 distinct_attribute_guide_filterable_1: |-
   curl \
     -X PUT 'MEILISEARCH_URL/indexes/products/settings/filterable-attributes' \

--- a/snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx
+++ b/snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx
@@ -1,0 +1,11 @@
+<CodeGroup>
+
+```bash cURL
+curl \
+  -X POST 'MEILISEARCH_URL/indexes/INDEX_NAME/search?analytics=false' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer DEFAULT_SEARCH_API_KEY' \
+  -H 'X-MS-USER-ID: MEILISEARCH_USER_ID' \
+  --data-binary '{}'
+```
+</CodeGroup>


### PR DESCRIPTION
## Description

Add missing code sample for analytics (exclude search requests)

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Analytics Code Sample for Excluding Search Requests

Added a missing code sample demonstrating how to exclude search requests from analytics tracking.

### Changes

- **New code sample entry**: `analytics_exclude_search_requests` in `.code-samples.meilisearch.yaml`
- **New MDX snippet**: `code_samples_analytics_exclude_search_requests.mdx` containing a cURL example

The code sample demonstrates a POST request to `MEILISEARCH_URL/indexes/INDEX_NAME/search` with the `analytics=false` query parameter, including standard headers (Content-Type, Authorization with DEFAULT_SEARCH_API_KEY, and X-MS-USER-ID) and an empty JSON body.

### Files Modified
- `.code-samples.meilisearch.yaml` (+7 lines)
- `snippets/generated-code-samples/code_samples_analytics_exclude_search_requests.mdx` (+11 lines)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->