### PR TITLE
Add SELinux note after moving the binary in the self-hosting deployment guides

### DIFF
--- a/resources/self_hosting/deployment/aws.mdx
+++ b/resources/self_hosting/deployment/aws.mdx
@@ -55,7 +55,7 @@ sudo mv ./meilisearch /usr/local/bin/
 <Note>
 **SELinux systems: Amazon Linux, Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
 
-If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+`mv` preserves the binary's original SELinux context instead of relabeling it for its new location, so the file in `/usr/local/bin` keeps the context of the directory you downloaded it into. If SELinux runs in enforcing mode, this prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
 
 Restore the default context of the binary:
 

--- a/resources/self_hosting/deployment/aws.mdx
+++ b/resources/self_hosting/deployment/aws.mdx
@@ -52,6 +52,30 @@ Move the binary file into `/usr/local/bin` to make it accessible from anywhere:
 sudo mv ./meilisearch /usr/local/bin/
 ```
 
+<Note>
+**SELinux systems: Amazon Linux, Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
+
+If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+
+Restore the default context of the binary:
+
+```sh
+sudo restorecon -v /usr/local/bin/meilisearch
+```
+
+Then check the resulting label:
+
+```sh
+ls -Z /usr/local/bin/meilisearch
+```
+
+The type must be `bin_t`:
+
+```
+unconfined_u:object_r:bin_t:s0 /usr/local/bin/meilisearch
+```
+</Note>
+
 ## Step 2: Create system user
 
 Running applications as root exposes you to unnecessary security risks. Create a dedicated user for Meilisearch:

--- a/resources/self_hosting/deployment/digitalocean.mdx
+++ b/resources/self_hosting/deployment/digitalocean.mdx
@@ -48,7 +48,7 @@ mv ./meilisearch /usr/local/bin/
 <Note>
 **SELinux systems: Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
 
-If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+`mv` preserves the binary's original SELinux context instead of relabeling it for its new location, so the file in `/usr/local/bin` keeps the context of the directory you downloaded it into. If SELinux runs in enforcing mode, this prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
 
 Restore the default context of the binary:
 

--- a/resources/self_hosting/deployment/digitalocean.mdx
+++ b/resources/self_hosting/deployment/digitalocean.mdx
@@ -45,6 +45,30 @@ Next, you need to make the binary accessible from anywhere in your system. Move 
 mv ./meilisearch /usr/local/bin/
 ```
 
+<Note>
+**SELinux systems: Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
+
+If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+
+Restore the default context of the binary:
+
+```sh
+restorecon -v /usr/local/bin/meilisearch
+```
+
+Then check the resulting label:
+
+```sh
+ls -Z /usr/local/bin/meilisearch
+```
+
+The type must be `bin_t`:
+
+```
+unconfined_u:object_r:bin_t:s0 /usr/local/bin/meilisearch
+```
+</Note>
+
 Meilisearch is now installed in your system, but it is not publicly accessible.
 
 ## Step 2: Create system user

--- a/resources/self_hosting/deployment/digitalocean.mdx
+++ b/resources/self_hosting/deployment/digitalocean.mdx
@@ -53,7 +53,7 @@ mv ./meilisearch /usr/local/bin/
 Restore the default context of the binary:
 
 ```sh
-restorecon -v /usr/local/bin/meilisearch
+sudo restorecon -v /usr/local/bin/meilisearch
 ```
 
 Then check the resulting label:

--- a/resources/self_hosting/deployment/gcp.mdx
+++ b/resources/self_hosting/deployment/gcp.mdx
@@ -45,7 +45,7 @@ sudo mv ./meilisearch /usr/local/bin/
 <Note>
 **SELinux systems: Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
 
-If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+`mv` preserves the binary's original SELinux context instead of relabeling it for its new location, so the file in `/usr/local/bin` keeps the context of the directory you downloaded it into. If SELinux runs in enforcing mode, this prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
 
 Restore the default context of the binary:
 

