### PR TITLE
Use absolute URL for download links

### DIFF
--- a/capabilities/filtering_sorting_faceting/how_to/filter_and_sort_by_date.mdx
+++ b/capabilities/filtering_sorting_faceting/how_to/filter_and_sort_by_date.mdx
@@ -45,7 +45,7 @@ As an example, consider a database of video games. In this dataset, the release 
 
 </CodeGroup>
 
-Once all documents in your dataset have a date field, [index your data](/reference/api/documents/add-or-replace-documents) as usual. The example below adds a <a id="downloadVideogames" href="/assets/datasets/videogames.json" download="videogames.json">videogame dataset</a> to a `games` index:
+Once all documents in your dataset have a date field, [index your data](/reference/api/documents/add-or-replace-documents) as usual. The example below adds a <a id="downloadVideogames" href="https://www.meilisearch.com/docs/assets/datasets/videogames.json" download="videogames.json">videogame dataset</a> to a `games` index:
 
 <CodeSamplesDateGuideIndex1 />
 

--- a/capabilities/filtering_sorting_faceting/how_to/filter_with_facets.mdx
+++ b/capabilities/filtering_sorting_faceting/how_to/filter_with_facets.mdx
@@ -13,7 +13,7 @@ In Meilisearch, facets are a specialized type of filter. This guide shows you ho
 
 ## Configure facet index settings
 
-First, create a new index using this <a id="downloadBooks" href="/assets/datasets/books.json" download="books.json">books dataset</a>. Documents in this dataset have the following fields:
+First, create a new index using this <a id="downloadBooks" href="https://www.meilisearch.com/docs/assets/datasets/books.json" download="books.json">books dataset</a>. Documents in this dataset have the following fields:
 
 <CodeGroup>
 

--- a/capabilities/multi_search/getting_started/federated_search.mdx
+++ b/capabilities/multi_search/getting_started/federated_search.mdx
@@ -13,7 +13,7 @@ In this tutorial you will see how to create separate indexes containing differen
 
 ## Create three indexes
 
-Download the following datasets: <a href="/assets/datasets/crm-chats.json">`crm-chats.json`</a>, <a href="/assets/datasets/crm-profiles.json">`crm-profiles.json`</a>, and <a href="/assets/datasets/crm-tickets.json">`crm-tickets.json`</a> containing data from a fictional CRM application.
+Download the following datasets: <a href="https://www.meilisearch.com/docs/assets/datasets/crm-chats.json" download="crm-chats.json">`crm-chats.json`</a>, <a href="https://www.meilisearch.com/docs/assets/datasets/crm-profiles.json" download="crm-profiles.json">`crm-profiles.json`</a>, and <a href="https://www.meilisearch.com/docs/assets/datasets/crm-tickets.json" download="crm-tickets.json">`crm-tickets.json`</a> containing data from a fictional CRM application.
 
 Add the datasets to Meilisearch and create three separate indexes, `profiles`, `chats`, and `tickets`:
 

--- a/capabilities/personalization/getting_started/recommendations.mdx
+++ b/capabilities/personalization/getting_started/recommendations.mdx
@@ -12,7 +12,7 @@ This guide requires a configured embedder. If you haven't set one up yet, see th
 
 ## Create an index with embeddings
 
-Create an index called `movies` and add this <a href="/assets/datasets/movies.json" download="movies.json">`movies.json`</a> dataset to it. If necessary, consult the [getting started](/getting_started/first_project) for more instructions on index creation.
+Create an index called `movies` and add this <a href="https://www.meilisearch.com/docs/assets/datasets/movies.json" download="movies.json">`movies.json`</a> dataset to it. If necessary, consult the [getting started](/getting_started/first_project) for more instructions on index creation.
 
 Then configure an OpenAI embedder:
 

--- a/getting_started/first_project.mdx
+++ b/getting_started/first_project.mdx
@@ -64,7 +64,7 @@ The final step in creating an index is to add data to it. Choose "File upload":
   <img src="/assets/images/cloud-getting-started/8-file-upload.png" alt="Another modal window with three options. A red arrow points at the chosen option, 'File upload'" />
 </Frame>
 
-Meilisearch Cloud will ask you for your dataset. To follow along, use this <a href="/assets/datasets/movies.json" download="movies.json">list of movies</a>. Download the file to your computer, drag and drop it into the indicated area, then click on "Import documents":
+Meilisearch Cloud will ask you for your dataset. To follow along, use this <a href="https://www.meilisearch.com/docs/assets/datasets/movies.json" download="movies.json">list of movies</a>. Download the file to your computer, drag and drop it into the indicated area, then click on "Import documents":
 
 <Frame>
   <img src="/assets/images/cloud-getting-started/9-data-import.png" alt="Another modal window with a large drag-and-drop area. It indicates a file named 'movies.json' will be uploaded" />

--- a/reference/api/openapi.mdx
+++ b/reference/api/openapi.mdx
@@ -4,6 +4,6 @@ sidebarTitle: OpenAPI specifications
 description: Meilisearch OpenAPI specifications and where to find them.
 ---
 
-You can <a href="/assets/open-api/meilisearch-openapi.json" download="meilisearch-openapi.json">download the OpenAPI specification</a> for the latest Meilisearch version.
+You can <a href="https://www.meilisearch.com/docs/assets/open-api/meilisearch-openapi.json" download="meilisearch-openapi.json">download the OpenAPI specification</a> for the latest Meilisearch version.
 
 For a specific Meilisearch version, get the specification from the [Meilisearch releases on GitHub](https://github.com/meilisearch/meilisearch/releases). Each release includes `meilisearch-openapi.json` in its assets.

--- a/resources/internals/storage.mdx
+++ b/resources/internals/storage.mdx
@@ -53,7 +53,7 @@ Meilisearch will always demand a certain amount of space to use as a [memory map
 
 ## Measured disk usage
 
-The following measurements were taken using <a href="/assets/datasets/movies.json" download="movies.json">movies.json</a> an 8.6 MB JSON dataset containing 19,553 documents.
+The following measurements were taken using <a href="https://www.meilisearch.com/docs/assets/datasets/movies.json" download="movies.json">movies.json</a> an 8.6 MB JSON dataset containing 19,553 documents.
 
 After indexing, the dataset size in LMDB is about 122MB.
 

--- a/resources/self_hosting/getting_started/quick_start.mdx
+++ b/resources/self_hosting/getting_started/quick_start.mdx
@@ -73,7 +73,7 @@ To learn more about securing Meilisearch, refer to the [security tutorial](/reso
 
 In this quick start, you will search through a collection of movies.
 
-To follow along, first click this link to download the file: <a href="https://www.meilisearch.com/movies.json" download="movies.json">movies.json</a>. Then, move the downloaded file into your working directory.
+To follow along, first click this link to download the file: <a href="https://www.meilisearch.com/docs/assets/datasets/movies.json" download="movies.json">movies.json</a>. Then, move the downloaded file into your working directory.
 
 <Note>
 Meilisearch accepts data in JSON, NDJSON, and CSV formats.


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->
The download links were using a relative path that failed to resolve correctly in some contexts. Replaced with an absolute URL to ensure consistent behavior across all environments.

Fixes #3591

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example dataset and resource links across documentation guides to ensure consistent accessibility and reliable downloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->