### PR TITLE
Fix compaction note: Cloud does not compact indexes automatically

### DIFF
--- a/capabilities/indexing/how_to/compact_an_index.mdx
+++ b/capabilities/indexing/how_to/compact_an_index.mdx
@@ -6,7 +6,7 @@ description: Reclaim disk space by compacting an index's internal data structure
 When you add, update, or delete documents, Meilisearch's internal data structures may retain unused space from previous versions of the data. Compaction reclaims this space by reorganizing the index on disk.
 
 <Note>
-Meilisearch Cloud monitors database fragmentation and compacts indexes automatically as needed. Self-hosted users do not benefit from automatic compaction and may need to build a pipeline that periodically compacts indexes to avoid performance degradation.
+Compaction is never triggered automatically. Whether you use Meilisearch Cloud or self-host, you must trigger compaction yourself when needed. Compaction is a regular Meilisearch task: it goes through the task queue and delays other queued tasks, such as document indexing or settings updates, until it completes. You may want to build a pipeline that periodically checks fragmentation and compacts your indexes during low-traffic hours to avoid performance degradation.
 </Note>
 
 ## When to compact

--- a/capabilities/indexing/how_to/compact_an_index.mdx
+++ b/capabilities/indexing/how_to/compact_an_index.mdx
@@ -6,7 +6,7 @@ description: Reclaim disk space by compacting an index's internal data structure
 When you add, update, or delete documents, Meilisearch's internal data structures may retain unused space from previous versions of the data. Compaction reclaims this space by reorganizing the index on disk.
 
 <Note>
-Compaction is never triggered automatically. Whether you use Meilisearch Cloud or self-host, you must trigger compaction yourself when needed. Compaction is a regular Meilisearch task: it goes through the task queue and delays other queued tasks, such as document indexing or settings updates, until it completes. You may want to build a pipeline that periodically checks fragmentation and compacts your indexes during low-traffic hours to avoid performance degradation.
+Compaction is never triggered automatically. Whether you use Meilisearch Cloud or self-host, you must trigger compaction yourself by calling [`POST /indexes/{index_uid}/compact`](/reference/api/indexes/compact-index) when needed. Compaction is a regular Meilisearch task: it goes through the task queue and delays tasks queued behind it, such as document indexing or settings updates, until it completes. You may want to build a pipeline that periodically checks fragmentation and compacts your indexes during low-traffic hours to avoid performance degradation.
 </Note>
 
 ## When to compact


### PR DESCRIPTION
## What does this PR do?

Fixes an incorrect statement on the "Compact an index" page.

The Note claimed that "Meilisearch Cloud monitors database fragmentation and compacts indexes automatically as needed." This is not the case: compaction is never triggered automatically, on Cloud or self-hosted. Users must trigger it themselves via `POST /indexes/{index_uid}/compact`.

The updated Note also clarifies why timing matters: compaction is a regular Meilisearch task, so it goes through the task queue and delays other queued tasks (document indexing, settings updates) until it completes. We observed this in production this week: a manual compaction on a customer instance blocked their document updates for several minutes (SP-2156).

## Changes

- Replaced the incorrect Cloud auto-compaction claim with accurate guidance applying to both Cloud and self-hosted
- Added the task-queue delay caveat and a recommendation to run compaction during low-traffic hours

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that index compaction is never triggered automatically (both cloud and self-hosted).
  * Explained that compaction must be started manually via the dedicated compaction endpoint and runs as an asynchronous task that can be queued behind other work.
  * Added guidance to periodically monitor fragmentation and compact during low-traffic periods to reduce performance impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->