### PR TITLE
Correct pagination redirect

### DIFF
--- a/config/redirects.json
+++ b/config/redirects.json
@@ -4169,7 +4169,7 @@
   },
   {
     "source": "/learn/front_end/pagination",
-    "destination": "/reference/api/pagination"
+    "destination": "/capabilities/full_text_search/how_to/paginate_search_results"
   },
   {
     "source": "/capabilities/hybrid_search/how_to/custom_hybrid_ranking",


### PR DESCRIPTION
## Description

<!-- Describe the changes and purpose of the PR -->
I noticed that links to /learn/front_end/pagination, were redirecting to https://www.meilisearch.com/docs/reference/api/pagination#pagination instead of the [guide on how to paginate search results
](https://www.meilisearch.com/docs/capabilities/full_text_search/how_to/paginate_search_results), so I corrected it

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation redirect paths to ensure users are directed to current resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->