### PR TITLE
Use per-index size metrics to estimate fragmentation

### DIFF
--- a/capabilities/indexing/how_to/compact_an_index.mdx
+++ b/capabilities/indexing/how_to/compact_an_index.mdx
@@ -21,9 +21,14 @@ You do not need to compact after every operation. It is most useful after large 
 
 Fragmentation is directly related to the number of indexing operations Meilisearch performs. Common indexing operations include adding and updating documents, as well as changes to index settings.
 
-To estimate your index's fragmentation, query the [`/stats` route](/reference/api/stats) and compare `databaseSize` to `usedDatabaseSize`:
+To estimate a single index's fragmentation, query [`GET /indexes/{index_uid}/stats`](/reference/api/stats) and compare `indexSize` to `usedIndexSize`:
 
-- If the ratio between `databaseSize` and `usedDatabaseSize` is bigger than 30%, compacting your indexes may improve performance.
+- `indexSize`: the total size of that index's database on disk, in bytes
+- `usedIndexSize`: the portion of those pages actively holding data, in bytes
+
+The gap between the two is reclaimable space. Compaction targets one index at a time, so these per-index figures tell you which index is worth compacting. `GET /stats` reports the same two fields per index under `indexes`, alongside the instance-wide `databaseSize` and `usedDatabaseSize`.
+
+- If the ratio between `indexSize` and `usedIndexSize` is bigger than 30%, compacting that index may improve performance.
 - If you update documents in your indexes a few times per day, checking fragmentation and compacting your database once per week is a reasonable baseline.
 
 Tune this cadence based on your own indexing patterns: higher write volumes warrant more frequent compaction, while mostly read-only indexes rarely need it.


### PR DESCRIPTION
## Description

v1.53.0 added `indexSize` and `usedIndexSize` to `GET /indexes/{index_uid}/stats` and `GET /stats`. They were in the OpenAPI spec but had no prose anywhere in the docs.

`capabilities/indexing/how_to/compact_an_index.mdx` told users to compare the instance-wide `databaseSize` and `usedDatabaseSize` when deciding whether to compact. Compaction operates on one index at a time, so the instance-wide numbers cannot tell you which index is fragmented. The guide now uses the per-index fields and notes that `GET /stats` reports them per index under `indexes`, alongside the instance-wide pair.

Field descriptions are taken from the `IndexStats` schema in the spec, and the `GET /stats` shape was confirmed against the `Stats` schema.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (no code sample changes needed)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the edit.
- [x] Have you made sure that the title is accurate and descriptive of the changes?