### PR TITLE
Add v1.48 changelog entry

### DIFF
--- a/changelog/changelog.mdx
+++ b/changelog/changelog.mdx
@@ -4,6 +4,80 @@ description: "New features and improvements in Meilisearch"
 rss: true
 ---
 
+<Update label="v1.48" description="2026-06-22">
+
+## New Features
+
+### Render Template Route (Experimental)
+
+A new `POST /render-template` route lets you test document templates and fragments before and after configuring an embedder. This is useful for validating template syntax and seeing how your documents will be rendered.
+
+Before using this route, enable the `renderRoute` experimental feature:
+
+```bash
+PATCH /experimental-features
+```
+
+```json
+{
+  "renderRoute": true
+}
+```
+
+The route accepts a template and optional input, and returns both the unrendered template and the rendered result:
+
+```http
+POST /render-template
+```
+
+```json
+{
+  "template": {
+    "kind": "documentTemplate",
+    "indexUid": "movies",
+    "embedder": "myMoviesEmbedder"
+  },
+  "input": {
+    "kind": "indexDocument",
+    "indexUid": "movies",
+    "id": "2"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "template": "A movie titled {{doc.title}} whose description starts with {{doc.overview|truncatewords:10}}",
+  "rendered": "A movie titled Ariel whose description starts with Taisto Kasurinen is a Finnish coal miner whose father has..."
+}
+```
+
+You can render templates from embedders, chat settings, or inline templates. You can also provide input from index documents, inline documents, or search queries. If `input` is `null`, the route returns just the template without rendering it.
+
+## Improvements
+
+### Foreign Filters Limited to Retrieval Routes
+
+Foreign filters are now only supported on retrieval routes (search, get document, etc.). They are no longer accepted on routes that write or modify documents. This prevents unexpected behavior when using foreign filters in contexts where they don't make sense.
+
+The following routes no longer support foreign filters:
+
+- Edit documents by function: `POST /indexes/{index_uid}/documents/edit`
+- Delete documents by filter: `POST /indexes/{index_uid}/documents/delete`
+- Export to a remote Meilisearch: `POST /export`
+
+## Other
+
+### Documents Fetch Queue Feature Inverted
+
+The `queueDocumentsFetch` experimental feature has been replaced with `disableDocumentsFetchQueue`. This changes the behavior from opt-in to opt-out. The documents fetch queue is now enabled by default and you must explicitly disable it if needed.
+
+[Find more information on GitHub](https://github.com/meilisearch/meilisearch/releases/tag/v1.48.0)
+
+</Update>
+
 <Update label="v1.47" description="2026-06-15">
 
 ## New Features


### PR DESCRIPTION
## What changed

Adds the **v1.48** entry to the changelog ([changelog/changelog.mdx](https://github.com/meilisearch/documentation/blob/qdequele/cool-shaw-1ef8c9/changelog/changelog.mdx)), generated from the [meilisearch v1.48.0 release](https://github.com/meilisearch/meilisearch/releases/tag/v1.48.0).

- **New Features** — Render Template Route (experimental): the new `POST /render-template` route, gated by the `renderRoute` experimental feature, with enable command and a request/response example.
- **Improvements** — Foreign filters are now limited to retrieval routes (no longer accepted on edit-by-function, delete-by-filter, or export).
- **Other** — `queueDocumentsFetch` replaced by `disableDocumentsFetchQueue` (queued document fetch is now opt-out).

## Why

Routine changelog update for the latest engine release, produced via `npm run generate-changelog`.

## Notes for reviewers

- Generated by the existing script, which summarizes the GitHub release notes via Claude. Internal CI, dependency bumps, and the Ollama test fix were excluded per the script's rules.
- One manual fix on top of the generated output: replaced an em dash with a period to comply with the docs no-em-dash rule.
- No navigation change needed — the Changelog tab points to the single `changelog/changelog` page that holds all `<Update>` blocks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR adds the v1.48 changelog entry to the documentation repository by documenting changes from the meilisearch v1.48.0 release.

## Changes

**changelog/changelog.mdx**
- Added a new v1.48 release entry (dated 2026-06-22) documenting:
  - **New Features**: Introduces an experimental `POST /render-template` endpoint for testing document templates and fragments, gated by the `renderRoute` experimental feature flag, with enablement instructions and example request/response
  - **Improvements**: Foreign filters are now restricted to retrieval routes only and are no longer accepted on edit-by-function, delete-by-filter, or export operations
  - **Other**: `queueDocumentsFetch` has been replaced by `disableDocumentsFetchQueue`, inverting the behavior from opt-in to opt-out (document fetch queuing is now enabled by default)

The changelog entry was generated using the `npm run generate-changelog` script, with one manual edit to replace an em dash with a period per documentation style guidelines.

Lines changed: +74/-0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->