### PR TITLE
clarify stop words are case-sensitive

### DIFF
--- a/capabilities/full_text_search/how_to/configure_stop_words.mdx
+++ b/capabilities/full_text_search/how_to/configure_stop_words.mdx
@@ -57,7 +57,7 @@ If your application serves multiple languages, the recommended approach is to cr
 ### Important considerations
 
 - **Stop words are index-specific.** Each index has its own stop word list. If you have multiple indexes with different languages, configure appropriate stop words for each one.
-- **Stop words are case-insensitive.** Adding `"The"` is equivalent to adding `"the"`.
+- **Stop words are case-sensitive.** Adding `"the"` is not equivalent to adding `"The"`.
 - **Stop words affect indexing.** Meilisearch removes stop words from the index, so changing this setting requires re-indexing.
 
 ## Reset stop words


### PR DESCRIPTION
## Description

Fixes #3651 

This is small PR to fix the stop words Documentation that says [stop words are case-insensitive](https://www.meilisearch.com/docs/capabilities/full_text_search/how_to/configure_stop_words#important-considerations) but the opposite is true

<!-- Describe the changes and purpose of the PR -->

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6)

For external maintainers
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that stop words are case-sensitive, so `"The"` and `"the"` are treated as different entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->