### PR TITLE
Document the remote status field on the network route

### DIFF
--- a/resources/self_hosting/sharding/configure_replication.mdx
+++ b/resources/self_hosting/sharding/configure_replication.mdx
@@ -102,14 +102,14 @@ Meilisearch tracks which remotes are reachable and exposes that judgement on the
   "remotes": {
     "ms-01": {
       "url": "http://ms-01.example.com:7700",
-      "searchApiKey": "REPLACE_ME",
-      "writeApiKey": "REPLACE_ME",
+      "searchApiKey": "SEARCH_KEY_01",
+      "writeApiKey": "WRITE_KEY_01",
       "status": "available"
     },
     "ms-02": {
       "url": "http://ms-02.example.com:7700",
-      "searchApiKey": "REPLACE_ME",
-      "writeApiKey": "REPLACE_ME",
+      "searchApiKey": "SEARCH_KEY_02",
+      "writeApiKey": "WRITE_KEY_02",
       "status": "unavailable"
     }
   }

--- a/resources/self_hosting/sharding/configure_replication.mdx
+++ b/resources/self_hosting/sharding/configure_replication.mdx
@@ -91,6 +91,39 @@ When a network search runs, Meilisearch builds an internal set of remotes to que
 
 Meilisearch supports automatic remote fallback. If the remote assigned to a shard is unreachable, the shard won't be queried, and another remote will be used to retrieve its content. However, if no remote is available for a given shard, that shard's results will be missing from the response. It's a best-effort approach.
 
+### Inspect remote availability
+
+Meilisearch tracks which remotes are reachable and exposes that judgement on the `/network` route. Each entry under `remotes` carries a `status` field:
+
+<CodeGroup>
+
+```json
+{
+  "remotes": {
+    "ms-01": {
+      "url": "http://ms-01.example.com:7700",
+      "searchApiKey": "REPLACE_ME",
+      "writeApiKey": "REPLACE_ME",
+      "status": "available"
+    },
+    "ms-02": {
+      "url": "http://ms-02.example.com:7700",
+      "searchApiKey": "REPLACE_ME",
+      "writeApiKey": "REPLACE_ME",
+      "status": "unavailable"
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+`status` is either `available` or `unavailable`, and it defaults to `available`. Meilisearch marks a remote unavailable after it fails to respond, skips it while choosing which remote serves each shard, and starts querying it again once it recovers. That is the mechanism behind the fallback described above.
+
+The field is read only. Meilisearch maintains it, and sending a `status` in a `PATCH /network` body has no effect.
+
+`GET /network` is therefore the quickest way to confirm whether missing results come from an unreachable instance rather than from your shard configuration.
+
 ## Scaling read throughput
 
 Replication is the primary way to scale search throughput in Meilisearch. Each replica can independently handle search requests, so adding more replicas increases the total number of concurrent searches your cluster can handle.


### PR DESCRIPTION
## Description

v1.42 ([engine PR #6306](https://github.com/meilisearch/meilisearch/pull/6306)) added remote availability tracking and exposed a `status` field for each remote on `/network`. The replication guide already described the resulting fallback behavior but never mentioned the field, so there was no documented way for an operator to see which remotes Meilisearch currently considers reachable.

Added an "Inspect remote availability" subsection to the existing "Remote availability" section, covering the two values, the default, that Meilisearch maintains the field, and that reading `GET /network` distinguishes an unreachable instance from a shard misconfiguration.

## Worth flagging: the field is missing from the OpenAPI spec

Unlike most gaps I have been filling, this one is absent from the API reference too. The `Remote` schema in `assets/open-api/meilisearch-openapi.json` has only `url`, `searchApiKey` and `writeApiKey`.

The cause looks structural rather than accidental. In `crates/meilisearch-types/src/network.rs` at v1.53.1 the field is declared as:

```rust
#[serde(skip_deserializing)]
pub status: route::Status,
```

`Remote` serves as both the request and response shape, and `status` is response-only, so the generated schema documents the input and drops it. Documenting it as read-only in prose is correct either way, but the spec probably wants a fix so the API reference shows it. Happy to open an engine issue if that is useful.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (illustrative JSON response, no new cURL sample)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog, confirmed the field and its read-only semantics against the engine source at v1.53.1, and drafted the section.
- [x] Have you made sure that the title is accurate and descriptive of the changes?