### PR TITLE
Document that searchCutoffMs bounds remote embedder calls

### DIFF
--- a/capabilities/full_text_search/how_to/configure_search_cutoff.mdx
+++ b/capabilities/full_text_search/how_to/configure_search_cutoff.mdx
@@ -53,6 +53,21 @@ As a general recommendation, avoid setting the cutoff below **500ms**. This prov
 The cutoff is most useful as a safety net, not as a performance tuning knob. If your searches are consistently slow, address the root cause with the optimizations below rather than lowering the cutoff.
 </Tip>
 
+## Search cutoff and remote embedders
+
+If your index uses an embedder that calls an external API at search time, the cutoff also bounds that call. Meilisearch derives the embedding request timeout from `searchCutoffMs` rather than applying a fixed timeout of its own, so the cutoff has to cover the provider round trip on top of the search itself.
+
+This matters when choosing a value:
+
+- A cutoff that is comfortable for keyword search can be too short once a provider round trip is included. A 150 ms cutoff is fine for a purely lexical query and will usually not survive a call to a hosted embedding API.
+- If the embedder does not answer in time, the query loses its semantic results. For a [pure semantic search](/capabilities/hybrid_search/advanced/semantic_vs_hybrid), where there are no keyword results to fall back on, the request can fail with an HTTP 500 instead.
+
+So if semantic results go missing, or pure semantic searches start returning HTTP 500, raise `searchCutoffMs` before looking elsewhere. Embedders that run locally are not affected, since no network call is involved.
+
+<Tip>
+Measure your provider's typical latency first, then set the cutoff above that plus your normal search time. [Choosing an embedder](/capabilities/hybrid_search/how_to/choose_an_embedder) covers the trade-offs between hosted and local models.
+</Tip>
+
 ## Search cutoff vs. other performance optimizations
 
 The search cutoff is a reactive measure that limits query time after it becomes a problem. For proactive performance improvements, consider:


### PR DESCRIPTION
## Description

v1.44 made the search-time timeout for external REST embedders derive from the index's `searchCutoffMs` rather than a fixed value ([engine PR #6377](https://github.com/meilisearch/meilisearch/pull/6377)). It was listed as a breaking change, with the guidance that missing semantic results or HTTP 500s on pure semantic search after upgrading mean the cutoff needs raising.

This was undocumented in both directions: `configure_search_cutoff.mdx` never mentioned embedders, and no page under `capabilities/hybrid_search/` mentioned `searchCutoffMs`.

It matters because the cutoff page actively steers readers toward low values. It demonstrates a 150 ms cutoff and suggests starting between 100 ms and 500 ms, which is reasonable advice for lexical search and can silently break semantic search against a hosted provider.

Added a "Search cutoff and remote embedders" section covering that the cutoff must absorb the provider round trip, what failure looks like (degraded results for hybrid, HTTP 500 for pure semantic), the fix, and that local embedders are unaffected.

## Reviewer check requested

This is the one item from my audit where I would like an engineer to confirm the wording rather than take my reading of the changelog and release notes. Specifically:

1. Does the derived timeout apply to every embedder that makes a search-time HTTP call, or only to `source: rest`? I wrote "an embedder that calls an external API at search time" to stay accurate either way, but naming the sources precisely would be better.
2. Is HTTP 500 still the observed failure mode for pure semantic search on a timeout, or has that since become a more specific error?

Happy to tighten the section once you confirm.

`npm run check-broken-links` passes.

## Checklist

For internal Meilisearch team member only:
- [x] I checked and followed our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link)
- [x] ⚠️ I updated the code samples according to our [internal guidelines](https://www.notion.so/meilisearch/Updating-docs-for-engineers-3034b06b651f808da3c6c4f5e34914fc?source=copy_link#3034b06b651f8026bd63cfa294dfa0c6) (no code sample changes needed)

For external maintainers
- [x] Did you use any AI tool while implementing this PR? Yes. Claude Code found the gap auditing docs against the changelog and drafted the section.
- [x] Have you made sure that the title is accurate and descriptive of the changes?