### PR TITLE
docs: clarify synonym term length limitation with warning and example table

### DIFF
--- a/capabilities/full_text_search/relevancy/synonyms.mdx
+++ b/capabilities/full_text_search/relevancy/synonyms.mdx
@@ -179,7 +179,7 @@ However, depending on the ranking rules, they might be considered less [relevant
 Meilisearch only fetches synonyms for search terms that are between 1 and 3 words. Terms with 4 or more words will not trigger synonym lookup.
 
 <Warning>
-This limitation applies to the **search term** (what the user types), not to the synonym value. A short search term can still resolve to a long synonym, but a long search term will never resolve to a short synonym — even if both directions are configured.
+This limitation applies to the **search term** (what the user types), not to the synonym value. A short search term can still resolve to a long synonym, but a long search term will never resolve to a short synonym, even if both directions are configured.
 </Warning>
 
 ### Example
@@ -199,12 +199,12 @@ Suppose you configure a mutual association between `"lotr"` and `"lord of the ri
 
 | Search query | Synonym lookup triggered? | Why |
 |---|---|---|
-| `lotr` | ✅ Yes | 1 word — within the 1–3 word limit |
-| `lord of the rings` | ❌ No | 4 words — exceeds the limit |
+| `lotr` | ✅ Yes | 1 word, within the 1–3 word limit |
+| `lord of the rings` | ❌ No | 4 words, exceeds the limit |
 
 Searching for `lotr` will return documents containing `"lord of the rings"`. However, searching for `"lord of the rings"` will **not** return documents containing `"lotr"`, because the 4-word search term is excluded from synonym lookup.
 
-To ensure synonym resolution works in both directions, configure the **shorter term as the search entry point**. In this case, users should search for `lotr` to benefit from the synonym, not the other way around.
+Synonym resolution works only from the search term, so configure the **shorter term as the search entry point**. In this case, users should search for `lotr` to benefit from the synonym, not for `lord of the rings`.
 
 ## Maximum number of synonyms per term
 

--- a/capabilities/full_text_search/relevancy/synonyms.mdx
+++ b/capabilities/full_text_search/relevancy/synonyms.mdx
@@ -176,9 +176,35 @@ However, depending on the ranking rules, they might be considered less [relevant
 
 ## Synonym term length limitation
 
-Meilisearch only fetches synonyms for search terms that are between 1 and 3 words. Terms with 4 or more words will not return any synonym matches.
+Meilisearch only fetches synonyms for search terms that are between 1 and 3 words. Terms with 4 or more words will not trigger synonym lookup.
 
-For example, if you set `"lord of the rings"` as a synonym for `"lotr"`, searching for `"lotr"` will return documents containing `"lord of the rings"`. However, if you search for `"lord of the rings"`, Meilisearch will not return documents containing `"lotr"` because the search term has more than 3 words.
+<Warning>
+This limitation applies to the **search term** (what the user types), not to the synonym value. A short search term can still resolve to a long synonym, but a long search term will never resolve to a short synonym — even if both directions are configured.
+</Warning>
+
+### Example
+
+Suppose you configure a mutual association between `"lotr"` and `"lord of the rings"`:
+
+<CodeGroup>
+
+```json
+{
+  "lotr": ["lord of the rings"],
+  "lord of the rings": ["lotr"]
+}
+```
+
+</CodeGroup>
+
+| Search query | Synonym lookup triggered? | Why |
+|---|---|---|
+| `lotr` | ✅ Yes | 1 word — within the 1–3 word limit |
+| `lord of the rings` | ❌ No | 4 words — exceeds the limit |
+
+Searching for `lotr` will return documents containing `"lord of the rings"`. However, searching for `"lord of the rings"` will **not** return documents containing `"lotr"`, because the 4-word search term is excluded from synonym lookup.
+
+To ensure synonym resolution works in both directions, configure the **shorter term as the search entry point**. In this case, users should search for `lotr` to benefit from the synonym, not the other way around.
 
 ## Maximum number of synonyms per term
 


### PR DESCRIPTION
## What does this PR do?

Improves the **Synonym term length limitation** section in \capabilities/full_text_search/relevancy/synonyms.mdx\.

The existing section described the 1–3 word limit correctly but did not make clear that the limitation is **asymmetric**: it applies to the search term only, not to the synonym value. This means that even with a mutual association configured, a 4+ word search term will never resolve to its short synonym — which is non-obvious and a common source of confusion.

## Changes

- Added a \<Warning>\ callout making explicit that the limit applies to the search term, not the synonym value
- Added a concrete mutual association example using \lotr\ / \lord of the rings\
- Added a comparison table showing which search direction works and why
- Added a recommendation for working around the limitation

## Related issue

Closes #2676

---

> ⚠️ AI disclosure: This contribution was assisted by an AI tool (Kiro). The content has been reviewed for accuracy against the existing Meilisearch behavior documented in the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that the 1–3 word limit applies to the user’s search term, not the synonym value.
  - Documented how short search terms can resolve to longer synonyms, while longer terms do not resolve to shorter ones.
  - Added a structured example showing synonym lookup behavior and recommending shorter search terms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->