### PR TITLE
Document showInternalDatabaseSizes and sizeFormat stats parameters

### DIFF
--- a/capabilities/platform/monitoring/indexing_performance.mdx
+++ b/capabilities/platform/monitoring/indexing_performance.mdx
@@ -90,7 +90,7 @@ The same breakdown is available outside the dashboard. Pass `showInternalDatabas
 ```bash cURL
 curl \
   -X GET 'MEILISEARCH_URL/indexes/movies/stats?showInternalDatabaseSizes=true&sizeFormat=human' \
-  -H 'Authorization: Bearer MEILISEARCH_KEY'
+  -H 'Authorization: Bearer API_KEY'
 ```
 
 </CodeGroup>

--- a/capabilities/platform/monitoring/indexing_performance.mdx
+++ b/capabilities/platform/monitoring/indexing_performance.mdx
@@ -81,6 +81,22 @@ The Internal DB table shows the current on-disk size of each internal data struc
 
 The delta (shown as `+N KiB` or `+N MiB`) tells you how much space each batch adds. A `vectorStore` growing much faster than `documents` indicates a high-dimensional embedding model.
 
+#### Fetch internal sizes from the API
+
+The same breakdown is available outside the dashboard. Pass `showInternalDatabaseSizes=true` to either stats route to add an `internalDatabaseSizes` object to the response, and `sizeFormat=human` to receive readable strings such as `19.64 MiB` instead of raw byte counts:
+
+<CodeGroup>
+
+```bash cURL
+curl \
+  -X GET 'MEILISEARCH_URL/indexes/movies/stats?showInternalDatabaseSizes=true&sizeFormat=human' \
+  -H 'Authorization: Bearer MEILISEARCH_KEY'
+```
+
+</CodeGroup>
+
+Both parameters work on `GET /indexes/{index_uid}/stats` and `GET /stats`. `sizeFormat` defaults to `raw`, which reports every size in the response as a number of bytes. Internal database names can change between Meilisearch versions, so treat this breakdown as diagnostic output rather than a stable contract.
+
 ### Other fields
 
 | Field | What it shows |


### PR DESCRIPTION
## Description

v1.44 added `showInternalDatabaseSizes` and `sizeFormat` to `GET /indexes/{index_uid}/stats` and `GET /stats`. Both were in the OpenAPI spec but had no prose anywhere.

The indexing performance page already documents the internal database breakdown as it appears in the Cloud dashboard's batch detail panel, so it read as dashboard-only with no programmatic equivalent. Added a subsection showing how to get the same breakdown from the API, including that `sizeFormat` defaults to `raw` and that internal database names are not a stable contract across versions.

Parameter behavior is taken from the spec descriptions.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (inline cURL example, follows the MEILISEARCH_URL/MEILISEARCH_KEY convention used on neighbouring pages)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the edit.
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added API guidance for retrieving internal database size details.
  * Documented supported statistics routes, cURL examples, and human-readable formatting.
  * Clarified that responses default to raw byte values and that internal database names are diagnostic details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->