### PR TITLE
Remove internal-meili-fetch-automation flag

### DIFF
--- a/.github/workflows/post-deployment.yml
+++ b/.github/workflows/post-deployment.yml
@@ -15,26 +15,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Reads the "internal-meili-fetch-automation" flag from docs.json and exposes it
-  # to the other jobs. Kept separate from build-code-samples so a failure in that
-  # job can never hide the flag from the rest of the chain.
-  check-automation-flag:
-    name: Check Meilisearch fetch automation flag
-    runs-on: ubuntu-latest
-    outputs:
-      run_fetch_automation: ${{ steps.fetch_automation.outputs.run }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Get Meilisearch fetch automation flag from docs.json
-        id: fetch_automation
-        run: |
-          # docs.json references config/*.json via $ref, so look for the flag in both places.
-          value=$(jq -r '.. | select(type == "object" and has("internal-meili-fetch-automation")) | .["internal-meili-fetch-automation"] | select(. != null) | tostring' docs.json config/navigation.json 2>/dev/null | head -1)
-          echo "run=${value:-false}" >> "$GITHUB_OUTPUT"
-
   build-code-samples:
     name: Build code samples
     runs-on: ubuntu-latest
@@ -84,14 +64,11 @@ jobs:
   # (avoid stacking both changes in one run and keep history clear).
   # Runs even if build-code-samples failed: fetching the release assets does not
   # depend on the code samples.
-  # Only runs when docs.json has "internal-meili-fetch-automation": true.
-  # In case of issues with the latest release assets: fetch the desired files
-  # manually, then set "internal-meili-fetch-automation" to false to prevent this automation from running.
   fetch-release-assets:
     name: Fetch Meilisearch release assets
     runs-on: ubuntu-latest
-    needs: [check-automation-flag, build-code-samples]
-    if: ${{ !cancelled() && needs.check-automation-flag.outputs.run_fetch_automation == 'true' }}
+    needs: [build-code-samples]
+    if: ${{ !cancelled() }}
 
     steps:
       - name: Checkout repository
@@ -141,8 +118,8 @@ jobs:
   generate-and-check-mintlify-openapi:
     name: Generate and check Mintlify OpenAPI file
     runs-on: ubuntu-latest
-    needs: [check-automation-flag, fetch-release-assets]
-    if: ${{ !cancelled() && needs.check-automation-flag.outputs.run_fetch_automation == 'true' }}
+    needs: [fetch-release-assets]
+    if: ${{ !cancelled() }}
 
     steps:
       - name: Checkout repository
@@ -189,8 +166,7 @@ jobs:
           fi
 
   # Generate reference/errors/error_codes.mdx from assets/release-assets/meilisearch-error-codes.json.
-  # Unlike the OpenAPI jobs above, this is NOT gated on "internal-meili-fetch-automation":
-  # it also runs when the JSON file is updated manually, so the page never goes stale.
+  # It also runs when the JSON file is updated manually, so the page never goes stale.
   # It waits for generate-and-check-mintlify-openapi to finish (whatever its result) to
   # avoid concurrent pushes to main, but runs even if an upstream job failed: the
   # generation only depends on the error codes JSON present on main.
@@ -246,8 +222,8 @@ jobs:
   check-undocumented-routes:
     name: Open issue for undocumented API routes
     runs-on: ubuntu-latest
-    needs: [check-automation-flag, generate-and-check-mintlify-openapi]
-    if: ${{ !cancelled() && needs.check-automation-flag.outputs.run_fetch_automation == 'true' }}
+    needs: [generate-and-check-mintlify-openapi]
+    if: ${{ !cancelled() }}
     permissions:
       issues: write
 
@@ -326,12 +302,11 @@ jobs:
   # Runs at the end of the push chain (after generate-error-codes) so it never pushes
   # to main at the same time as the other jobs. Runs even if an upstream job failed,
   # as long as the workflow was not cancelled.
-  # Only runs when docs.json has "internal-meili-fetch-automation": true.
   update-changelog:
     name: Update changelog if new release exists
     runs-on: ubuntu-latest
-    needs: [check-automation-flag, generate-error-codes]
-    if: ${{ !cancelled() && needs.check-automation-flag.outputs.run_fetch_automation == 'true' }}
+    needs: [generate-error-codes]
+    if: ${{ !cancelled() }}
 
     steps:
       - name: Checkout repository

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -122,9 +122,9 @@ It does the following:
 
 1. **Build code samples** — Runs `generate-code-sample-snippets-file`. If `snippets/` has changes, it commits and pushes them to `main` (which triggers a new Mintlify deployment). This keeps generated snippets in sync with `.code-samples.meilisearch.yaml` and the SDK repos.
 
-2. **Fetch OpenAPI file** *(only if `docs.json` has `internal-meili-fetch-automation: true`)* — Fetches the latest `meilisearch-openapi.json` from the Meilisearch GitHub release. If the file changed, it commits and pushes to `main`. To disable this (e.g. if the latest release OpenAPI causes issues), set the flag to `false` or update the OpenAPI file manually.
+2. **Fetch OpenAPI file** — Fetches the latest `meilisearch-openapi.json` from the Meilisearch GitHub release. If the file changed, it commits and pushes to `main`.
 
-3. **Generate and check Mintlify OpenAPI** *(same condition)* — Runs `generate-mintlify-openapi-file`, validates with `npx mint openapi-check`, then commits and pushes `meilisearch-openapi-mintlify.json` if it changed.
+3. **Generate and check Mintlify OpenAPI** — Runs `generate-mintlify-openapi-file`, validates with `npx mint openapi-check`, then commits and pushes `meilisearch-openapi-mintlify.json` if it changed.
 
 Each step commits separately so the history stays clear. Contributors don’t need to run these steps manually for normal edits; the workflow keeps code samples and OpenAPI files up to date after merges to `main`.
 

--- a/config/navigation.json
+++ b/config/navigation.json
@@ -488,7 +488,6 @@
                 "source": "assets/release-assets/meilisearch-openapi-mintlify.json",
                 "directory": "reference/api"
               },
-              "internal-meili-fetch-automation": true,
               "examples": {
                 "languages": [
                   "curl",


### PR DESCRIPTION
## What does this PR do?

Removes the `internal-meili-fetch-automation` flag and everything related to it:

- **`.github/workflows/post-deployment.yml`**: removes the `check-automation-flag` job; the four jobs that were gated on it (`fetch-release-assets`, `generate-and-check-mintlify-openapi`, `check-undocumented-routes`, `update-changelog`) now always run (`if: ${{ !cancelled() }}`).
- **`config/navigation.json`**: removes the `"internal-meili-fetch-automation": true` entry.
- **`CONTRIBUTING.md`**: removes the mentions of the flag in the Deployment section.

Note: there is no longer a toggle to disable the OpenAPI fetch automation. If a release causes issues, disable the workflow from the GitHub UI or revert the faulty commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Changes**
  - Deployment documentation and automation no longer reference the internal automation flag.
  - OpenAPI retrieval, generation, validation, and changelog updates now proceed according to workflow status and job dependencies rather than the removed configuration gate.
  - Removed the obsolete automation setting from the API reference navigation configuration.
- **Documentation**
  - Updated contributor guidance to reflect the revised deployment workflow and unconditional OpenAPI processing steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->