### PR TITLE
Add foreign filters route limitations

### DIFF
--- a/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx
+++ b/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx
@@ -180,6 +180,18 @@ If a foreign filter returns more than 100 matching documents from the target ind
 - Break into multiple queries with narrower filters
 - Consider denormalization if filtering patterns require very broad queries
 
+## Routes supporting Foreign filters
+
+You can use foreign filters only on document retrieval routes:
+- GET/POST `/indexes/{index_uid}/search`
+- POST `/indexes/{index_uid}/facet-search`
+- GET/POST `/indexes/{index_uid}/similar`
+- GET `/indexes/{index_uid}/documents`
+- POST `/indexes/{index_uid}/documents/fetch`
+- POST `/multi-search`
+
+Other routes that accept filters do not support foreign filters. Meilisearch returns an error if you use `_foreign()` on them.
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx
+++ b/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx
@@ -180,7 +180,7 @@ If a foreign filter returns more than 100 matching documents from the target ind
 - Break into multiple queries with narrower filters
 - Consider denormalization if filtering patterns require very broad queries
 
-## Routes supporting Foreign filters
+## Routes supporting foreign filters
 
 You can use foreign filters only on document retrieval routes:
 - GET/POST `/indexes/{index_uid}/search`


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Documentation Updates**
  * Added a new subsection, **“Routes supporting foreign filters,”** to advanced filtering-by-joined-data documentation.
  * Clarifies that `_foreign()` is supported only on these endpoints: `/search`, `/facet-search`, `/similar`, `/documents`, `/documents/fetch`, and `/multi-search`.
  * States that `_foreign()` on other filter-capable routes will result in an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->