### PR TITLE
Document search personalization in federated search

### DIFF
--- a/capabilities/personalization/getting_started/personalized_search.mdx
+++ b/capabilities/personalization/getting_started/personalized_search.mdx
@@ -27,6 +27,35 @@ Submit a search query and include the `personalize` search parameter. `personali
 
 <CodeSamplesPersonalizationSearch1 />
 
+## Personalize a federated search
+
+Personalization also works with [federated search](/capabilities/multi_search/getting_started/federated_search). Set `personalize` inside the `federation` object, alongside options such as `limit` and `offset`, so one user profile reranks the single merged result list:
+
+<CodeGroup>
+
+```bash
+curl \
+  -X POST 'MEILISEARCH_URL/multi-search' \
+  -H 'Content-Type: application/json' \
+  -H 'Authorization: Bearer MEILISEARCH_KEY' \
+  --data-binary '{
+    "federation": {
+      "limit": 20,
+      "personalize": {
+        "userContext": "Enjoys hiking and camping, recently bought a two-person tent"
+      }
+    },
+    "queries": [
+      { "indexUid": "products", "q": "sleeping bag" },
+      { "indexUid": "guides", "q": "sleeping bag" }
+    ]
+  }'
+```
+
+</CodeGroup>
+
+Setting `personalize` on an individual query inside a federated request returns an error asking you to move it into `federation`.
+
 ## Reranking scope and the `limit` parameter
 
 The reranker only sees the documents that Meilisearch returns for a given query. This means `limit` directly controls how many documents the reranker can choose from.
@@ -34,6 +63,8 @@ The reranker only sees the documents that Meilisearch returns for a given query.
 If you set `limit` to 20, the reranker picks the best order from those 20 documents. It cannot promote a document that Meilisearch did not return. Increasing `limit` gives the reranker a wider pool to work with, but also increases latency and the number of tokens sent to the reranking model.
 
 A `limit` between 20 and 100 is a reasonable starting point for most personalized search use cases. Go higher if ranking quality matters more than latency for your application.
+
+In a federated request the merged result list is what reaches the reranker, so `federation.limit` or `federation.hitsPerPage` sets the pool size instead.
 
 ## Limits
 


### PR DESCRIPTION
## Description

v1.47 enabled [search personalization](/capabilities/personalization/overview) on federated search requests. As with `limit`/`offset` and `page`/`hitsPerPage`, `personalize` must be set inside the `federation` object, and putting it on an individual query returns an error.

Before this PR there were zero mentions of federated search anywhere under `capabilities/personalization/`, so the combination looked unsupported.

Added a "Personalize a federated search" section to the personalized search guide, and a line tying the existing reranking-scope guidance to its federated equivalent, since `federation.limit` and `federation.hitsPerPage` bound the merged list that reaches the reranker rather than the per-query `limit`.

Put deliberately in `personalization/getting_started/personalized_search.mdx` rather than the federated search tutorial, both because it belongs with the personalization capability and to keep this PR conflict-free with #3659, which adds a section to the federated search page.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (inline cURL; this page otherwise uses a generated snippet, so tell me if you would rather this became one too)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the section.
- [x] Have you made sure that the title is accurate and descriptive of the changes?