### PR TITLE
Fix foreign filter document limit (100 to 1000) and sharding fallback claim

### DIFF
--- a/capabilities/filtering_sorting_faceting/advanced/filter_expression_syntax.mdx
+++ b/capabilities/filtering_sorting_faceting/advanced/filter_expression_syntax.mdx
@@ -330,7 +330,7 @@ _foreign(company, id = "company_42")
 </CodeGroup>
 
 <Warning>
-Foreign filters return an error when the filter on the related index matches more than 100 documents. Keep `_foreign()` conditions narrow, and prefer filtering on identifiers or tightly scoped attributes. See [Foreign filters](/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data#hard-limit-foreign-filters-with-maximum-100-matching-documents) for details.
+Foreign filters return an error when the filter on the related index matches more than 1000 documents. Keep `_foreign()` conditions narrow, and prefer filtering on identifiers or tightly scoped attributes. See [Foreign filters](/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data#hard-limit-foreign-filters-with-maximum-1000-matching-documents) for details.
 </Warning>
 
 For more examples and use cases, see the [Foreign filters guide](/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data).

--- a/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx
+++ b/capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx
@@ -140,13 +140,13 @@ For detailed examples and use cases, see the [Precise filtering with array relat
 
 ### Filter specificity
 
-Broader filters on related data may hit the 100-document limit:
+Broader filters on related data may hit the 1000-document limit:
 
 ```bash
 # ✓ Good: Very specific
 filter: "_foreign(company, industry = \"Technology\" AND state = \"CA\")"
 
-# ✗ Problematic: May return > 100 docs
+# ✗ Problematic: May return > 1000 docs
 filter: "_foreign(company, industry = \"Technology\")"
 ```
 
@@ -163,16 +163,16 @@ filter: "value >= 500000 AND _foreign(company, founded_year >= 2020)"
 
 Before production, verify filter performance:
 - Estimate how many target documents match each filter
-- Ensure results stay under 100 documents
+- Ensure results stay under 1000 documents
 - Add more specific conditions if needed
 
-## Hard limit: Foreign filters with maximum 100 matching documents
+## Hard limit: Foreign filters with maximum 1000 matching documents
 
 <Callout type="warning">
-If a foreign filter returns more than 100 matching documents from the target index, Meilisearch will return an error. Design your foreign filters carefully to stay within this limit by being more specific with your filtering criteria.
+If a foreign filter returns more than 1000 matching documents from the target index, Meilisearch will return an error. Design your foreign filters carefully to stay within this limit by being more specific with your filtering criteria.
 </Callout>
 
-**Example:** If you filter for `_foreign(company, industry = "Technology")` and your database has 150 technology companies, the query fails.
+**Example:** If you filter for `_foreign(company, industry = "Technology")` and your database has 1,500 technology companies, the query fails.
 
 **Solutions:**
 - Add additional filter conditions: `_foreign(company, industry = "Technology" AND founded_year >= 2020)` (narrows results)

--- a/capabilities/security/advanced/rbac_with_joins.mdx
+++ b/capabilities/security/advanced/rbac_with_joins.mdx
@@ -158,12 +158,12 @@ Filter to include public documents:
 
 1. **Access table size:** Each document's access rules create entries. For 1000 documents with 10 team access rules each, you need ~10,000 access records.
 
-2. **Filter specificity:** The foreign filter must match ≤ 100 access records. Design your access control structure to stay within this limit:
+2. **Filter specificity:** The foreign filter must match ≤ 1000 access records. Design your access control structure to stay within this limit:
    - Use team-based rules instead of per-user rules where possible
    - Group documents by access level (public, internal, secret)
    - Consider combining user + team checks: `(user = "..." OR (teams IN [...] AND roles IN [...]))`
 
-3. **Denormalization trade-off:** If RBAC queries regularly hit the 100-document limit, consider denormalizing permission fields directly into documents instead of using joins.
+3. **Denormalization trade-off:** If RBAC queries regularly hit the 1000-document limit, consider denormalizing permission fields directly into documents instead of using joins.
 
 ## Security best practices
 

--- a/resources/self_hosting/sharding/setup_sharded_cluster.mdx
+++ b/resources/self_hosting/sharding/setup_sharded_cluster.mdx
@@ -101,7 +101,7 @@ curl \
 In this configuration, each shard lives on exactly one remote. Documents are distributed across all three instances, and each instance handles searches for its own shards.
 
 <Note>
-This setup has no replication. If a remote becomes unavailable, its shards are missing from search results. Meilisearch does not yet automatically fall back to another instance. See [Configure replication](/resources/self_hosting/sharding/configure_replication) for a high-availability setup.
+This setup has no replication. Meilisearch does fall back automatically when the remote assigned to a shard is unreachable, but only if another remote holds a copy of that shard. Here each shard lives on exactly one instance, so if a remote becomes unavailable its shards are missing from search results. See [Configure replication](/resources/self_hosting/sharding/configure_replication) for a high-availability setup.
 </Note>
 
 ## Step 4: Index documents


### PR DESCRIPTION
## Description

Two factual corrections found while auditing the docs against the engine changelog.

**1. Foreign filter document limit is 1000, not 100**

v1.53.0 raised the foreign filter retrieval limit from 100 to 1000 documents. The docs still stated 100 in eight places across three pages:

- `capabilities/filtering_sorting_faceting/advanced/filtering_by_joined_data.mdx` (6), including the `## Hard limit:` section heading
- `capabilities/security/advanced/rbac_with_joins.mdx` (2), which sizes its whole access-table guidance around the limit
- `capabilities/filtering_sorting_faceting/advanced/filter_expression_syntax.mdx` (1)

The worked example in `filtering_by_joined_data` used 150 matching companies to illustrate the error, which no longer exceeds the limit, so it is now 1,500.

Renaming the `## Hard limit:` heading changes its slug. It was linked from exactly one place (`filter_expression_syntax.mdx`), updated in the same commit. `npm run check-broken-links` passes.

**2. Sharded cluster setup claimed fallback does not exist**

`resources/self_hosting/sharding/setup_sharded_cluster.mdx` said Meilisearch "does not yet automatically fall back to another instance". Remote availability tracking landed in v1.42, and `configure_replication.mdx` already documents automatic fallback, as does the compatibility table added in #3650. The practical warning still holds for that topology because each shard has exactly one copy, so the note now explains that fallback requires another remote holding the same shard rather than denying the capability.

## Note for reviewers

The limit is stated as 1000 with no version caveat, matching how these pages treat the latest release as the present tense. Users on v1.52 and earlier still have 100. Happy to add a version note instead if you would prefer that.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (no code sample changes needed)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code audited the docs against the engine changelog, located the stale references, and drafted these edits.
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated foreign-filter guidance to reflect the increased limit of 1,000 matching documents.
  * Revised validation examples, warnings, failure scenarios, and performance recommendations for joined-data and RBAC queries.
  * Clarified sharded-cluster behavior when an unavailable shard has no replicated copy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->