### PR TITLE
Document the search rules fuel environment variables

### DIFF
--- a/resources/self_hosting/configuration/reference.mdx
+++ b/resources/self_hosting/configuration/reference.mdx
@@ -462,6 +462,44 @@ Configures the number of concurrent search requests each CPU core can handle.
 
 Enables search personalization. Must be a valid Cohere API key in string format.
 
+### Search rules fuel <NoticeTag type="experimental" label="experimental" />
+
+Resolving [search rules](/capabilities/search_rules/overview) during a search costs work, and "fuel" is the budget Meilisearch spends on it. These limits keep rule evaluation from degrading search performance as a rule set grows, which is what allows the feature to scale to tens of thousands of rules.
+
+The defaults suit most rule sets. Raise a limit only if rules stop applying as expected and you have confirmed the relevant budget is the cause. Each of these is available via environment variable only; no CLI flag is available.
+
+#### Maximum counted words
+
+**Environment variable**: `MEILI_EXPERIMENTAL_DSR_FUEL_MAX_COUNTED_WORDS`<br />
+**Default value**: `10`<br />
+**Expected value**: an integer up to `255`
+
+Maximum number of words from the search query that Meilisearch considers when looking for `conditions.query.words` constraints. Words beyond this count cannot trigger a rule.
+
+#### Maximum active rules
+
+**Environment variable**: `MEILI_EXPERIMENTAL_DSR_FUEL_MAX_ACTIVE_RULES`<br />
+**Default value**: `1000`<br />
+**Expected value**: an integer up to `4294967295`
+
+Maximum number of active rules whose actions are evaluated for a single search.
+
+#### Maximum pin actions
+
+**Environment variable**: `MEILI_EXPERIMENTAL_DSR_FUEL_MAX_PIN_ACTIONS`<br />
+**Default value**: `100`<br />
+**Expected value**: an integer up to `4294967295`
+
+Maximum number of pin actions applied to a single search. Raise it if a search legitimately needs more pinned documents than this.
+
+#### Word fuel
+
+**Environment variable**: `MEILI_EXPERIMENTAL_DSR_FUEL_WORD_FUEL`<br />
+**Default value**: `4096`<br />
+**Expected value**: an integer up to `4294967295`
+
+Maximum number of constraint combinations evaluated when looking for `conditions.query.words` constraints.
+
 ### Allow requests to private networks <NoticeTag type="experimental" label="experimental" />
 
 **Environment variable**: `MEILI_EXPERIMENTAL_ALLOWED_IP_NETWORKS`<br />


### PR DESCRIPTION
## Description

v1.50 introduced the "DSR fuel" system as part of scaling search rules to 75,000 rules. It exposes four environment variables that bound how much work rule resolution may spend during a search. The changelog mentions "configurable limits via environment variables" without naming them, and none appeared in the configuration reference.

Added a grouped `### Search rules fuel` section following the same structure as the existing `### S3 options` group, with one `####` entry per variable:

| Variable | Default | Max |
|---|---|---|
| `MEILI_EXPERIMENTAL_DSR_FUEL_MAX_COUNTED_WORDS` | `10` | `255` |
| `MEILI_EXPERIMENTAL_DSR_FUEL_MAX_ACTIVE_RULES` | `1000` | `4294967295` |
| `MEILI_EXPERIMENTAL_DSR_FUEL_MAX_PIN_ACTIONS` | `100` | `4294967295` |
| `MEILI_EXPERIMENTAL_DSR_FUEL_WORD_FUEL` | `4096` | `4294967295` |

Names, defaults, maxima and semantics come from the v1.50.0 release notes ([engine PRs #6484 and #6506](https://github.com/meilisearch/meilisearch/pull/6484)), not from the changelog entry.

Placed with the other search-related experimental options rather than the task queue ones, which also keeps it clear of #3656's insertion point in the same file.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (no code sample changes needed)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog, read the variable names and limits from the release notes, and drafted the section.
- [x] Have you made sure that the title is accurate and descriptive of the changes?