### PR TITLE
Clarify synonyms and index settings

### DIFF
--- a/capabilities/full_text_search/relevancy/synonyms.mdx
+++ b/capabilities/full_text_search/relevancy/synonyms.mdx
@@ -20,7 +20,7 @@ The number of search results may vary depending on changes to the `movies` datas
 
 ## Normalization
 
-All synonyms are **lowercased** and **de-unicoded** during the indexing process.
+During the indexing process, all synonyms are processed by using the index settings, i.e., stop words, separator and non-separator tokens. Always make sure no synonyms are treated as separator tokens (e.g., `&`), or they'll be ignored during the search.
 
 ### Example
 


### PR DESCRIPTION
## Description

I just clarified a bit the interaction between the synonyms and index settings.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [ ] ~⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)~

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified how synonyms are processed during indexing, including stop words and tokenization rules.
  * Added a warning that synonyms treated as separator tokens, such as “&”, are ignored.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->