### PR TITLE
Update Rust examples to use the Tokio runtime

### DIFF
--- a/snippets/generated-code-samples/code_samples_add_movies_json_1.mdx
+++ b/snippets/generated-code-samples/code_samples_add_movies_json_1.mdx
@@ -72,10 +72,14 @@ use meilisearch_sdk::{
 };
 use serde::{Serialize, Deserialize};
 use std::{io::prelude::*, fs::File};
-use futures::executor::block_on;
 
-fn main() { block_on(async move {
-  let client = Client::new("MEILISEARCH_URL", Some("masterKey"));
+#[tokio::main]
+async fn main() {
+  let client = Client::new(
+    "MEILISEARCH_URL",
+    Some("masterKey"),
+  )
+  .unwrap();
 
   // reading and parsing the file
   let mut file = File::open("movies.json")
@@ -93,7 +97,7 @@ fn main() { block_on(async move {
     .add_documents(&movies_docs, None)
     .await
     .unwrap();
-})}
+}
 ```
 
 ```swift Swift

--- a/snippets/generated-code-samples/code_samples_getting_started_add_documents.mdx
+++ b/snippets/generated-code-samples/code_samples_getting_started_add_documents.mdx
@@ -185,8 +185,8 @@ namespace Meilisearch_demo
 // In your .toml file:
   [dependencies]
   meilisearch-sdk = "0.33.0"
-  # futures: because we want to block on futures
-  futures = "0.3"
+  # tokio: async runtime required by the Meilisearch SDK
+  tokio = { version = "1", features = ["full"] }
   # serde: required if you are going to use documents
   serde = { version="1.0",   features = ["derive"] }
   # serde_json: required in some parts of this guide
@@ -224,10 +224,14 @@ use meilisearch_sdk::{
 };
 use serde::{Serialize, Deserialize};
 use std::{io::prelude::*, fs::File};
-use futures::executor::block_on;
 
-fn main() { block_on(async move {
-  let client = Client::new("MEILISEARCH_URL", Some("aSampleMasterKey"));
+#[tokio::main]
+async fn main() {
+  let client = Client::new(
+    "MEILISEARCH_URL",
+    Some("aSampleMasterKey"),
+  )
+  .unwrap();
 
   // Reading and parsing the file
   let mut file = File::open("movies.json")
@@ -245,7 +249,7 @@ fn main() { block_on(async move {
     .add_documents(&movies_docs, None)
     .await
     .unwrap();
-})}
+}
 ```
 
 ```swift Swift


### PR DESCRIPTION
## Description

Fixes #3640 

This PR fixes the Rust documentation examples in [Get started](https://www.meilisearch.com/docs/resources/self_hosting/getting_started/quick_start#add-documents) and [Working with tasks](https://www.meilisearch.com/docs/capabilities/indexing/tasks_and_batches/monitor_tasks#adding-a-task-to-the-task-queue) pages.

Replaces `futures::executor::block_on` with `#[tokio::main]` and adds the required Tokio dependency.
Along with it, i also added the missing `.unwrap()` to `Client::new()` in the examples.

These changes ensure the examples compile and work with the current `meilisearch-sdk`.

<!-- Describe the changes and purpose of the PR -->

## Checklist

For internal Meilisearch team member only:
- [ ] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [ ] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Have you made sure that the title is accurate and descriptive of the changes?
