### PR TITLE
Document federation.distinct in the federated search tutorial

### DIFF
--- a/capabilities/multi_search/getting_started/federated_search.mdx
+++ b/capabilities/multi_search/getting_started/federated_search.mdx
@@ -149,9 +149,60 @@ The response includes `page`, `hitsPerPage`, and `totalPages` instead of `offset
 
 This makes it straightforward to build paginated UIs that display merged results from multiple indexes.
 
+## Deduplicate results across indexes
+
+The same client may appear in a profile, a chat log, and a support ticket at once. Use the `distinct` property of the `federation` parameter to keep at most one result per value of a given attribute, computed across every query in the request.
+
+`distinct` requires the attribute to be filterable in each participating index, so add `client_name` to `filterableAttributes` for all three indexes first:
+
+<CodeGroup>
+
+```sh
+curl -X PUT 'MEILISEARCH_URL/indexes/profiles/settings/filterable-attributes' -H 'Content-Type: application/json' -H 'Authorization: Bearer MEILISEARCH_KEY' --data-binary '["client_name"]' &&
+curl -X PUT 'MEILISEARCH_URL/indexes/chats/settings/filterable-attributes' -H 'Content-Type: application/json' -H 'Authorization: Bearer MEILISEARCH_KEY' --data-binary '["client_name"]' &&
+curl -X PUT 'MEILISEARCH_URL/indexes/tickets/settings/filterable-attributes' -H 'Content-Type: application/json' -H 'Authorization: Bearer MEILISEARCH_KEY' --data-binary '["client_name"]'
+```
+
+</CodeGroup>
+
+Then set `distinct` inside `federation`:
+
+<CodeGroup>
+
+```bash
+curl \
+  -X POST 'MEILISEARCH_URL/multi-search' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer MEILISEARCH_KEY' \
+  --data-binary '{
+    "federation": {
+      "distinct": "client_name"
+    },
+    "queries": [
+      { "indexUid": "profiles", "q": "Nguyen" },
+      { "indexUid": "chats", "q": "Nguyen" },
+      { "indexUid": "tickets", "q": "Nguyen" }
+    ]
+  }'
+```
+
+</CodeGroup>
+
+Natasha Nguyen now occupies a single entry in the merged list instead of one per source.
+
+Federation-level `distinct` behaves differently from the [index-level distinct attribute](/capabilities/full_text_search/how_to/configure_distinct_attribute) in three ways:
+
+- It applies across every query in the request, whatever index or remote they target
+- It overrides the distinct attribute configured on each participating index
+- Setting `distinct` on an individual query and on `federation` at the same time returns an HTTP 400 error
+
+<Note>
+When queries reach remote instances, Meilisearch computes facet distribution as accurately as it can but cannot guarantee exact counts, because the distinct computation is not applied to documents held on every remote.
+</Note>
+
 ## Conclusion
 
-You have created three indexes, then performed a federated multi-index search to receive all results in a single list. You then used `weight` to boost results from the index most likely to contain the information you wanted, and paginated through merged results using `federation.page` and `federation.hitsPerPage`.
+You have created three indexes, then performed a federated multi-index search to receive all results in a single list. You then used `weight` to boost results from the index most likely to contain the information you wanted, paginated through merged results using `federation.page` and `federation.hitsPerPage`, and collapsed duplicate matches with `federation.distinct`.
 
 ## Next steps
 


### PR DESCRIPTION
## Description

v1.40 added `distinct` to the `federation` object of `/multi-search`, applying a global cross-index and cross-remote distinct computation. It was in the OpenAPI spec but had no prose, and the federated search tutorial documented only `weight`, `federation.page` and `federation.hitsPerPage`.

Added a "Deduplicate results across indexes" section that uses the tutorial's existing CRM datasets, so one client collapses to a single entry instead of appearing once per source. It includes the prerequisite step of making the attribute filterable in all three indexes, which is easy to miss and produces a confusing error otherwise.

Behavior is taken from the `Federation` schema in the spec plus the v1.40 changelog entry:

- applies across every query regardless of index or remote
- overrides the index-level distinct attribute
- setting `distinct` at both query and federation level returns HTTP 400
- facet distribution accuracy is not guaranteed once remotes are involved

The conclusion now mentions `distinct` alongside the other parameters the tutorial walks through.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (inline cURL, matching the surrounding examples on this page; happy to move these into `.code-samples.meilisearch.yaml` if you would prefer generated snippets here)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the section.
- [x] Have you made sure that the title is accurate and descriptive of the changes?