### PR TITLE
Document wildcard patterns in the facets search parameter

### DIFF
--- a/capabilities/filtering_sorting_faceting/how_to/build_faceted_navigation.mdx
+++ b/capabilities/filtering_sorting_faceting/how_to/build_faceted_navigation.mdx
@@ -92,6 +92,23 @@ The response includes a `facetDistribution` object showing every value for each 
 
 The `facetDistribution` tells you exactly which values exist and how many documents match each one. The `facetStats` object provides minimum and maximum values for numeric facets, useful for building range sliders.
 
+### Request several facets with a wildcard
+
+`facets` also accepts wildcard patterns, which is convenient when related facets share a prefix and you do not want to list them one by one. Pass `"*"` to request every filterable attribute, or a pattern containing `*` to request the subset that matches it:
+
+```json
+{
+  "q": "classic",
+  "facets": ["specs.*"]
+}
+```
+
+Given filterable attributes `specs.language`, `specs.binding`, and `specs.edition`, that single entry returns a distribution for all three. Patterns follow the same matching rules as [`filterableAttributes.attributePatterns`](/capabilities/filtering_sorting_faceting/how_to/configure_granular_filters#wildcard-patterns), and only filterable attributes are ever matched.
+
+<Warning>
+A wildcard makes it easy to request far more facets than your interface displays, and every matched attribute costs a distribution computation. Prefer an explicit list for a page whose facets you know, and keep wildcards for cases where the attribute names are genuinely dynamic. See [Optimize facet performance](/capabilities/filtering_sorting_faceting/advanced/optimize_facet_performance) for the cost model.
+</Warning>
+
 <Note>
 `facetStats` only considers values stored as JSON numbers. String values are ignored, even when the string contains a numeric value such as `"42"`. If you expect `min`/`max` for a given facet and the object is missing, confirm that the underlying field is indexed as a number rather than a string.
 </Note>

--- a/capabilities/filtering_sorting_faceting/how_to/build_faceted_navigation.mdx
+++ b/capabilities/filtering_sorting_faceting/how_to/build_faceted_navigation.mdx
@@ -103,7 +103,7 @@ The `facetDistribution` tells you exactly which values exist and how many docume
 }
 ```
 
-Given filterable attributes `specs.language`, `specs.binding`, and `specs.edition`, that single entry returns a distribution for all three. Patterns follow the same matching rules as [`filterableAttributes.attributePatterns`](/capabilities/filtering_sorting_faceting/how_to/configure_granular_filters#wildcard-patterns), and only filterable attributes are ever matched.
+Given filterable attributes `specs.language`, `specs.binding`, and `specs.edition`, that single entry returns a distribution for all three. Only filterable attributes are ever matched.
 
 <Warning>
 A wildcard makes it easy to request far more facets than your interface displays, and every matched attribute costs a distribution computation. Prefer an explicit list for a page whose facets you know, and keep wildcards for cases where the attribute names are genuinely dynamic. See [Optimize facet performance](/capabilities/filtering_sorting_faceting/advanced/optimize_facet_performance) for the cost model.


### PR DESCRIPTION
## Description

v1.50 ([engine PR #6497](https://github.com/meilisearch/meilisearch/pull/6497)) extended the `facets` search parameter from the single `"*"` wildcard to any pattern containing `*`, matched with the same rules as `filterableAttributes.attributePatterns`. So `specs.*` requests a distribution for every filterable attribute under that prefix.

Neither the plain `"*"` form nor the new patterns appeared anywhere in the docs, so the only documented way to request facets was an explicit list.

Added a subsection to Step 2 of the faceted navigation guide, cross-linked to the existing wildcard patterns section for filterable attributes. It carries a warning about cost, since a wildcard can silently request many more distributions than the interface renders, and the neighbouring performance guide is explicit that each requested facet costs a computation.

Semantics were taken from the v1.50.0 release notes rather than the changelog entry, which only gives the `dogs.*` example. The OpenAPI spec has no description for `facets` on `SearchQuery`, so there was nothing to draw on there.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (illustrative JSON body, no new cURL sample)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the section.
- [x] Have you made sure that the title is accurate and descriptive of the changes?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for requesting multiple facet distributions using wildcard patterns.
  * Documented support for all filterable attributes and prefix-based attribute matching.
  * Added performance considerations and recommendations for choosing between wildcards and explicit facet lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->