### PR TITLE
Document version requirements for sharding and replication

### DIFF
--- a/resources/self_hosting/sharding/manage_network.mdx
+++ b/resources/self_hosting/sharding/manage_network.mdx
@@ -99,6 +99,10 @@ Cancelling a topology change at step 3 only results in stale documents being ret
 Search requests may return incomplete results during a topology change. Wait for all `NetworkTopologyChange` tasks to complete before resuming normal search traffic.
 </Warning>
 
+<Warning>
+Run the same Meilisearch version on all instances before rebalancing. Network rebalancing is not guaranteed to work across instances on different versions.
+</Warning>
+
 ## Validation
 
 `PATCH /network` rejects requests with a `400 invalid_network_shards` error in the following cases:

--- a/resources/self_hosting/sharding/overview.mdx
+++ b/resources/self_hosting/sharding/overview.mdx
@@ -142,6 +142,10 @@ Before setting up sharding and replication, you need:
 - Network connectivity between all instances
 - If using private networks (`10.x.x.x`, `192.168.x.x`), the `--experimental-allowed-ip-networks` flag must be set on each instance
 
+<Note>
+Run the same Meilisearch version on all instances. Internal communication between instances has had no breaking changes so far, so instances on different versions can currently communicate, but cross-version compatibility is not guaranteed in future versions. Search and federated features remain compatible on a best-effort basis, while network rebalancing requires all instances on the same version (see [Manage the network](/resources/self_hosting/sharding/manage_network)).
+</Note>
+
 ## Next steps
 
 <CardGroup cols={2}>


### PR DESCRIPTION
## What

Adds version-compatibility guidance to the sharding/replication docs, which currently say nothing about whether instances in a network must run the same Meilisearch version.

- **overview.mdx → Prerequisites**: note that all instances should run the same version; cross-version internal communication works today but isn't guaranteed in future versions.
- **manage_network.mdx → rebalancing**: warning that network rebalancing requires all instances on the same version.

## Why

A recurring support/customer question ("do all instances need the same version for sharding/replication?") that the docs couldn't answer. Sourced from engineering guidance (Clément Renault, Louis Dureuil): same version preferred, internal comms compatible so far but not guaranteed, search/federated features best-effort, rebalancing should be same-version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer guidance for self-hosted sharding setups, including a warning and prerequisite note about keeping all instances on the same Meilisearch version.
  * Clarified that cross-version compatibility is limited, with best-effort support for some features and stricter requirements for network rebalancing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->