### PR TITLE
Use web archive link because of content issues

### DIFF
--- a/capabilities/indexing/how_to/import_large_datasets.mdx
+++ b/capabilities/indexing/how_to/import_large_datasets.mdx
@@ -45,7 +45,7 @@ The ideal batch size depends on your document size. If each document is small (u
 
 ## Use NDJSON for streaming
 
-For large imports, [NDJSON](http://ndjson.org/) (Newline Delimited JSON) is more efficient than JSON arrays. NDJSON lets you stream documents line by line without loading the entire payload into memory:
+For large imports, [NDJSON](https://web.archive.org/web/20231218162511/https://ndjson.org/) (Newline Delimited JSON) is more efficient than JSON arrays. NDJSON lets you stream documents line by line without loading the entire payload into memory:
 
 <CodeGroup>
 


### PR DESCRIPTION
The NDJSON.org site no longer contains anything related to newline delimited JSON anymore. The webarchive link shows the original content.

- #3677 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the NDJSON reference link in the large dataset import guide to point to an archived version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->