### PR TITLE
Document the lastUpdatedAt field on search rules

### DIFF
--- a/capabilities/search_rules/how_to/list_and_filter_rules.mdx
+++ b/capabilities/search_rules/how_to/list_and_filter_rules.mdx
@@ -52,13 +52,16 @@ Send a `POST /dynamic-search-rules` with pagination and optional filters:
 }
 ```
 
-The response contains the rules that match, with the same structure you used to create them (`uid`, `conditions`, `actions`, `precedence`, `active`, `description`).
+The response contains the rules that match, with the same structure you used to create them (`uid`, `conditions`, `actions`, `precedence`, `active`, `description`), plus a read-only `lastUpdatedAt` timestamp.
+
+`lastUpdatedAt` holds the date and time of the task that last modified the rule, and Meilisearch maintains it for you. Listings come back sorted by `lastUpdatedAt` in descending order, so the most recently modified rules appear first.
 
 ### Parameters
 
 - `offset` and `limit` control pagination. Defaults are `offset: 0` and `limit: 20`. The maximum `limit` varies by Meilisearch version, keep requests under a few hundred rules per call.
 - `filter.query` accepts a string query. `promo` returns every rule whose description contains the words "promo". `seasonal` returns every rule whose description contains the word `seasonal`. The search rules applied are similar to a search in a regular index.
 - `filter.active` filters by status: `true` returns only active rules, `false` returns only paused rules. Omit the field to return rules regardless of status.
+- `lastUpdatedAt` is not a filter. To narrow a listing by date, page through the results and stop once the timestamps fall outside the window you care about, which the descending sort makes cheap.
 
 You can combine filters. The example above returns active rules containing `promo`, which is exactly the campaign-audit case described above.
 
@@ -78,6 +81,7 @@ This returns the full rule definition, which is convenient when you want to edit
 - **Rules per index**: the list response includes each rule's actions, so you can group by `selector.indexUid` locally to see how many pins target each index.
 - **Scheduled promotions**: list every rule whose conditions contain a `time` scope with a `start` in the future. This is a good sanity check before a campaign goes live.
 - **Priority conflicts**: list rules that share a `words` value and compare their `precedence` values. If two rules have the same precedence and target different documents for the same query, ordering is not guaranteed.
+- **Recent changes**: because listings are sorted by `lastUpdatedAt` descending, the first page of a plain listing is a change log of the rules touched most recently. This is a quick way to see what someone else edited before a campaign goes live.
 
 ## Variations and tips
 

--- a/capabilities/search_rules/how_to/list_and_filter_rules.mdx
+++ b/capabilities/search_rules/how_to/list_and_filter_rules.mdx
@@ -54,7 +54,7 @@ Send a `POST /dynamic-search-rules` with pagination and optional filters:
 
 The response contains the rules that match, with the same structure you used to create them (`uid`, `conditions`, `actions`, `precedence`, `active`, `description`), plus a read-only `lastUpdatedAt` timestamp.
 
-`lastUpdatedAt` holds the date and time of the task that last modified the rule, and Meilisearch maintains it for you. Listings come back sorted by `lastUpdatedAt` in descending order, so the most recently modified rules appear first.
+`lastUpdatedAt` holds the `enqueuedAt` value of the last task that modified the rule, and Meilisearch maintains it for you. Listings come back sorted by `lastUpdatedAt` in descending order, so the most recently modified rules appear first.
 
 ### Parameters
 


### PR DESCRIPTION
## Description

v1.51 added a read-only `lastUpdatedAt` field to search rules, populated with the timestamp of the task that last modified the rule, and started sorting listings by it in descending order.

`capabilities/search_rules/how_to/list_and_filter_rules.mdx` enumerated the response structure as `uid`, `conditions`, `actions`, `precedence`, `active`, `description`, which is now incomplete, and said nothing about ordering. The field is present in the `DynamicSearchRule` schema in the spec; the default sort is documented only in the v1.51 release notes.

Three changes:

- `lastUpdatedAt` added to the response field list, with a note that Meilisearch maintains it
- The default descending sort documented
- A "Recent changes" auditing pattern, plus a note under Parameters that `lastUpdatedAt` is not filterable, since the neighbouring bullets are all filters and readers may assume it is one

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (no code sample changes needed)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the edit.
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented the read-only `lastUpdatedAt` timestamp in API responses.
  * Clarified that results are sorted from newest to oldest.
  * Added guidance for using the first page as a recent-change audit log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->