--- a/resources/self_hosting/deployment/gcp.mdx
+++ b/resources/self_hosting/deployment/gcp.mdx
@@ -42,6 +42,30 @@ Move the binary to make it accessible system-wide:
 sudo mv ./meilisearch /usr/local/bin/
 ```
 
+<Note>
+**SELinux systems: Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
+
+If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+
+Restore the default context of the binary:
+
+```sh
+sudo restorecon -v /usr/local/bin/meilisearch
+```
+
+Then check the resulting label:
+
+```sh
+ls -Z /usr/local/bin/meilisearch
+```
+
+The type must be `bin_t`:
+
+```
+unconfined_u:object_r:bin_t:s0 /usr/local/bin/meilisearch
+```
+</Note>
+
 ## Step 2: Create system user
 
 Create a dedicated user for running Meilisearch:

--- a/resources/self_hosting/deployment/running_production.mdx
+++ b/resources/self_hosting/deployment/running_production.mdx
@@ -44,6 +44,30 @@ Next, you need to make the binary accessible from anywhere in your system. Move 
 mv ./meilisearch /usr/local/bin/
 ```
 
+<Note>
+**SELinux systems: Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
+
+If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+
+Restore the default context of the binary:
+
+```sh
+restorecon -v /usr/local/bin/meilisearch
+```
+
+Then check the resulting label:
+
+```sh
+ls -Z /usr/local/bin/meilisearch
+```
+
+The type must be `bin_t`:
+
+```
+unconfined_u:object_r:bin_t:s0 /usr/local/bin/meilisearch
+```
+</Note>
+
 Meilisearch is now installed in your system, but it is not publicly accessible.
 
 ## Step 2: Create system user

--- a/resources/self_hosting/deployment/running_production.mdx
+++ b/resources/self_hosting/deployment/running_production.mdx
@@ -47,7 +47,7 @@ mv ./meilisearch /usr/local/bin/
 <Note>
 **SELinux systems: Fedora, RHEL, Rocky Linux, AlmaLinux, and CentOS Stream**
 
-If SELinux runs in enforcing mode, the binary keeps the security context of the directory you downloaded it into. This prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
+`mv` preserves the binary's original SELinux context instead of relabeling it for its new location, so the file in `/usr/local/bin` keeps the context of the directory you downloaded it into. If SELinux runs in enforcing mode, this prevents systemd from running it in [step 4](#step-4-run-meilisearch-as-a-service), which fails with `Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied`.
 
 Restore the default context of the binary:
 

--- a/resources/self_hosting/deployment/running_production.mdx
+++ b/resources/self_hosting/deployment/running_production.mdx
@@ -52,7 +52,7 @@ mv ./meilisearch /usr/local/bin/
 Restore the default context of the binary:
 
 ```sh
-restorecon -v /usr/local/bin/meilisearch
+sudo restorecon -v /usr/local/bin/meilisearch
 ```
 
 Then check the resulting label:


### PR DESCRIPTION
## Description

Closes #3643

The four production deployment guides instruct users to move the binary into `/usr/local/bin`. On systems running SELinux in enforcing mode (Fedora, RHEL, Rocky Linux, AlmaLinux, CentOS Stream, and Amazon Linux on the AWS page), `mv` preserves the binary's original SELinux context instead of relabeling it for its destination. As a result, systemd cannot execute it, and step 4 fails with:

```
Failed at step EXEC spawning /usr/local/bin/meilisearch: Permission denied
```

The `chown` command in step 2 does not fix this issue because file ownership and SELinux labels are separate. Therefore, a user following the guide exactly may end up with a service that does not start and an error that does not clearly indicate the cause.

This PR adds a `<Note>` immediately after the move step in each guide. It identifies the affected distributions, quotes the error message verbatim so it is searchable, links to step 4 where the failure occurs, and provides the following fix:

```sh
sudo restorecon -v /usr/local/bin/meilisearch
```

Pages changed:

- `resources/self_hosting/deployment/running_production.mdx`
- `resources/self_hosting/deployment/aws.mdx`
- `resources/self_hosting/deployment/gcp.mdx`
- `resources/self_hosting/deployment/digitalocean.mdx`

The note is duplicated across the four pages rather than extracted into a shared snippet, matching how the existing Meilisearch Cloud `<Note>` is already repeated across them. Each copy uses `sudo` for the command that restores the binary's SELinux context. The AWS version also lists Amazon Linux because that guide supports it.

## AI usage disclosure

AI tools were used to review the wording and consistency of the SELinux troubleshooting notes. The technical behavior and commands were manually verified.

## Checklist

For internal Meilisearch team member only:

- [ ] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [ ] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers:

- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added SELinux troubleshooting guidance to self-hosted deployment documentation.
  * Explained how to resolve systemd execution failures caused by incorrect binary security contexts.
  * Added commands to restore and verify the required `bin_t` SELinux label across supported Linux distributions and deployment platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->